### PR TITLE
fix(sonar): Reduce docker images surface

### DIFF
--- a/ci/alerts.dockerfile
+++ b/ci/alerts.dockerfile
@@ -1,15 +1,30 @@
 ARG BASE_IMAGE=scratch
 
 FROM golang:1.21-bullseye
+
 WORKDIR /app
-COPY . .
-WORKDIR /app
+
+COPY .git .git
+COPY cmd cmd
+COPY pkg pkg
+COPY vendor vendor
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+
 ENV GOSUMDB=off
 RUN now=$(date +'%Y-%m-%d_%T') && \
     go build -ldflags "-X main.sha1ver=`git rev-parse HEAD` -X main.buildTime=$now" -mod=vendor -o alerts cmd/alerts/main.go 
 
 FROM ubuntu:20.04
-# COPY pkg/alerts/server/resources/email.html /app/templates/email.html
-# COPY pkg/alerts/server/resources/config.json /app/templates/config.json
+
+ARG USERNAME=lamassu
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME 
+
+USER $USERNAME
 COPY --from=0 /app/alerts /
 CMD ["/alerts"]

--- a/ci/alerts.dockerfile
+++ b/ci/alerts.dockerfile
@@ -22,8 +22,8 @@ ARG USERNAME=lamassu
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
-RUN groupadd --gid $USER_GID $USERNAME \
-    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME 
+RUN groupadd --gid "$USER_GID" "$USERNAME" \
+    && useradd --uid "$USER_UID" --gid "$USER_GID" -m "$USERNAME" 
 
 USER $USERNAME
 COPY --from=0 /app/alerts /

--- a/ci/aws-connector.dockerfile
+++ b/ci/aws-connector.dockerfile
@@ -2,16 +2,31 @@ ARG BASE_IMAGE=scratch
 
 FROM golang:1.21-bullseye
 WORKDIR /app
-COPY . .
-WORKDIR /app
+
+COPY .git .git
+COPY cmd cmd
+COPY pkg pkg
+COPY vendor vendor
+COPY go.mod go.mod
+COPY go.sum go.sum
+
 ENV GOSUMDB=off
 RUN now=$(date +'%Y-%m-%d_%T') && \
     go build -ldflags "-X main.sha1ver=`git rev-parse HEAD` -X main.buildTime=$now" -mod=vendor -o aws cmd/aws/main.go 
 
 # cannot use scratch becaue of the ca-certificates & hosntame -i command used by the service
 FROM ubuntu:20.04
-RUN apt-get update && apt-get install -y ca-certificates \
+RUN apt-get update && apt-get install -y ca-certificates --no-install-recommends \
     && apt-get clean
+
+ARG USERNAME=lamassu
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
+
+USER $USERNAME
 
 COPY --from=0 /app/aws /
 CMD ["/aws"]

--- a/ci/aws-connector.dockerfile
+++ b/ci/aws-connector.dockerfile
@@ -23,8 +23,8 @@ ARG USERNAME=lamassu
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
-RUN groupadd --gid $USER_GID $USERNAME \
-    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
+RUN groupadd --gid "$USER_GID" "$USERNAME" \
+    && useradd --uid "$USER_UID" --gid "$USER_GID" -m "$USERNAME" 
 
 USER $USERNAME
 

--- a/ci/aws-connector.dockerfile
+++ b/ci/aws-connector.dockerfile
@@ -16,7 +16,7 @@ RUN now=$(date +'%Y-%m-%d_%T') && \
 
 # cannot use scratch becaue of the ca-certificates & hosntame -i command used by the service
 FROM ubuntu:20.04
-RUN apt-get update && apt-get install -y ca-certificates --no-install-recommends \
+RUN apt-get update && apt-get --no-install-recommends install -y ca-certificates \
     && apt-get clean
 
 ARG USERNAME=lamassu

--- a/ci/ca.dockerfile
+++ b/ci/ca.dockerfile
@@ -32,8 +32,8 @@ ARG USERNAME=lamassu
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
-RUN groupadd --gid $USER_GID $USERNAME \
-    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
+RUN groupadd --gid "$USER_GID" "$USERNAME" \
+    && useradd --uid "$USER_UID" --gid "$USER_GID" -m "$USERNAME" 
 
 USER $USERNAME
 

--- a/ci/ca.dockerfile
+++ b/ci/ca.dockerfile
@@ -1,10 +1,14 @@
 FROM golang:1.21-bullseye
 WORKDIR /app
-COPY . .
-WORKDIR /app
-ENV GOSUMDB=off
-ENV GOWORK=off 
 
+COPY .git .git
+COPY cmd cmd
+COPY pkg pkg
+COPY vendor vendor
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+ENV GOSUMDB=off
 RUN now=$(date +'%Y-%m-%d_%T') && \ 
     go build -ldflags "-X main.sha1ver=`git rev-parse HEAD` -X main.buildTime=$now" -mod=vendor -o ca cmd/ca/main.go 
 
