### PR TITLE
Fix unordered slices comparison

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -24,4 +24,4 @@ jobs:
 
       - name: Run Tests
         run: |
-          go run gotest.tools/gotestsum@latest --format github-actions ./pkg/assemblers -timeout 600s -coverprofile coverage.out
+          go run gotest.tools/gotestsum@latest --format github-actions ./pkg/assemblers ./pkg/helpers/... -timeout 600s -coverprofile coverage.out

--- a/pkg/helpers/slices/compare.go
+++ b/pkg/helpers/slices/compare.go
@@ -5,12 +5,13 @@ func UnorderedEqualContent[E any](s1, s2 []E, cmp func(e1, e2 E) bool) bool {
 		return false
 	}
 
-	for i1, e1 := range s1 {
+	for _, e1 := range s1 {
 		found := false
-		for i := i1; i < len(s2); i++ {
-			e2 := s1[i1]
+		for i := 0; i < len(s2); i++ {
+			e2 := s2[i]
 			if cmp(e1, e2) {
 				found = true
+				break
 			}
 		}
 		if !found {

--- a/pkg/helpers/slices/compare_test.go
+++ b/pkg/helpers/slices/compare_test.go
@@ -1,0 +1,55 @@
+package lms_slices
+
+import (
+	"testing"
+)
+
+func TestUnorderedEqualContent(t *testing.T) {
+	// Test case 1: Equal slices with string elements
+	s1 := []string{"apple", "banana", "cherry"}
+	s2 := []string{"banana", "cherry", "apple"}
+	cmp := func(e1, e2 string) bool {
+		return e1 == e2
+	}
+	if !UnorderedEqualContent(s1, s2, cmp) {
+		t.Errorf("UnorderedEqualContent failed for equal string slices")
+	}
+
+	// Test case 2: Equal slices with integer elements
+	s3 := []int{1, 2, 3}
+	s4 := []int{3, 2, 1}
+	cmpInt := func(e1, e2 int) bool {
+		return e1 == e2
+	}
+	if !UnorderedEqualContent(s3, s4, cmpInt) {
+		t.Errorf("UnorderedEqualContent failed for equal integer slices")
+	}
+
+	// Test case 3: Unequal slices with string elements
+	s5 := []string{"apple", "banana", "cherry"}
+	s6 := []string{"apple", "banana"}
+	if UnorderedEqualContent(s5, s6, cmp) {
+		t.Errorf("UnorderedEqualContent should have returned false for unequal string slices")
+	}
+
+	// Test case 4: Unequal slices with integer elements
+	s7 := []int{1, 2, 3}
+	s8 := []int{1, 2}
+	if UnorderedEqualContent(s7, s8, cmpInt) {
+		t.Errorf("UnorderedEqualContent should have returned false for unequal integer slices")
+	}
+
+	// Test case 5: Unequal slices with integer elements, same length
+	s9 := []int{1, 2, 3}
+	s10 := []int{1, 2, 4}
+	if UnorderedEqualContent(s9, s10, cmpInt) {
+		t.Errorf("UnorderedEqualContent should have returned false for unequal integer slices")
+	}
+
+	// Test case 5: Unequal slices with string elements, same length
+	s11 := []string{"apple", "banana", "cherry"}
+	s12 := []string{"apple", "banana", "orange"}
+	if UnorderedEqualContent(s11, s12, cmp) {
+		t.Errorf("UnorderedEqualContent should have returned false for unequal integer slices")
+	}
+}


### PR DESCRIPTION
This PR fixes the unordered slices comparison

There was bug in the comparison logic. We were comparing the first slice with itself and not with the second slice.

A test has been added for this logic 