### PR TITLE
fix durationToString while using nanoseconds

### DIFF
--- a/pkg/models/tiemduration.go
+++ b/pkg/models/tiemduration.go
@@ -217,7 +217,7 @@ func DurationToString(d time.Duration) string {
 	}
 
 	// Largest time is 15250w1d23h47m16s854ms775us807ns
-	var buf [32]byte
+	var buf [64]byte
 	w := len(buf)
 	var sign string
 


### PR DESCRIPTION
I've seen that some durations that include nanoseconds trigger 

```
runtime error: index out of range [-1]
/usr/local/go/src/runtime/panic.go:114 (0x439f9b)
/app/pkg/v3/models/tiemduration.go:366 (0x9d2b74)
/app/pkg/v3/models/tiemduration.go:339 (0x9d2b65)
/app/pkg/v3/models/tiemduration.go:12 (0xdc076f)
```

I could reproduce it using the following main program: 
```go
now := time.Date(2023, time.December, 29, 15, 18, 2, 1, time.Local)
currentDeviceCert := time.Date(2023, time.December, 29, 15, 20, 0, 2, time.Local)
dms, _ := models.ParseDuration("50y")
comparisonTimeThreshold := currentDeviceCert.Add(-time.Duration(dms))
logrus.Infof(
  "current device certificate expires at %s (%s duration). DMS allows reenrolling %s. Reenroll window opens %s. (delta=%s)",
  currentDeviceCert.UTC().Format("2006-01-02T15:04:05Z07:00"),
  models.TimeDuration(currentDeviceCert.Sub(now)).String(),
  dms.String(),
  comparisonTimeThreshold.UTC().Format("2006-01-02T15:04:05Z07:00"),
  models.TimeDuration(now.Sub(comparisonTimeThreshold)).String(),
)
```

If  instead of the values used at `now` and `currentDeviceCert` that have 1, and 2 ns, 0 ns are used, no errors are obtained
```go
now := time.Date(2023, time.December, 29, 15, 18, 2, 0, time.Local)
currentDeviceCert := time.Date(2023, time.December, 29, 15, 20, 0, 0, time.Local)
```
Since many functions use `time.Now()` that most likely will have ns, I've updated the `DurationToString` to have a larger buffer from 32 to 64 bytes and prevent the index-out-of-range error