### PR TITLE
Prevent "soft" SQL injections

### DIFF
--- a/pkg/controllers/utils.go
+++ b/pkg/controllers/utils.go
@@ -24,7 +24,10 @@ func FilterQuery(r *http.Request, filterFieldMap map[string]resources.FilterFiel
 				sortQueryParam := value
 				sortField := strings.Trim(sortQueryParam, " ")
 
-				queryParams.Sort.SortField = sortField
+				_, exists := filterFieldMap[sortField]
+				if exists {
+					queryParams.Sort.SortField = sortField
+				}
 
 			case "sort_mode":
 				value := v[len(v)-1] //only get last
@@ -111,11 +114,13 @@ func FilterQuery(r *http.Request, filterFieldMap map[string]resources.FilterFiel
 								filterOperand = resources.EnumNotEqual
 							}
 						}
-						queryParams.Filters = append(queryParams.Filters, resources.FilterOption{
-							Field:           field,
-							Value:           arg,
-							FilterOperation: filterOperand,
-						})
+						if exists {
+							queryParams.Filters = append(queryParams.Filters, resources.FilterOption{
+								Field:           field,
+								Value:           arg,
+								FilterOperation: filterOperand,
+							})
+						}
 					}
 
 				}

--- a/pkg/storage/postgres/castore.go
+++ b/pkg/storage/postgres/castore.go
@@ -76,11 +76,11 @@ func (db *PostgresCAStore) SelectExistsByID(ctx context.Context, id string) (boo
 }
 
 func (db *PostgresCAStore) Insert(ctx context.Context, caCertificate *models.CACertificate) (*models.CACertificate, error) {
-	return db.querier.Insert(*caCertificate, caCertificate.ID)
+	return db.querier.Insert(caCertificate, caCertificate.ID)
 }
 
 func (db *PostgresCAStore) Update(ctx context.Context, caCertificate *models.CACertificate) (*models.CACertificate, error) {
-	return db.querier.Update(*caCertificate, caCertificate.ID)
+	return db.querier.Update(caCertificate, caCertificate.ID)
 }
 
 func (db *PostgresCAStore) Delete(ctx context.Context, id string) error {

--- a/pkg/storage/postgres/certstore.go
+++ b/pkg/storage/postgres/certstore.go
@@ -56,11 +56,11 @@ func (db *PostgresCertificateStorage) SelectExistsBySerialNumber(ctx context.Con
 }
 
 func (db *PostgresCertificateStorage) Insert(ctx context.Context, certificate *models.Certificate) (*models.Certificate, error) {
-	return db.querier.Insert(*certificate, certificate.SerialNumber)
+	return db.querier.Insert(certificate, certificate.SerialNumber)
 }
 
 func (db *PostgresCertificateStorage) Update(ctx context.Context, certificate *models.Certificate) (*models.Certificate, error) {
-	return db.querier.Update(*certificate, certificate.SerialNumber)
+	return db.querier.Update(certificate, certificate.SerialNumber)
 }
 
 func (db *PostgresCertificateStorage) SelectByCA(ctx context.Context, caID string, req storage.StorageListRequest[models.Certificate]) (string, error) {

--- a/pkg/storage/postgres/devicemanager.go
+++ b/pkg/storage/postgres/devicemanager.go
@@ -54,9 +54,9 @@ func (db *PostgresDeviceManagerStore) SelectExists(ctx context.Context, ID strin
 }
 
 func (db *PostgresDeviceManagerStore) Update(ctx context.Context, device *models.Device) (*models.Device, error) {
-	return db.querier.Update(*device, device.ID)
+	return db.querier.Update(device, device.ID)
 }
 
 func (db *PostgresDeviceManagerStore) Insert(ctx context.Context, device *models.Device) (*models.Device, error) {
-	return db.querier.Insert(*device, device.ID)
+	return db.querier.Insert(device, device.ID)
 }

--- a/pkg/storage/postgres/dmsmanager.go
+++ b/pkg/storage/postgres/dmsmanager.go
@@ -39,9 +39,9 @@ func (db *PostgresDMSManagerStore) SelectExists(ctx context.Context, ID string) 
 }
 
 func (db *PostgresDMSManagerStore) Update(ctx context.Context, DMS *models.DMS) (*models.DMS, error) {
-	return db.querier.Update(*DMS, DMS.ID)
+	return db.querier.Update(DMS, DMS.ID)
 }
 
 func (db *PostgresDMSManagerStore) Insert(ctx context.Context, DMS *models.DMS) (*models.DMS, error) {
-	return db.querier.Insert(*DMS, DMS.ID)
+	return db.querier.Insert(DMS, DMS.ID)
 }

--- a/pkg/storage/postgres/eventstore.go
+++ b/pkg/storage/postgres/eventstore.go
@@ -27,7 +27,7 @@ func NewEventsPostgresRepository(db *gorm.DB) (storage.EventRepository, error) {
 }
 
 func (db *PostgresEventsStore) InsertUpdateEvent(ctx context.Context, ev *models.AlertLatestEvent) (*models.AlertLatestEvent, error) {
-	return db.querier.Update(*ev, string(ev.EventType))
+	return db.querier.Update(ev, string(ev.EventType))
 }
 
 func (db *PostgresEventsStore) GetLatestEventByEventType(ctx context.Context, eventType models.EventType) (bool, *models.AlertLatestEvent, error) {

--- a/pkg/storage/postgres/subscriptionstore.go
+++ b/pkg/storage/postgres/subscriptionstore.go
@@ -34,7 +34,7 @@ func (db *PostgresSubscriptionsStore) GetSubscriptions(ctx context.Context, user
 }
 
 func (db *PostgresSubscriptionsStore) Subscribe(ctx context.Context, sub *models.Subscription) (*models.Subscription, error) {
-	return db.querier.Insert(*sub, sub.ID)
+	return db.querier.Insert(sub, sub.ID)
 }
 
 func (db *PostgresSubscriptionsStore) Unsubscribe(ctx context.Context, subscriptionID string) error {

--- a/pkg/storage/postgres/utils.go
+++ b/pkg/storage/postgres/utils.go
@@ -295,40 +295,36 @@ func (db *postgresDBQuerier[E]) SelectExists(queryID string, queryCol *string) (
 	return true, &elem, nil
 }
 
-func (db *postgresDBQuerier[E]) Insert(elem E, elemID string) (*E, error) {
+func (db *postgresDBQuerier[E]) Insert(elem *E, elemID string) (*E, error) {
 	tx := db.Table(db.tableName).Create(elem)
 	if err := tx.Error; err != nil {
 		return nil, err
 	}
 
-	_, newElem, err := db.SelectExists(elemID, nil)
-	return newElem, err
+	return elem, nil
 }
 
-func (db *postgresDBQuerier[E]) Update(elem E, elemID string) (*E, error) {
-	_, newElem, err := db.SelectExists(elemID, nil)
-	tx := db.Table(db.tableName).Save(&elem)
+func (db *postgresDBQuerier[E]) Update(elem *E, elemID string) (*E, error) {
+	tx := db.Table(db.tableName).Where(fmt.Sprintf("%s = ?", db.primaryKeyColumn), elemID).Updates(elem)
 	if err := tx.Error; err != nil {
 		return nil, err
 	}
 
-	_, newElem, err = db.SelectExists(elemID, nil)
-	return newElem, err
+	if tx.RowsAffected != 1 {
+		return nil, gorm.ErrRecordNotFound
+	}
+
+	return elem, nil
 }
 
 func (db *postgresDBQuerier[E]) Delete(elemID string) error {
-	exists, elem, err := db.SelectExists(elemID, nil)
-	if err != nil {
-		return err
-	}
-
-	if !exists {
-		return gorm.ErrRecordNotFound
-	}
-
-	tx := db.DB.Delete(&elem)
+	tx := db.Table(db.tableName).Delete(nil, db.Where(fmt.Sprintf("%s = ?", db.primaryKeyColumn), elemID))
 	if err := tx.Error; err != nil {
 		return err
+	}
+
+	if tx.RowsAffected != 1 {
+		return gorm.ErrRecordNotFound
 	}
 
 	return nil


### PR DESCRIPTION
This PR solves adding uncontrolled fields in queries. It can be though that this allows a "soft/minor" SQL injection. All filterMaps needs to be checked to ensure that no internal columns can be used externally.