### PR TITLE
Tests - Add tests to X509Criptoengine

### DIFF
--- a/pkg/x509engines/x509engine.go
+++ b/pkg/x509engines/x509engine.go
@@ -10,7 +10,6 @@ import (
 	"crypto/sha512"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"hash"
@@ -367,7 +366,7 @@ func (engine X509Engine) Verify(caCertificate *x509.Certificate, signature []byt
 			h.Write(message)
 			hasher = h.Sum(nil)
 		} else {
-			hasher, err = hex.DecodeString(string(message))
+			hasher = message
 			if err != nil {
 				return false, err
 			}

--- a/pkg/x509engines/x509engine_sing_test.go
+++ b/pkg/x509engines/x509engine_sing_test.go
@@ -1,0 +1,286 @@
+package x509engines
+
+import (
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/sha512"
+	"crypto/x509"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/lamassuiot/lamassuiot/v2/pkg/cryptoengines"
+	"github.com/lamassuiot/lamassuiot/v2/pkg/helpers"
+	"github.com/lamassuiot/lamassuiot/v2/pkg/models"
+)
+
+func generateAndImportCA(keyType x509.PublicKeyAlgorithm, engine cryptoengines.CryptoEngine) (*x509.Certificate, any, error) {
+	caCertificate, key, err := helpers.GenerateSelfSignedCA(keyType, 365*24*time.Hour)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate self signed CA: %s", err)
+	}
+
+	switch keyType {
+	case x509.RSA:
+		rsaPrivateKey, ok := key.(*rsa.PrivateKey)
+		if !ok {
+			return nil, nil, fmt.Errorf("private key is not of type rsa.PrivateKey")
+		}
+		key, err = engine.ImportRSAPrivateKey(rsaPrivateKey, CryptoAssetLRI(Certificate, helpers.SerialNumberToString(caCertificate.SerialNumber)))
+		return caCertificate, key, err
+	case x509.ECDSA:
+		ecdsaPrivateKey, ok := key.(*ecdsa.PrivateKey)
+		if !ok {
+			return nil, nil, fmt.Errorf("private key is not of type ecdsa.PrivateKey")
+		}
+		key, err := engine.ImportECDSAPrivateKey(ecdsaPrivateKey, CryptoAssetLRI(Certificate, helpers.SerialNumberToString(caCertificate.SerialNumber)))
+		return caCertificate, key, err
+	default:
+		return nil, nil, fmt.Errorf("unsupported key type")
+	}
+}
+
+func checkValidSignature(validationResult bool, signatureError error, validationError error) error {
+
+	if signatureError != nil {
+		return fmt.Errorf("unexpected signature error %s", signatureError)
+	}
+	if validationError != nil {
+		return fmt.Errorf("unexpected validation error %s", validationError)
+	}
+	if !validationResult {
+		return fmt.Errorf("unexpected signature validation result, expected true, got false")
+	}
+
+	return nil
+}
+
+func TestSignVerify(t *testing.T) {
+	tempDir, engine, x509Engine := setup(t)
+	defer teardown(tempDir)
+
+	caCertificateRSA, _, err := generateAndImportCA(x509.RSA, engine)
+	if err != nil {
+		t.Fatalf("failed to generate and import CA: %s", err)
+	}
+	caCertificateECDSA, _, err := generateAndImportCA(x509.ECDSA, engine)
+
+	if err != nil {
+		t.Fatalf("failed to generate and import CA: %s", err)
+	}
+
+	caCertificateNotImported, _, err := helpers.GenerateSelfSignedCA(x509.ECDSA, 365*24*time.Hour)
+	if err != nil {
+		t.Fatalf("failed to generate self signed CA: %s", err)
+	}
+
+	// Create a sample message
+	message := []byte("Hello, World!")
+
+	var testcases = []struct {
+		name             string
+		certificate      *x509.Certificate
+		msgType          models.SignMessageType
+		signingAlgorithm string
+		verifyAlgorithm  string
+		value            func() ([]byte, error)
+		check            func(validationResult bool, signatureError error, validationError error) error
+	}{
+		{
+			name:             "OK/RSASSA_PSS_SHA_256",
+			certificate:      caCertificateRSA,
+			msgType:          models.Raw,
+			signingAlgorithm: "RSASSA_PSS_SHA_256",
+			check:            checkValidSignature,
+		},
+		{
+			name:             "OK/RSASSA_PKCS1_V1_5_SHA_256",
+			certificate:      caCertificateRSA,
+			msgType:          models.Raw,
+			signingAlgorithm: "RSASSA_PKCS1_V1_5_SHA_256",
+			check:            checkValidSignature,
+		},
+		{
+			name:             "OK/RSASSA_PSS_SHA_384",
+			certificate:      caCertificateRSA,
+			msgType:          models.Raw,
+			signingAlgorithm: "RSASSA_PSS_SHA_384",
+			check:            checkValidSignature,
+		},
+		{
+			name:             "OK/RSASSA_PKCS1_V1_5_SHA_384",
+			certificate:      caCertificateRSA,
+			msgType:          models.Raw,
+			signingAlgorithm: "RSASSA_PKCS1_V1_5_SHA_384",
+			check:            checkValidSignature,
+		},
+		{
+			name:             "OK/RSASSA_PSS_SHA_512",
+			certificate:      caCertificateRSA,
+			msgType:          models.Raw,
+			signingAlgorithm: "RSASSA_PSS_SHA_512",
+			check:            checkValidSignature,
+		},
+		{
+			name:             "OK/RSASSA_PKCS1_V1_5_SHA_512",
+			certificate:      caCertificateRSA,
+			msgType:          models.Raw,
+			signingAlgorithm: "RSASSA_PKCS1_V1_5_SHA_512",
+			check:            checkValidSignature,
+		},
+		{
+			name:             "OK/ECDSA_SHA_256",
+			certificate:      caCertificateECDSA,
+			msgType:          models.Raw,
+			signingAlgorithm: "ECDSA_SHA_256",
+			check:            checkValidSignature,
+		},
+		{
+			name:             "OK/ECDSA_SHA_384",
+			certificate:      caCertificateECDSA,
+			msgType:          models.Raw,
+			signingAlgorithm: "ECDSA_SHA_384",
+			check:            checkValidSignature,
+		},
+		{
+			name:             "OK/ECDSA_SHA_512",
+			certificate:      caCertificateECDSA,
+			msgType:          models.Raw,
+			signingAlgorithm: "ECDSA_SHA_512",
+			check:            checkValidSignature,
+		},
+		{
+			name:             "OK/DIGEST/RSASSA_PSS_SHA_512",
+			certificate:      caCertificateRSA,
+			msgType:          models.Hashed,
+			signingAlgorithm: "RSASSA_PSS_SHA_512",
+			check:            checkValidSignature,
+			value: func() ([]byte, error) {
+				h := sha512.New()
+				h.Write(message)
+				return h.Sum(nil), nil
+			},
+		},
+		{
+			name:             "OK/DIGEST/ECDSA_SHA_512",
+			certificate:      caCertificateECDSA,
+			msgType:          models.Hashed,
+			signingAlgorithm: "ECDSA_SHA_512",
+			check:            checkValidSignature,
+			value: func() ([]byte, error) {
+				h := sha512.New()
+				h.Write(message)
+				return h.Sum(nil), nil
+			},
+		},
+		{
+			name:             "FAIL/ECDSA_UNKNOWN",
+			certificate:      caCertificateECDSA,
+			msgType:          models.Raw,
+			signingAlgorithm: "ECDSA_UNKNOWN",
+			check: func(validationResult bool, signatureError, validationError error) error {
+				if signatureError == nil {
+					return fmt.Errorf("expected signature error, got nil")
+				}
+				if validationError == nil {
+					return fmt.Errorf("expected validation error, got nil")
+				}
+				return nil
+			},
+		},
+		{
+			name:             "FAIL/RSA_UNKNOWN",
+			certificate:      caCertificateRSA,
+			msgType:          models.Raw,
+			signingAlgorithm: "RSA_UNKNOWN",
+			check: func(validationResult bool, signatureError, validationError error) error {
+				if signatureError == nil {
+					return fmt.Errorf("expected signature error, got nil")
+				}
+				if validationError == nil {
+					return fmt.Errorf("expected validation error, got nil")
+				}
+				return nil
+			},
+		},
+		{
+			name:             "FAIL/RSA_WITH_ECDSA_CA",
+			certificate:      caCertificateECDSA,
+			msgType:          models.Raw,
+			signingAlgorithm: "RSASSA_PSS_SHA_512",
+			check: func(validationResult bool, signatureError, validationError error) error {
+				if signatureError == nil {
+					return fmt.Errorf("expected signature error, got nil")
+				}
+				if validationError == nil {
+					return fmt.Errorf("expected validation error, got nil")
+				}
+				return nil
+			},
+		},
+		{
+			name:             "FAIL/SIGN_AND_VERIFY_WITH_DIFFERENT_ALGORITHMS",
+			certificate:      caCertificateRSA,
+			msgType:          models.Raw,
+			signingAlgorithm: "RSASSA_PSS_SHA_256",
+			verifyAlgorithm:  "RSASSA_PSS_SHA_384",
+			check: func(validationResult bool, signatureError, validationError error) error {
+				if signatureError != nil {
+					return fmt.Errorf("unexpected signature error %s", signatureError)
+				}
+				if validationError == nil {
+					return fmt.Errorf("expected validation error, got nil")
+				}
+
+				if validationResult {
+					return fmt.Errorf("unexpected signature validation result, expected false, got true")
+				}
+
+				return nil
+			},
+		},
+		{
+			name:             "FAIL/UNKOWN_CA",
+			certificate:      caCertificateNotImported,
+			msgType:          models.Raw,
+			signingAlgorithm: "RSASSA_PSS_SHA_256",
+			check: func(validationResult bool, signatureError, validationError error) error {
+				if signatureError == nil {
+					return fmt.Errorf("expected signature error, got nil")
+				}
+				if validationError == nil {
+					return fmt.Errorf("expected validation error, got nil")
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+
+			value := message
+			if tc.value != nil {
+				value, err = tc.value()
+				if err != nil {
+					t.Fatalf("failed to generate value: %s", err)
+				}
+			}
+
+			// Call the Sign method
+			signature, errSignature := x509Engine.Sign(Certificate, tc.certificate, value, tc.msgType, tc.signingAlgorithm)
+			verifyAlgorithm := tc.signingAlgorithm
+			if tc.verifyAlgorithm != "" {
+				verifyAlgorithm = tc.verifyAlgorithm
+			}
+			val, errValidation := x509Engine.Verify(tc.certificate, signature, value, tc.msgType, verifyAlgorithm)
+			err := tc.check(val, errSignature, errValidation)
+			if err != nil {
+				t.Fatalf("unexpected result in test case: %s", err)
+			}
+		})
+	}
+
+}

--- a/pkg/x509engines/x509engine_test.go
+++ b/pkg/x509engines/x509engine_test.go
@@ -1,0 +1,539 @@
+package x509engines
+
+import (
+	"crypto/elliptic"
+	"crypto/rsa"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/lamassuiot/lamassuiot/v2/pkg/config"
+	"github.com/lamassuiot/lamassuiot/v2/pkg/cryptoengines"
+	"github.com/lamassuiot/lamassuiot/v2/pkg/helpers"
+	"github.com/lamassuiot/lamassuiot/v2/pkg/models"
+)
+
+func setup(t *testing.T) (string, cryptoengines.CryptoEngine, X509Engine) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+
+	// Create a new instance of GoCryptoEngine
+	log := helpers.ConfigureLogger(config.Info, "Golang Engine")
+	engine := cryptoengines.NewGolangPEMEngine(log, config.GolangEngineConfig{StorageDirectory: tempDir})
+
+	x509Engine := NewX509Engine(&engine, "")
+
+	return tempDir, engine, x509Engine
+}
+
+func teardown(tempDir string) {
+	// Remove the temporary directory
+	os.RemoveAll(tempDir)
+}
+
+func TestGetCACryptoSigner(t *testing.T) {
+	tempDir, engine, x509Engine := setup(t)
+	defer teardown(tempDir)
+	caCertificate, key, err := helpers.GenerateSelfSignedCA(x509.RSA, 365*24*time.Hour)
+	if err != nil {
+		t.Fatalf("failed to generate self signed CA: %s", err)
+	}
+
+	rsaPrivateKey, ok := key.(*rsa.PrivateKey)
+	if !ok {
+		t.Fatal("private key is not of type rsa.PrivateKey")
+	}
+
+	importedSigner, err := engine.ImportRSAPrivateKey(rsaPrivateKey, helpers.SerialNumberToString(caCertificate.SerialNumber))
+	if err != nil {
+		t.Fatalf("failed to import private key: %s", err)
+	}
+
+	// Call the GetCACryptoSigner method
+	signer, err := x509Engine.GetCACryptoSigner(caCertificate)
+
+	// Verify the result
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	if !reflect.DeepEqual(signer.Public(), caCertificate.PublicKey) {
+		t.Error("Public key does not match to the certificates public key")
+	}
+
+	if !reflect.DeepEqual(signer.Public(), importedSigner.Public()) {
+		t.Error("Public key does not match to the imported signer public key")
+	}
+
+}
+
+func TestGetCACryptoSignerNonExistentKey(t *testing.T) {
+	tempDir, _, x509Engine := setup(t)
+	defer teardown(tempDir)
+	caCertificate, _, err := helpers.GenerateSelfSignedCA(x509.RSA, 365*24*time.Hour)
+	if err != nil {
+		t.Fatalf("failed to generate self signed CA: %s", err)
+	}
+
+	// Call the GetCACryptoSigner method
+	signer, err := x509Engine.GetCACryptoSigner(caCertificate)
+
+	// Verify the result
+	if err == nil {
+		t.Error("expected an error, but got nil")
+	}
+
+	if signer != nil {
+		t.Error("expected signer to be nil, but got non-nil value")
+	}
+}
+
+func TestCryptoAssetLRI(t *testing.T) {
+	cryptoAssetType := CryptoAssetType("sample")
+	keyID := "12345"
+
+	expected := "lms-caservice-sample-keyid-12345"
+	result := CryptoAssetLRI(cryptoAssetType, keyID)
+
+	if result != expected {
+		t.Errorf("unexpected result, got: %s, want: %s", result, expected)
+	}
+
+	cryptoAssetType = Certificate
+	expected = "lms-caservice-cert-keyid-12345"
+	result = CryptoAssetLRI(cryptoAssetType, keyID)
+
+	if result != expected {
+		t.Errorf("unexpected result, got: %s, want: %s", result, expected)
+	}
+
+	cryptoAssetType = CertificateAuthority
+	expected = "lms-caservice-certauth-keyid-12345"
+	result = CryptoAssetLRI(cryptoAssetType, keyID)
+
+	if result != expected {
+		t.Errorf("unexpected result, got: %s, want: %s", result, expected)
+	}
+}
+
+func TestCreateRootCA(t *testing.T) {
+
+	tempDir, _, x509Engine := setup(t)
+	defer teardown(tempDir)
+
+	expirationTime := time.Now().AddDate(1, 0, 0) // Set expiration time to 1 year from now
+
+	checkOk := func(cert *x509.Certificate, tcSubject models.Subject, tcKeyMetadata models.KeyMetadata, err error) error {
+		if err != nil {
+			return fmt.Errorf("unexpected error: %s", err)
+		}
+
+		if cert.Subject.CommonName != tcSubject.CommonName {
+			return fmt.Errorf("unexpected result, got: %s, want: %s", cert.Subject.CommonName, tcSubject.CommonName)
+		}
+		return nil
+	}
+
+	checkFail := func(cert *x509.Certificate, tcSubject models.Subject, tcKeyMetadata models.KeyMetadata, err error) error {
+		if err == nil {
+			return fmt.Errorf("expected error, got nil")
+		}
+		return nil
+	}
+
+	var testcases = []struct {
+		name           string
+		caId           string
+		subject        models.Subject
+		keyMetadata    models.KeyMetadata
+		expirationTime time.Time
+		check          func(cert *x509.Certificate, tcSubject models.Subject, tcKeyMetadata models.KeyMetadata, err error) error
+	}{
+		{
+			name: "OK/RSA_2048",
+			caId: "rootCA-RSA2048",
+			subject: models.Subject{
+				CommonName: "Root CA",
+			},
+			keyMetadata: models.KeyMetadata{
+				Type: models.KeyType(x509.RSA),
+				Bits: 2048,
+			},
+			expirationTime: expirationTime,
+			check:          checkOk,
+		},
+		{
+			name: "FAIL/RSA_1",
+			caId: "rootCA-RSA1",
+			subject: models.Subject{
+				CommonName: "Root CA",
+			},
+			keyMetadata: models.KeyMetadata{
+				Type: models.KeyType(x509.RSA),
+				Bits: 1,
+			},
+			expirationTime: expirationTime,
+			check:          checkFail,
+		},
+		{
+			name: "OK/ECDSA_256",
+			caId: "rootCA-ECDSA_256",
+			subject: models.Subject{
+				CommonName: "Root CA",
+			},
+			keyMetadata: models.KeyMetadata{
+				Type: models.KeyType(x509.ECDSA),
+				Bits: 256,
+			},
+			expirationTime: expirationTime,
+			check:          checkOk,
+		},
+		{
+			name: "OK/ECDSA_224",
+			caId: "rootCA-ECDSA_224",
+			subject: models.Subject{
+				CommonName: "Root CA",
+			},
+			keyMetadata: models.KeyMetadata{
+				Type: models.KeyType(x509.ECDSA),
+				Bits: 224,
+			},
+			expirationTime: expirationTime,
+			check:          checkOk,
+		},
+		{
+			name: "OK/ECDSA_384",
+			caId: "rootCA-ECDSA_384",
+			subject: models.Subject{
+				CommonName: "Root CA",
+			},
+			keyMetadata: models.KeyMetadata{
+				Type: models.KeyType(x509.ECDSA),
+				Bits: 384,
+			},
+			expirationTime: expirationTime,
+			check:          checkOk,
+		},
+		{
+			name: "OK/ECDSA_521",
+			caId: "rootCA-ECDSA_521",
+			subject: models.Subject{
+				CommonName: "Root CA",
+			},
+			keyMetadata: models.KeyMetadata{
+				Type: models.KeyType(x509.ECDSA),
+				Bits: 521,
+			},
+			expirationTime: expirationTime,
+			check:          checkOk,
+		},
+		{
+			name: "FAIL/ECDSA_NOT_SUPORTED",
+			caId: "rootCA-ECDSA_FAIL",
+			subject: models.Subject{
+				CommonName: "Root CA",
+			},
+			keyMetadata: models.KeyMetadata{
+				Type: models.KeyType(x509.ECDSA),
+				Bits: 1024,
+			},
+			expirationTime: expirationTime,
+			check:          checkFail,
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			// Call the CreateRootCA method
+			cert, err := x509Engine.CreateRootCA(tc.caId, tc.keyMetadata, tc.subject, tc.expirationTime)
+			err = tc.check(cert, tc.subject, tc.keyMetadata, err)
+			if err != nil {
+				t.Fatalf("unexpected result in test case: %s", err)
+
+			}
+		})
+
+	}
+}
+
+func TestCreateSubordinateCA(t *testing.T) {
+	// Setup
+	tempDir, _, x509Engine := setup(t)
+	defer teardown(tempDir)
+
+	caID := "rootCA"
+	keyMetadata := models.KeyMetadata{
+		Type: models.KeyType(x509.RSA),
+		Bits: 2048,
+	}
+	subject := models.Subject{
+		CommonName: "Root CA",
+	}
+	expirationTime := time.Now().AddDate(1, 0, 0) // Set expiration time to 1 year from now
+
+	// Call the CreateRootCA method
+	rootCaCertRSA, err := x509Engine.CreateRootCA(caID, keyMetadata, subject, expirationTime)
+	// Verify the result
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	keyMetadata = models.KeyMetadata{
+		Type: models.KeyType(x509.ECDSA),
+		Bits: 256,
+	}
+
+	// Call the CreateRootCA method
+	rootCaCertEC, err := x509Engine.CreateRootCA(caID, keyMetadata, subject, expirationTime)
+	// Verify the result
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	subordinateSubject := models.Subject{
+		CommonName: "Subordinate CA",
+	}
+
+	checkOk := func(cert *x509.Certificate, tcSubject models.Subject, tcKeyMetadata models.KeyMetadata, err error) error {
+		// Verify the result
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+
+		if cert.Subject.CommonName != tcSubject.CommonName {
+			t.Errorf("unexpected result, got: %s, want: %s", cert.Subject.CommonName, tcSubject.CommonName)
+		}
+		return nil
+	}
+
+	var testcases = []struct {
+		name            string
+		subordinateCAID string
+		aki             string
+		rootCaCert      *x509.Certificate
+		subject         models.Subject
+		keyMetadata     models.KeyMetadata
+		expirationTime  time.Time
+		check           func(cert *x509.Certificate, tcSubject models.Subject, tcKeyMetadata models.KeyMetadata, err error) error
+	}{
+		{name: "OK/RSA_RSA",
+			subordinateCAID: "subCA",
+			aki:             "12345",
+			rootCaCert:      rootCaCertRSA,
+			subject:         subordinateSubject,
+			keyMetadata: models.KeyMetadata{
+				Type: models.KeyType(x509.RSA),
+				Bits: 2048,
+			},
+			expirationTime: expirationTime,
+			check:          checkOk,
+		},
+		{name: "OK/RSA_EC",
+			subordinateCAID: "subCA",
+			aki:             "12345",
+			rootCaCert:      rootCaCertRSA,
+			subject:         subordinateSubject,
+			keyMetadata: models.KeyMetadata{
+				Type: models.KeyType(x509.ECDSA),
+				Bits: 256,
+			},
+			expirationTime: expirationTime,
+			check:          checkOk,
+		},
+		{name: "OK/EC_RSA",
+			subordinateCAID: "subCA",
+			aki:             "12345",
+			rootCaCert:      rootCaCertEC,
+			subject:         subordinateSubject,
+			keyMetadata: models.KeyMetadata{
+				Type: models.KeyType(x509.RSA),
+				Bits: 2048,
+			},
+			expirationTime: expirationTime,
+			check:          checkOk,
+		},
+		{name: "OK/EC_EC",
+			subordinateCAID: "subCA",
+			aki:             "12345",
+			rootCaCert:      rootCaCertEC,
+			subject:         subordinateSubject,
+			keyMetadata: models.KeyMetadata{
+				Type: models.KeyType(x509.ECDSA),
+				Bits: 256,
+			},
+			expirationTime: expirationTime,
+			check:          checkOk,
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+
+			// Call the CreateSubordinateCA method
+			cert, err := x509Engine.CreateSubordinateCA(tc.aki, tc.subordinateCAID, tc.rootCaCert, tc.keyMetadata, tc.subject, tc.expirationTime, x509Engine)
+			err = tc.check(cert, tc.subject, tc.keyMetadata, err)
+			if err != nil {
+				t.Fatalf("unexpected result in test case: %s", err)
+			}
+		})
+
+	}
+}
+
+func TestSignCertificateRequest(t *testing.T) {
+
+	tempDir, _, x509Engine := setup(t)
+	defer teardown(tempDir)
+
+	caID := "rootCA"
+	keyMetadata := models.KeyMetadata{
+		Type: models.KeyType(x509.RSA),
+		Bits: 2048,
+	}
+	subject := models.Subject{
+		CommonName: "Root CA",
+	}
+	expirationTime := time.Now().AddDate(1, 0, 0) // Set expiration time to 1 year from now
+
+	// Call the CreateRootCA method
+	caCertificateRSA, err := x509Engine.CreateRootCA(caID, keyMetadata, subject, expirationTime)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	keyMetadata = models.KeyMetadata{
+		Type: models.KeyType(x509.ECDSA),
+		Bits: 256,
+	}
+
+	caCertificateEC, err := x509Engine.CreateRootCA(caID, keyMetadata, subject, expirationTime)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	caCertificateNotImported, _, err := helpers.GenerateSelfSignedCA(x509.ECDSA, 365*24*time.Hour)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	csrSubject := models.Subject{
+		CommonName:       "example.com",
+		Organization:     "Acme Inc",
+		OrganizationUnit: "IT",
+	}
+
+	checkOk := func(cert *x509.Certificate, tcSubject models.Subject, errCsr error, errSign error) error {
+
+		if errCsr != nil {
+			return fmt.Errorf("unexpected error: %s", err)
+		}
+
+		if errSign != nil {
+			return fmt.Errorf("unexpected error: %s", err)
+		}
+
+		if cert.Subject.CommonName != tcSubject.CommonName {
+			return fmt.Errorf("unexpected result, got: %s, want: %s", cert.Subject.CommonName, tcSubject.CommonName)
+		}
+		return nil
+	}
+
+	checkFail := func(cert *x509.Certificate, tcSubject models.Subject, errCsr error, errSign error) error {
+		if errCsr != nil {
+			return fmt.Errorf("unexpected error: %s", err)
+		}
+		if errSign == nil {
+			return fmt.Errorf("expected error, got nil")
+		}
+		return nil
+	}
+
+	var testcases = []struct {
+		name          string
+		caCertificate *x509.Certificate
+		subject       models.Subject
+		key           func() any
+		check         func(cert *x509.Certificate, tcSubject models.Subject, errCsr error, errSign error) error
+	}{
+		{
+			name:          "OK/RSA_RSA",
+			caCertificate: caCertificateRSA,
+			subject:       csrSubject,
+			key: func() any {
+				key, _ := helpers.GenerateRSAKey(2048)
+				return key
+			},
+			check: checkOk,
+		},
+		{
+			name:          "OK/EC_RSA",
+			caCertificate: caCertificateEC,
+			subject:       csrSubject,
+			key: func() any {
+				key, _ := helpers.GenerateRSAKey(2048)
+				return key
+			},
+			check: checkOk,
+		},
+		{
+			name:          "OK/RSA_EC",
+			caCertificate: caCertificateRSA,
+			subject:       csrSubject,
+			key: func() any {
+				key, _ := helpers.GenerateECDSAKey(elliptic.P256())
+				return key
+			},
+			check: checkOk,
+		},
+		{
+			name:          "OK/EC_EC",
+			caCertificate: caCertificateEC,
+			subject:       csrSubject,
+			key: func() any {
+				key, _ := helpers.GenerateECDSAKey(elliptic.P256())
+				return key
+			},
+			check: checkOk,
+		},
+		{
+			name:          "FAIL/NOT_EXISTENT_CA",
+			caCertificate: caCertificateNotImported,
+			subject:       csrSubject,
+			key: func() any {
+				key, _ := helpers.GenerateECDSAKey(elliptic.P256())
+				return key
+			},
+			check: checkFail,
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			csr, errCsr := helpers.GenerateCertificateRequest(tc.subject, tc.key())
+			cert, errSing := x509Engine.SignCertificateRequest(tc.caCertificate, csr, expirationTime)
+			tc.check(cert, tc.subject, errCsr, errSing)
+		})
+	}
+}
+
+func TestGetEngineConfig(t *testing.T) {
+	tempDir, engine, x509Engine := setup(t)
+	defer teardown(tempDir)
+
+	// Call the GetEngineConfig method
+	config := x509Engine.GetEngineConfig()
+
+	// Verify the result
+	expected := engine.GetEngineConfig()
+	if !reflect.DeepEqual(config, expected) {
+		t.Errorf("unexpected result, got: %v, want: %v", config, expected)
+	}
+}


### PR DESCRIPTION
This PR adds tests for pkg/x509engines/x509engine.go

Includes a fix for an error validating a signature using ECSA alogrithm when the content was hashed. The code was trying to decode the string into binary which is not necesary. 