@@ -23,6 +27,15 @@ RUN git clone https://github.com/SUNET/pkcs11-proxy && \
 
 # Clean build artifacts
 RUN rm -rf /pkcs11-proxy
+
+ARG USERNAME=lamassu
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
+
+USER $USERNAME
 
 COPY --from=0 /app/ca /
 CMD ["/ca"]

--- a/ci/devmanager.dockerfile
+++ b/ci/devmanager.dockerfile
@@ -20,8 +20,8 @@ ARG USERNAME=lamassu
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
-RUN groupadd --gid $USER_GID $USERNAME \
-    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
+RUN groupadd --gid "$USER_GID" "$USERNAME" \
+    && useradd --uid "$USER_UID" --gid "$USER_GID" -m "$USERNAME" 
 
 USER $USERNAME
 

--- a/ci/devmanager.dockerfile
+++ b/ci/devmanager.dockerfile
@@ -2,12 +2,28 @@ ARG BASE_IMAGE=scratch
 
 FROM golang:1.21-bullseye
 WORKDIR /app
-COPY . .
-WORKDIR /app
+
+COPY .git .git
+COPY cmd cmd
+COPY pkg pkg
+COPY vendor vendor
+COPY go.mod go.mod
+COPY go.sum go.sum
+
 ENV GOSUMDB=off
 RUN now=$(date +'%Y-%m-%d_%T') && \
     go build -ldflags "-X main.sha1ver=`git rev-parse HEAD` -X main.buildTime=$now" -mod=vendor -o device-manager cmd/device-manager/main.go 
 
 FROM ubuntu:20.04
+
+ARG USERNAME=lamassu
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
+
+USER $USERNAME
+
 COPY --from=0 /app/device-manager /
 CMD ["/device-manager"]

--- a/ci/dmsmanager.dockerfile
+++ b/ci/dmsmanager.dockerfile
@@ -20,8 +20,8 @@ ARG USERNAME=lamassu
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
-RUN groupadd --gid $USER_GID $USERNAME \
-    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
+RUN groupadd --gid "$USER_GID" "$USERNAME" \
+    && useradd --uid "$USER_UID" --gid "$USER_GID" -m "$USERNAME" 
 
 USER $USERNAME
 

--- a/ci/dmsmanager.dockerfile
+++ b/ci/dmsmanager.dockerfile
@@ -2,12 +2,28 @@ ARG BASE_IMAGE=scratch
 
 FROM golang:1.21-bullseye
 WORKDIR /app
-COPY . .
-WORKDIR /app
+
+COPY .git .git
+COPY cmd cmd
+COPY pkg pkg
+COPY vendor vendor
+COPY go.mod go.mod
+COPY go.sum go.sum
+
 ENV GOSUMDB=off
 RUN now=$(date +'%Y-%m-%d_%T') && \
     go build -ldflags "-X main.sha1ver=`git rev-parse HEAD` -X main.buildTime=$now" -mod=vendor -o dms-manager cmd/ra/main.go 
 
 FROM ubuntu:20.04
+
+ARG USERNAME=lamassu
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
+
+USER $USERNAME
+
 COPY --from=0 /app/dms-manager /
 CMD ["/dms-manager"]

--- a/ci/va.dockerfile
+++ b/ci/va.dockerfile
@@ -20,8 +20,8 @@ ARG USERNAME=lamassu
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
-RUN groupadd --gid $USER_GID $USERNAME \
-    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
+RUN groupadd --gid "$USER_GID" "$USERNAME" \
+    && useradd --uid "$USER_UID" --gid "$USER_GID" -m "$USERNAME" 
 
 USER $USERNAME
 

--- a/ci/va.dockerfile
+++ b/ci/va.dockerfile
@@ -2,12 +2,28 @@ ARG BASE_IMAGE=scratch
 
 FROM golang:1.21-bullseye
 WORKDIR /app
-COPY . .
-WORKDIR /app
+
+COPY .git .git
+COPY cmd cmd
+COPY pkg pkg
+COPY vendor vendor
+COPY go.mod go.mod
+COPY go.sum go.sum
+
 ENV GOSUMDB=off
 RUN now=$(date +'%Y-%m-%d_%T') && \
     go build -ldflags "-X main.sha1ver=`git rev-parse HEAD` -X main.buildTime=$now" -mod=vendor -o va cmd/va/main.go 
 
 FROM ubuntu:20.04
+
+ARG USERNAME=lamassu
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
+
+USER $USERNAME
+
 COPY --from=0 /app/va /
 CMD ["/va"]


### PR DESCRIPTION
This PR addresses  the Security Hotspots reported by SonarQube

- Better control on the resources copied at the first stage
- Better control the packages installed ignoring apt-get recommended
- Reduce exposure by running process using a non-root user