### PR TITLE
Integration tests for Device Manager service

### DIFF
--- a/pkg/assemblers/ca_test.go
+++ b/pkg/assemblers/ca_test.go
@@ -2744,7 +2744,7 @@ func initCA(caSDK services.CAService) (*models.CACertificate, error) {
 func BuildCATestServer() (*CATestServer, error) {
 	vaultSDKConf, vaultSuite := vault_test.BeforeSuite()
 
-	pConfig, postgresSuite := postgres_test.BeforeSuite("ca")
+	pConfig, postgresSuite := postgres_test.BeforeSuite([]string{"ca", "devicemanager"})
 
 	svc, port, err := AssembleCAServiceWithHTTPServer(config.CAConfig{
 		BaseConfig: config.BaseConfig{
@@ -2807,12 +2807,12 @@ func BuildCATestServer() (*CATestServer, error) {
 			}
 
 			//reinitialize tables schemas
-			_, err = postgres.NewCAPostgresRepository(postgresSuite.DB)
+			_, err = postgres.NewCAPostgresRepository(postgresSuite.DB["ca"])
 			if err != nil {
 				return fmt.Errorf("could not run reinitialize CA tables: %s", err)
 			}
 
-			_, err = postgres.NewCertificateRepository(postgresSuite.DB)
+			_, err = postgres.NewCertificateRepository(postgresSuite.DB["ca"])
 			if err != nil {
 				return fmt.Errorf("could not run reinitialize Certificates tables: %s", err)
 			}

--- a/pkg/assemblers/ca_test.go
+++ b/pkg/assemblers/ca_test.go
@@ -33,7 +33,6 @@ func TestCryptoEngines(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create CA test server: %s", err)
 	}
-	t.Cleanup(serverTest.AfterSuite)
 	caTest := serverTest.CA
 
 	var testcases = []struct {
@@ -79,7 +78,7 @@ func TestCreateCA(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create CA test server: %s", err)
 	}
-	t.Cleanup(serverTest.AfterSuite)
+
 	caTest := serverTest.CA
 
 	caID := "12345-11111"
@@ -244,7 +243,7 @@ func TestGetCertificatesByCaAndStatus(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create CA test server: %s", err)
 	}
-	t.Cleanup(serverTest.AfterSuite)
+
 	caTest := serverTest.CA
 
 	t.Parallel()
@@ -381,7 +380,7 @@ func TestRevokeCA(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create CA test server: %s", err)
 	}
-	t.Cleanup(serverTest.AfterSuite)
+
 	caTest := serverTest.CA
 
 	var testcases = []struct {
@@ -510,7 +509,7 @@ func TestUpdateCAMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create CA test server: %s", err)
 	}
-	t.Cleanup(serverTest.AfterSuite)
+
 	caTest := serverTest.CA
 
 	var testcases = []struct {
@@ -611,7 +610,7 @@ func TestGetCAsByCommonName(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create CA test server: %s", err)
 	}
-	t.Cleanup(serverTest.AfterSuite)
+
 	caTest := serverTest.CA
 
 	var testcases = []struct {
@@ -681,7 +680,7 @@ func TestUpdateCertificateMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create CA test server: %s", err)
 	}
-	t.Cleanup(serverTest.AfterSuite)
+
 	caTest := serverTest.CA
 
 	var testcases = []struct {
@@ -806,7 +805,7 @@ func TestUpdateCAStatus(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create CA test server: %s", err)
 	}
-	t.Cleanup(serverTest.AfterSuite)
+
 	caTest := serverTest.CA
 
 	var testcases = []struct {
@@ -954,7 +953,7 @@ func TestGetStats(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create CA test server: %s", err)
 	}
-	t.Cleanup(serverTest.AfterSuite)
+
 	caTest := serverTest.CA
 
 	var testcases = []struct {
@@ -1018,7 +1017,7 @@ func TestGetCertificates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create CA test server: %s", err)
 	}
-	t.Cleanup(serverTest.AfterSuite)
+
 	caTest := serverTest.CA
 
 	var testcases = []struct {
@@ -1157,7 +1156,7 @@ func TestGetCertificatesByCA(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create CA test server: %s", err)
 	}
-	t.Cleanup(serverTest.AfterSuite)
+
 	caTest := serverTest.CA
 
 	var testcases = []struct {
@@ -1392,7 +1391,7 @@ func TestImportCA(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create CA test server: %s", err)
 	}
-	t.Cleanup(serverTest.AfterSuite)
+
 	caTest := serverTest.CA
 
 	generateSelfSignedCA := func(keyType x509.PublicKeyAlgorithm) (*x509.Certificate, any, error) {
@@ -1669,10 +1668,9 @@ func TestDeleteCA(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create CA test server: %s", err)
 	}
-	t.Cleanup(serverTest.AfterSuite)
+
 	caTest := serverTest.CA
 
-	t.Cleanup(caTest.AfterSuite)
 	var testcases = []struct {
 		name        string
 		before      func(svc services.CAService) error
@@ -1801,7 +1799,7 @@ func TestGetCAs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create CA test server: %s", err)
 	}
-	t.Cleanup(serverTest.AfterSuite)
+
 	caTest := serverTest.CA
 
 	var testcases = []struct {
@@ -1962,7 +1960,7 @@ func TestGetCertificatesByExpirationDate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create CA test server: %s", err)
 	}
-	t.Cleanup(serverTest.AfterSuite)
+
 	caTest := serverTest.CA
 
 	var testcases = []struct {
@@ -2143,10 +2141,9 @@ func TestSignatureVerify(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create CA test server: %s", err)
 	}
-	t.Cleanup(serverTest.AfterSuite)
+
 	caTest := serverTest.CA
 
-	t.Cleanup(caTest.AfterSuite)
 	var testcases = []struct {
 		name        string
 		before      func(svc services.CAService) error
@@ -2266,7 +2263,7 @@ func TestHierarchyCryptoEngines(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create CA test server: %s", err)
 	}
-	t.Cleanup(serverTest.AfterSuite)
+
 	caTest := serverTest.CA
 
 	var testcases = []struct {
@@ -2376,7 +2373,7 @@ func TestHierarchy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create CA test server: %s", err)
 	}
-	t.Cleanup(serverTest.AfterSuite)
+
 	caTest := serverTest.CA
 
 	var testcases = []struct {
@@ -2700,9 +2697,6 @@ func TestHierarchy(t *testing.T) {
 		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
-			//
-			// err := postgres_test.BeforeEach()
-			// fmt.Errorf("Error while running BeforeEach job: %s", err)
 
 			err = serverTest.BeforeEach()
 			if err != nil {

--- a/pkg/assemblers/device-manager_test.go
+++ b/pkg/assemblers/device-manager_test.go
@@ -1,0 +1,596 @@
+package assemblers
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/lamassuiot/lamassuiot/v2/pkg/clients"
+	"github.com/lamassuiot/lamassuiot/v2/pkg/config"
+	"github.com/lamassuiot/lamassuiot/v2/pkg/models"
+	"github.com/lamassuiot/lamassuiot/v2/pkg/resources"
+	"github.com/lamassuiot/lamassuiot/v2/pkg/services"
+	"github.com/lamassuiot/lamassuiot/v2/pkg/storage/postgres"
+	postgres_test "github.com/lamassuiot/lamassuiot/v2/pkg/test/subsystems/storage/postgres"
+)
+
+type DeviceManagerTestServer struct {
+	Service              services.DeviceManagerService
+	HttpDeviceManagerSDK services.DeviceManagerService
+	BeforeEach           func() error
+	AfterSuite           func()
+}
+
+func initPostgres(dbs []string) (config.PostgresPSEConfig, postgres_test.PostgresSuite) {
+	return postgres_test.BeforeSuite(dbs)
+}
+
+func buildCASimpleTestServer(pConfig config.PostgresPSEConfig, postgresSuite postgres_test.PostgresSuite) (*CATestServer, error) {
+
+	svc, port, err := AssembleCAServiceWithHTTPServer(config.CAConfig{
+		BaseConfig: config.BaseConfig{
+			Logs: config.BaseConfigLogging{
+				Level: config.Info,
+			},
+			Server: config.HttpServer{
+				LogLevel:           config.Info,
+				HealthCheckLogging: false,
+				Protocol:           config.HTTP,
+			},
+			EventBus: config.EventBusEngine{Enabled: false},
+		},
+		Storage: config.PluggableStorageEngine{
+			LogLevel: config.Info,
+			Provider: config.Postgres,
+			Postgres: pConfig,
+		},
+		CryptoEngines: config.CryptoEngines{
+			LogLevel:      config.Info,
+			DefaultEngine: "filesystem-1",
+			GolangProvider: []config.GolangEngineConfig{
+				{
+					ID:               "filesystem-1",
+					Metadata:         map[string]interface{}{},
+					StorageDirectory: "/tmp/lms-test/",
+				},
+			},
+		},
+		CryptoMonitoring: config.CryptoMonitoring{
+			Enabled: false,
+		},
+		VAServerDomain: "http://dev.lamassu.test",
+	}, models.APIServiceInfo{
+		Version:   "test",
+		BuildSHA:  "-",
+		BuildTime: "-",
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("could not assemble CA with HTTP server")
+	}
+
+	return &CATestServer{
+		Service:   *svc,
+		HttpCASDK: clients.NewHttpCAClient(http.DefaultClient, fmt.Sprintf("http://127.0.0.1:%d", port)),
+		BeforeEach: func() error {
+			//reinitialize tables schemas
+			_, err = postgres.NewCAPostgresRepository(postgresSuite.DB["ca"])
+			if err != nil {
+				return fmt.Errorf("could not run reinitialize CA tables: %s", err)
+			}
+
+			_, err = postgres.NewCertificateRepository(postgresSuite.DB["ca"])
+			if err != nil {
+				return fmt.Errorf("could not run reinitialize Certificates tables: %s", err)
+			}
+
+			return nil
+		},
+		AfterSuite: func() {
+			fmt.Println("TEST CLEANUP CA")
+			postgresSuite.AfterSuite()
+		},
+	}, nil
+}
+
+func BuildDeviceManagerServiceTestServer(t *testing.T) (*DeviceManagerTestServer, error) {
+	pConfig, postgresSuite := initPostgres([]string{"ca", "devicemanager"})
+
+	caTest, err := buildCASimpleTestServer(pConfig, postgresSuite)
+	if err != nil {
+		return nil, fmt.Errorf("could not create CA test server: %s", err)
+	}
+	t.Cleanup(caTest.AfterSuite)
+
+	svc, port, err := AssembleDeviceManagerServiceWithHTTPServer(config.DeviceManagerConfig{
+		BaseConfig: config.BaseConfig{
+			Logs: config.BaseConfigLogging{
+				Level: config.Info,
+			},
+			Server: config.HttpServer{
+				LogLevel:           config.Info,
+				HealthCheckLogging: false,
+				Protocol:           config.HTTP,
+			},
+			EventBus: config.EventBusEngine{Enabled: false},
+		},
+		Storage: config.PluggableStorageEngine{
+			LogLevel: config.Info,
+			Provider: config.Postgres,
+			Postgres: pConfig,
+		},
+	}, caTest.Service, models.APIServiceInfo{
+		Version:   "test",
+		BuildSHA:  "-",
+		BuildTime: "-",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not assemble Device Manager Service. Exiting: %s", err)
+	}
+
+	return &DeviceManagerTestServer{
+		Service:              *svc,
+		HttpDeviceManagerSDK: clients.NewHttpDeviceManagerClient(http.DefaultClient, fmt.Sprintf("http://127.0.0.1:%d", port)),
+		BeforeEach: func() error {
+			err := postgresSuite.BeforeEach()
+			if err != nil {
+				return fmt.Errorf("could not run postgres BeforeEach: %s", err)
+			}
+
+			err = caTest.BeforeEach()
+			if err != nil {
+				return fmt.Errorf("could not run postgres BeforeEach: %s", err)
+			}
+
+			//reinitialize tables schemas
+			_, err = postgres.NewDeviceManagerRepository(postgresSuite.DB["devicemanager"])
+			if err != nil {
+				return fmt.Errorf("could not run reinitialize Certificates tables: %s", err)
+			}
+
+			return nil
+		},
+		AfterSuite: func() {
+			fmt.Println("TEST CLEANUP DEVICE MANAGER")
+			postgresSuite.AfterSuite()
+		},
+	}, nil
+
+}
+
+func TestDuplicateDeviceCreation(t *testing.T) {
+	dmgr, err := BuildDeviceManagerServiceTestServer(t)
+	if err != nil {
+		t.Fatalf("could not create CA test server: %s", err)
+	}
+	t.Cleanup(dmgr.AfterSuite)
+	err = dmgr.BeforeEach()
+	if err != nil {
+		t.Fatalf("failed running 'BeforeEach' cleanup func in test case: %s", err)
+	}
+
+	deviceSample := services.CreateDeviceInput{
+		ID:        "test",
+		Alias:     "test",
+		Tags:      []string{"test"},
+		Metadata:  map[string]interface{}{"test": "test"},
+		DMSID:     "test",
+		Icon:      "test",
+		IconColor: "#000000",
+	}
+	device, err := dmgr.Service.CreateDevice(deviceSample)
+	if err != nil {
+		t.Fatalf("could not create device: %s", err)
+	}
+	checkDevice(t, device, deviceSample)
+	_, err = dmgr.Service.CreateDevice(deviceSample)
+	if err == nil {
+		t.Fatalf("duplicate device creation should fail")
+	}
+
+}
+
+func TestPagination(t *testing.T) {
+	dmgr, err := BuildDeviceManagerServiceTestServer(t)
+	if err != nil {
+		t.Fatalf("could not create CA test server: %s", err)
+	}
+	t.Cleanup(dmgr.AfterSuite)
+	err = dmgr.BeforeEach()
+	if err != nil {
+		t.Fatalf("failed running 'BeforeEach' cleanup func in test case: %s", err)
+	}
+
+	deviceSample := services.CreateDeviceInput{
+		ID:        "test",
+		Alias:     "test",
+		Tags:      []string{"test"},
+		Metadata:  map[string]interface{}{"test": "test"},
+		DMSID:     "test",
+		Icon:      "test",
+		IconColor: "#000000",
+	}
+
+	deviceSample2 := services.CreateDeviceInput{
+		ID:        "test2",
+		Alias:     "test2",
+		Tags:      []string{"test2"},
+		Metadata:  map[string]interface{}{"test2": "test2"},
+		DMSID:     "test2",
+		Icon:      "test2",
+		IconColor: "#000001",
+	}
+
+	deviceSample3 := services.CreateDeviceInput{
+		ID:        "test3",
+		Alias:     "test3",
+		Tags:      []string{"test3"},
+		Metadata:  map[string]interface{}{"test3": "test3"},
+		DMSID:     "test3",
+		Icon:      "test3",
+		IconColor: "#000002",
+	}
+
+	deviceSample4 := services.CreateDeviceInput{
+		ID:        "test4",
+		Alias:     "test4",
+		Tags:      []string{"test4"},
+		Metadata:  map[string]interface{}{"test4": "test4"},
+		DMSID:     "test4",
+		Icon:      "test4",
+		IconColor: "#000003",
+	}
+
+	deviceSample5 := services.CreateDeviceInput{
+		ID:        "test5",
+		Alias:     "test5",
+		Tags:      []string{"test5"},
+		Metadata:  map[string]interface{}{"test5": "test5"},
+		DMSID:     "test5",
+		Icon:      "test5",
+		IconColor: "#000004",
+	}
+
+	dmgr.Service.CreateDevice(deviceSample)
+	dmgr.Service.CreateDevice(deviceSample2)
+	dmgr.Service.CreateDevice(deviceSample3)
+	dmgr.Service.CreateDevice(deviceSample4)
+	dmgr.Service.CreateDevice(deviceSample5)
+
+	devices := []models.Device{}
+	request := services.GetDevicesInput{
+		ListInput: resources.ListInput[models.Device]{
+			QueryParameters: &resources.QueryParameters{
+				PageSize: 2,
+				Sort: resources.SortOptions{
+					SortMode:  resources.SortModeAsc,
+					SortField: "id",
+				},
+			},
+			ExhaustiveRun: false,
+			ApplyFunc: func(dev models.Device) {
+				devices = append(devices, dev)
+			},
+		},
+	}
+
+	bookmark, err := dmgr.Service.GetDevices(request)
+	if err != nil {
+		t.Fatalf("could not retrieve device: %s", err)
+	}
+	if bookmark == "" {
+		t.Fatalf("bookmark is empty")
+	}
+	if len(devices) != 2 {
+		t.Fatalf("could not retrieve device: %s", err)
+	}
+
+	checkDevice(t, &devices[0], deviceSample)
+
+	devices = []models.Device{}
+	request = services.GetDevicesInput{
+		ListInput: resources.ListInput[models.Device]{
+			QueryParameters: &resources.QueryParameters{
+				NextBookmark: bookmark,
+				Sort: resources.SortOptions{
+					SortMode:  resources.SortModeAsc,
+					SortField: "id",
+				},
+			},
+			ExhaustiveRun: false,
+			ApplyFunc: func(dev models.Device) {
+				devices = append(devices, dev)
+			},
+		},
+	}
+
+	bookmark, err = dmgr.Service.GetDevices(request)
+	if err != nil {
+		t.Fatalf("could not retrieve device: %s", err)
+	}
+	if bookmark == "" {
+		t.Fatalf("bookmark is empty")
+	}
+	if len(devices) != 2 {
+		t.Fatalf("could not retrieve device: %s", err)
+	}
+
+	checkDevice(t, &devices[0], deviceSample3)
+
+	devices = []models.Device{}
+	request = services.GetDevicesInput{
+		ListInput: resources.ListInput[models.Device]{
+			QueryParameters: &resources.QueryParameters{
+				NextBookmark: bookmark,
+				Sort: resources.SortOptions{
+					SortMode:  resources.SortModeAsc,
+					SortField: "id",
+				},
+			},
+			ExhaustiveRun: false,
+			ApplyFunc: func(dev models.Device) {
+				devices = append(devices, dev)
+			},
+		},
+	}
+
+	bookmark, err = dmgr.Service.GetDevices(request)
+	if err != nil {
+		t.Fatalf("could not retrieve device: %s", err)
+	}
+
+	if len(devices) != 1 {
+		t.Fatalf("could not retrieve device: %v", len(devices))
+	}
+	checkDevice(t, &devices[0], deviceSample5)
+
+	devices = []models.Device{}
+	request = services.GetDevicesInput{
+		ListInput: resources.ListInput[models.Device]{
+			QueryParameters: &resources.QueryParameters{
+				NextBookmark: bookmark,
+				Sort: resources.SortOptions{
+					SortMode:  resources.SortModeAsc,
+					SortField: "id",
+				},
+			},
+			ExhaustiveRun: false,
+			ApplyFunc: func(dev models.Device) {
+				devices = append(devices, dev)
+			},
+		},
+	}
+
+	bookmark, err = dmgr.Service.GetDevices(request)
+	if err != nil {
+		t.Fatalf("could not retrieve device: %s", err)
+	}
+
+	if len(devices) != 0 {
+		t.Fatalf("could not retrieve device: %v", len(devices))
+	}
+
+	if bookmark != "" {
+		t.Fatalf("bookmark should be empty at last page %s", bookmark)
+	}
+
+	// Sort by id desc
+	devices = []models.Device{}
+	request = services.GetDevicesInput{
+		ListInput: resources.ListInput[models.Device]{
+			QueryParameters: &resources.QueryParameters{
+				PageSize: 1,
+				Sort: resources.SortOptions{
+					SortMode:  resources.SortModeDesc,
+					SortField: "id",
+				},
+			},
+			ExhaustiveRun: false,
+			ApplyFunc: func(dev models.Device) {
+				devices = append(devices, dev)
+			},
+		},
+	}
+
+	_, err = dmgr.Service.GetDevices(request)
+	if err != nil {
+		t.Fatalf("could not retrieve device: %s", err)
+	}
+	checkDevice(t, &devices[0], deviceSample5)
+
+}
+
+func TestBasicDeviceManager(t *testing.T) {
+	dmgr, err := BuildDeviceManagerServiceTestServer(t)
+	if err != nil {
+		t.Fatalf("could not create CA test server: %s", err)
+	}
+
+	t.Cleanup(dmgr.AfterSuite)
+	err = dmgr.BeforeEach()
+	if err != nil {
+		t.Fatalf("failed running 'BeforeEach' cleanup func in test case: %s", err)
+	}
+
+	deviceSample := services.CreateDeviceInput{
+		ID:        "test",
+		Alias:     "test",
+		Tags:      []string{"test"},
+		Metadata:  map[string]interface{}{"test": "test"},
+		DMSID:     "test",
+		Icon:      "test",
+		IconColor: "#000000",
+	}
+
+	deviceSample2 := services.CreateDeviceInput{
+		ID:        "test2",
+		Alias:     "test2",
+		Tags:      []string{"test2"},
+		Metadata:  map[string]interface{}{"test2": "test2"},
+		DMSID:     "test2",
+		Icon:      "test2",
+		IconColor: "#000001",
+	}
+
+	device, err := dmgr.Service.CreateDevice(deviceSample)
+	dmgr.Service.CreateDevice(deviceSample2)
+	if err != nil {
+		t.Fatalf("could not create device: %s", err)
+	}
+	checkDevice(t, device, deviceSample)
+
+	request := services.GetDeviceByIDInput{ID: "test"}
+
+	deviceGet, err := dmgr.Service.GetDeviceByID(request)
+	if err != nil {
+		t.Fatalf("could not retrieve device: %s", err)
+	}
+	checkDevice(t, deviceGet, deviceSample)
+
+	checkSelectAll(t, dmgr)
+
+	checkSelectByDMS(t, dmgr, deviceSample2)
+	checkDeviceStats(t, dmgr)
+	checkUpdateDeviceStatus(t, dmgr, deviceSample)
+	checkUpdateDeviceMetadata(t, dmgr, deviceSample)
+
+}
+
+func checkUpdateDeviceMetadata(t *testing.T, dmgr *DeviceManagerTestServer, deviceSample services.CreateDeviceInput) {
+	request := services.UpdateDeviceMetadataInput{
+		ID:       deviceSample.ID,
+		Metadata: map[string]interface{}{"test": "test2"},
+	}
+
+	device, err := dmgr.Service.UpdateDeviceMetadata(request)
+	if err != nil {
+		t.Fatalf("could not update device metadata: %s", err)
+	}
+
+	if device.Metadata["test"] != "test2" {
+		t.Fatalf("device metadata mismatch: expected %s, got %s", "test2", device.Metadata["test"])
+	}
+}
+
+func checkUpdateDeviceStatus(t *testing.T, dmgr *DeviceManagerTestServer, deviceSample services.CreateDeviceInput) {
+	request := services.UpdateDeviceStatusInput{
+		ID:        deviceSample.ID,
+		NewStatus: models.DeviceActive,
+	}
+
+	device, err := dmgr.Service.UpdateDeviceStatus(request)
+	if err != nil {
+		t.Fatalf("could not update device status: %s", err)
+	}
+
+	if device.Status != models.DeviceActive {
+		t.Fatalf("device status mismatch: expected %s, got %s", models.DeviceActive, device.Status)
+	}
+}
+
+func checkDeviceStats(t *testing.T, dmgr *DeviceManagerTestServer) {
+
+	request := services.GetDevicesStatsInput{}
+
+	stats, err := dmgr.Service.GetDevicesStats(request)
+	if err != nil {
+		t.Fatalf("could not retrieve device stats: %s", err)
+	}
+
+	if stats.TotalDevices != 2 {
+		t.Fatalf("device stats mismatch: expected %d, got %d", 2, stats.TotalDevices)
+	}
+
+	if stats.DevicesStatus[models.DeviceNoIdentity] != 2 {
+		t.Fatalf("device stats mismatch: expected %d, got %d", 2, stats.DevicesStatus[models.DeviceNoIdentity])
+	}
+
+	if stats.DevicesStatus[models.DeviceActive] != 0 {
+		t.Fatalf("device stats mismatch: expected %d, got %d", 0, stats.DevicesStatus[models.DeviceActive])
+	}
+}
+
+func checkDevice(t *testing.T, device *models.Device, deviceSample services.CreateDeviceInput) {
+	if device.ID != deviceSample.ID {
+		t.Fatalf("device id mismatch: expected %s, got %s", deviceSample.ID, device.ID)
+	}
+
+	if device.Icon != deviceSample.Icon {
+		t.Fatalf("device icon mismatch: expected %s, got %s", deviceSample.Icon, device.Icon)
+	}
+
+	if device.IconColor != deviceSample.IconColor {
+		t.Fatalf("device icon mismatch: expected %s, got %s", deviceSample.IconColor, device.IconColor)
+	}
+
+	if device.Status != models.DeviceNoIdentity {
+		t.Fatalf("device status mismatch: expected %s, got %s", models.DeviceNoIdentity, device.Status)
+	}
+
+	if device.DMSOwnerID != deviceSample.DMSID {
+		t.Fatalf("device dms id mismatch: expected %s, got %s", deviceSample.DMSID, device.DMSOwnerID)
+	}
+
+	if device.Tags[0] != deviceSample.Tags[0] {
+		t.Fatalf("device tags mismatch: expected %s, got %s", deviceSample.Tags[0], device.Tags[0])
+	}
+
+	if device.CreationTimestamp.IsZero() {
+		t.Fatalf("device creation timestamp is zero")
+	}
+
+	if device.Events == nil {
+		t.Fatalf("device events is nil")
+	}
+
+	if device.IdentitySlot != nil {
+		t.Fatalf("device identity slot is not nil")
+	}
+}
+
+func checkSelectByDMS(t *testing.T, dmgr *DeviceManagerTestServer, deviceSample services.CreateDeviceInput) {
+	devices := []models.Device{}
+	request2 := services.GetDevicesByDMSInput{
+		DMSID: "test2",
+		ListInput: resources.ListInput[models.Device]{
+			QueryParameters: nil,
+			ExhaustiveRun:   false,
+			ApplyFunc: func(dev models.Device) {
+				devices = append(devices, dev)
+			},
+		},
+	}
+
+	_, err := dmgr.Service.GetDeviceByDMS(request2)
+	if err != nil {
+		t.Fatalf("could not retrieve device: %s", err)
+	}
+
+	if len(devices) != 1 {
+		t.Fatalf("could not retrieve device: %s", err)
+	}
+
+	checkDevice(t, &devices[0], deviceSample)
+}
+
+func checkSelectAll(t *testing.T, dmgr *DeviceManagerTestServer) {
+	devices := []models.Device{}
+	request2 := services.GetDevicesInput{
+		ListInput: resources.ListInput[models.Device]{
+			QueryParameters: nil,
+			ExhaustiveRun:   false,
+			ApplyFunc: func(dev models.Device) {
+				devices = append(devices, dev)
+			},
+		},
+	}
+
+	_, err := dmgr.Service.GetDevices(request2)
+	if err != nil {
+		t.Fatalf("could not retrieve device: %s", err)
+	}
+
+	if len(devices) != 2 {
+		t.Fatalf("could not retrieve device: %s", err)
+	}
+}

--- a/pkg/assemblers/service-assembler_test.go
+++ b/pkg/assemblers/service-assembler_test.go
@@ -1,0 +1,375 @@
+package assemblers
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/lamassuiot/lamassuiot/v2/pkg/clients"
+	"github.com/lamassuiot/lamassuiot/v2/pkg/config"
+	"github.com/lamassuiot/lamassuiot/v2/pkg/models"
+	"github.com/lamassuiot/lamassuiot/v2/pkg/services"
+	"github.com/lamassuiot/lamassuiot/v2/pkg/storage/postgres"
+	vault_test "github.com/lamassuiot/lamassuiot/v2/pkg/test/subsystems/cryptoengines/keyvaultkv2"
+	postgres_test "github.com/lamassuiot/lamassuiot/v2/pkg/test/subsystems/storage/postgres"
+)
+
+type CryptoEngine int
+
+const (
+	_ CryptoEngine = iota
+	GOLANG
+	VAULT
+	AWS_SECRETS
+	AWS_KMS
+)
+
+type Service int
+
+const (
+	_ Service = iota
+	CA
+	DEVICE_MANAGER
+	VA
+	DMS_MANAGER
+)
+
+type TestStorageEngineConfig struct {
+	config     config.PluggableStorageEngine
+	BeforeEach func() error
+	AfterSuite func()
+}
+
+type TestCryptoEngineConfig struct {
+	config     config.CryptoEngines
+	BeforeEach func() error
+	AfterSuite func()
+}
+
+type CATestServer struct {
+	Service    services.CAService
+	HttpCASDK  services.CAService
+	BeforeEach func() error
+	AfterSuite func()
+}
+
+type DeviceManagerTestServer struct {
+	Service              services.DeviceManagerService
+	HttpDeviceManagerSDK services.DeviceManagerService
+	BeforeEach           func() error
+	AfterSuite           func()
+}
+
+type VATestServer struct {
+	HttpServerURL string
+	CaSDK         services.CAService
+	BeforeEach    func() error
+	AfterSuite    func()
+}
+
+type TestServer struct {
+	CA            *CATestServer
+	VA            *VATestServer
+	DeviceManager *DeviceManagerTestServer
+	BeforeEach    func() error
+	AfterSuite    func()
+}
+
+func PreparePostgresForTest(dbs []string) (TestStorageEngineConfig, error) {
+
+	pConfig, postgresEngine := postgres_test.BeforeSuite(dbs)
+
+	return TestStorageEngineConfig{
+		config: config.PluggableStorageEngine{LogLevel: config.Info, Provider: config.Postgres, Postgres: pConfig},
+		BeforeEach: func() error {
+			for _, dbName := range dbs {
+				postgresEngine.BeforeEach()
+				switch dbName {
+				case "ca":
+					_, err := postgres.NewCAPostgresRepository(postgresEngine.DB[dbName])
+					if err != nil {
+						return fmt.Errorf("could not run reinitialize CA tables: %s", err)
+					}
+				case "certificates":
+					_, err := postgres.NewCertificateRepository(postgresEngine.DB[dbName])
+					if err != nil {
+						return fmt.Errorf("could not run reinitialize Certificates tables: %s", err)
+					}
+				case "devicemanager":
+					_, err := postgres.NewDeviceManagerRepository(postgresEngine.DB[dbName])
+					if err != nil {
+						return fmt.Errorf("could not run reinitialize DeviceManager tables: %s", err)
+					}
+				default:
+					return fmt.Errorf("unknown db name: %s", dbName)
+				}
+			}
+			return nil
+		},
+		AfterSuite: postgresEngine.AfterSuite,
+	}, nil
+}
+
+func PrepareCryptoEnginesForTest(engines []CryptoEngine) TestCryptoEngineConfig {
+
+	beforeEachActions := []func() error{}
+	afterSuiteActions := []func(){}
+
+	cryptoEngineConf := config.CryptoEngines{
+		LogLevel:      config.Info,
+		DefaultEngine: "filesystem-1",
+		GolangProvider: []config.GolangEngineConfig{
+			{
+				ID:               "filesystem-1",
+				Metadata:         map[string]interface{}{},
+				StorageDirectory: "/tmp/lms-test/",
+			},
+		},
+	}
+
+	beforeEachActions = append(beforeEachActions, func() error {
+		return nil
+	})
+	afterSuiteActions = append(afterSuiteActions, func() {})
+
+	if contains(engines, VAULT) {
+		vaultSDKConf, vaultSuite := vault_test.BeforeSuite()
+		cryptoEngineConf.HashicorpVaultKV2Provider = []config.HashicorpVaultCryptoEngineConfig{
+			{
+				ID:                "vault-1",
+				HashicorpVaultSDK: vaultSDKConf,
+				Metadata:          map[string]interface{}{},
+			},
+		}
+		beforeEachActions = append(beforeEachActions, vaultSuite.BeforeEach)
+		afterSuiteActions = append(afterSuiteActions, vaultSuite.AfterSuite)
+	}
+
+	beforeEach := func() error {
+		for _, action := range beforeEachActions {
+			err := action()
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	afterSuite := func() {
+		for _, action := range afterSuiteActions {
+			action()
+		}
+	}
+
+	return TestCryptoEngineConfig{
+		config:     cryptoEngineConf,
+		BeforeEach: beforeEach,
+		AfterSuite: afterSuite,
+	}
+}
+
+func contains[T comparable](slice []T, value T) bool {
+	for _, item := range slice {
+		if item == value {
+			return true
+		}
+	}
+	return false
+}
+
+func BuildCATestServer(storageEngine TestStorageEngineConfig, criptoEngines TestCryptoEngineConfig) (*CATestServer, error) {
+
+	svc, port, err := AssembleCAServiceWithHTTPServer(config.CAConfig{
+		BaseConfig: config.BaseConfig{
+			Logs: config.BaseConfigLogging{
+				Level: config.Info,
+			},
+			Server: config.HttpServer{
+				LogLevel:           config.Info,
+				HealthCheckLogging: false,
+				Protocol:           config.HTTP,
+			},
+			EventBus: config.EventBusEngine{Enabled: false},
+		},
+		Storage:       storageEngine.config,
+		CryptoEngines: criptoEngines.config,
+		CryptoMonitoring: config.CryptoMonitoring{
+			Enabled: false,
+		},
+		VAServerDomain: "http://dev.lamassu.test",
+	}, models.APIServiceInfo{
+		Version:   "test",
+		BuildSHA:  "-",
+		BuildTime: "-",
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("could not assemble CA with HTTP server")
+	}
+
+	return &CATestServer{
+		Service:   *svc,
+		HttpCASDK: clients.NewHttpCAClient(http.DefaultClient, fmt.Sprintf("http://127.0.0.1:%d", port)),
+		BeforeEach: func() error {
+			err := storageEngine.BeforeEach()
+			if err != nil {
+				return err
+			}
+			err = criptoEngines.BeforeEach()
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+		AfterSuite: func() {
+			storageEngine.AfterSuite()
+			criptoEngines.AfterSuite()
+		},
+	}, nil
+}
+
+func BuildDeviceManagerServiceTestServer(storageEngine TestStorageEngineConfig, caCATestServer CATestServer) (*DeviceManagerTestServer, error) {
+	svc, port, err := AssembleDeviceManagerServiceWithHTTPServer(config.DeviceManagerConfig{
+		BaseConfig: config.BaseConfig{
+			Logs: config.BaseConfigLogging{
+				Level: config.Info,
+			},
+			Server: config.HttpServer{
+				LogLevel:           config.Info,
+				HealthCheckLogging: false,
+				Protocol:           config.HTTP,
+			},
+			EventBus: config.EventBusEngine{Enabled: false},
+		},
+		Storage: storageEngine.config,
+	}, caCATestServer.Service, models.APIServiceInfo{
+		Version:   "test",
+		BuildSHA:  "-",
+		BuildTime: "-",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not assemble Device Manager Service. Exiting: %s", err)
+	}
+
+	return &DeviceManagerTestServer{
+		Service:              *svc,
+		HttpDeviceManagerSDK: clients.NewHttpDeviceManagerClient(http.DefaultClient, fmt.Sprintf("http://127.0.0.1:%d", port)),
+		BeforeEach: func() error {
+			err := storageEngine.BeforeEach()
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+		AfterSuite: func() {
+			fmt.Println("TEST CLEANUP DEVICE MANAGER")
+		},
+	}, nil
+}
+
+func BuildVATestServer(caCATestServer CATestServer) (*VATestServer, error) {
+	_, _, port, err := AssembleVAServiceWithHTTPServer(config.VAconfig{
+		BaseConfig: config.BaseConfig{
+			Logs: config.BaseConfigLogging{
+				Level: config.Info,
+			},
+			Server: config.HttpServer{
+				LogLevel:           config.Info,
+				HealthCheckLogging: false,
+				Protocol:           config.HTTP,
+			},
+			EventBus: config.EventBusEngine{Enabled: false},
+		},
+		CAClient: config.CAClient{},
+	}, caCATestServer.HttpCASDK, models.APIServiceInfo{
+		Version:   "test",
+		BuildSHA:  "-",
+		BuildTime: "-",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &VATestServer{
+		HttpServerURL: fmt.Sprintf("http://127.0.0.1:%d", port),
+		CaSDK:         caCATestServer.HttpCASDK,
+		BeforeEach: func() error {
+			err := caCATestServer.BeforeEach()
+			if err != nil {
+				return fmt.Errorf("could not run CATestServer BeforeEach: %s", err)
+			}
+			return nil
+		},
+	}, nil
+}
+
+func AssembleSerices(storageEngine TestStorageEngineConfig, criptoEngines TestCryptoEngineConfig, services []Service) (*TestServer, error) {
+	servicesMap := make(map[Service]interface{})
+
+	beforeEachActions := []func() error{}
+	afterSuiteActions := []func(){}
+
+	caCATestServer, err := BuildCATestServer(storageEngine, criptoEngines)
+	servicesMap[CA] = caCATestServer
+	if err != nil {
+		return nil, fmt.Errorf("could not build CATestServer: %s", err)
+	}
+
+	beforeEachActions = append(beforeEachActions, caCATestServer.BeforeEach)
+	afterSuiteActions = append(afterSuiteActions, caCATestServer.AfterSuite)
+
+	if contains(services, DEVICE_MANAGER) {
+		deviceManagerTestServer, err := BuildDeviceManagerServiceTestServer(storageEngine, *caCATestServer)
+		if err != nil {
+			return nil, fmt.Errorf("could not build DeviceManagerTestServer: %s", err)
+		}
+		servicesMap[DEVICE_MANAGER] = deviceManagerTestServer
+		beforeEachActions = append(beforeEachActions, deviceManagerTestServer.BeforeEach)
+		afterSuiteActions = append(afterSuiteActions, deviceManagerTestServer.AfterSuite)
+	}
+
+	if contains(services, VA) {
+		vaTestServer, err := BuildVATestServer(*caCATestServer)
+		if err != nil {
+			return nil, fmt.Errorf("could not build VATestServer: %s", err)
+		}
+		servicesMap[VA] = vaTestServer
+		beforeEachActions = append(beforeEachActions, vaTestServer.BeforeEach)
+		afterSuiteActions = append(afterSuiteActions, vaTestServer.AfterSuite)
+	}
+
+	beforeEach := func() error {
+		for _, action := range beforeEachActions {
+			err := action()
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	afterSuite := func() {
+		for _, action := range afterSuiteActions {
+			if action != nil {
+				action()
+			}
+		}
+	}
+
+	return &TestServer{
+		CA: caCATestServer,
+		DeviceManager: func() *DeviceManagerTestServer {
+			if servicesMap[DEVICE_MANAGER] != nil {
+				return servicesMap[DEVICE_MANAGER].(*DeviceManagerTestServer)
+			}
+			return nil
+		}(),
+		VA: func() *VATestServer {
+			if servicesMap[VA] != nil {
+				return servicesMap[VA].(*VATestServer)
+			}
+			return nil
+		}(),
+		BeforeEach: beforeEach,
+		AfterSuite: afterSuite,
+	}, nil
+}

--- a/pkg/assemblers/va_test.go
+++ b/pkg/assemblers/va_test.go
@@ -96,7 +96,7 @@ func TestCRL(t *testing.T) {
 		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
-			vaTest, err := BuildVATestServer()
+			vaTest, err := BuildVATestServer(t)
 			if err != nil {
 				t.Fatalf("could not create VA test server")
 			}
@@ -207,7 +207,7 @@ func TestPostOCSP(t *testing.T) {
 		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
-			vaTest, err := BuildVATestServer()
+			vaTest, err := BuildVATestServer(t)
 			if err != nil {
 				t.Fatalf("could not create VA test server")
 			}
@@ -238,7 +238,7 @@ func TestPostOCSP(t *testing.T) {
 }
 func TestGetOCSP(t *testing.T) {
 	t.Skip("Skip until we have a reliable way to test this")
-	vaTest, err := BuildVATestServer()
+	vaTest, err := BuildVATestServer(t)
 	if err != nil {
 		t.Fatalf("could not create VA test server")
 	}
@@ -277,7 +277,7 @@ func TestCheckOCSPRevocationCodes(t *testing.T) {
 		ocsp.AACompromise:         "AACompromise",
 	}
 
-	vaTest, err := BuildVATestServer()
+	vaTest, err := BuildVATestServer(t)
 	if err != nil {
 		t.Fatalf("could not create VA test server")
 	}
@@ -430,11 +430,14 @@ type VATestServer struct {
 	BeforeEach    func() error
 }
 
-func BuildVATestServer() (*VATestServer, error) {
-	caServer, err := BuildCATestServer()
+func BuildVATestServer(t *testing.T) (*VATestServer, error) {
+	pConfig, postgresSuite := initPostgres([]string{"ca", "devicemanager"})
+
+	caServer, err := buildCASimpleTestServer(pConfig, postgresSuite)
 	if err != nil {
 		return nil, fmt.Errorf("could not create CA test server: %s", err)
 	}
+	t.Cleanup(caServer.AfterSuite)
 
 	_, _, port, err := AssembleVAServiceWithHTTPServer(config.VAconfig{
 		BaseConfig: config.BaseConfig{

--- a/pkg/test/subsystems/storage/postgres/postgres.go
+++ b/pkg/test/subsystems/storage/postgres/postgres.go
@@ -28,8 +28,8 @@ func RunPostgresDocker(dbs []string) (func() error, *config.PostgresPSEConfig, e
 	for _, dbName := range dbs {
 		sqlStatements = sqlStatements + fmt.Sprintf("CREATE DATABASE %s;\n", dbName)
 	}
-
-	initScriptFname := fmt.Sprintf("%s/init.sql", pwd)
+	os.Mkdir(fmt.Sprintf("%s/testdata", pwd), 0755) // #nosec
+	initScriptFname := fmt.Sprintf("%s/testdata/init.sql", pwd)
 	os.WriteFile(initScriptFname, []byte(sqlStatements), 0644) // #nosec
 
 	containerCleanup, container, dockerHost, err := dockerunner.RunDocker(dockertest.RunOptions{


### PR DESCRIPTION
This PRs adds new tests for the device manager service. It includes basic integration tests supported on a conainerized Postgres as persistence support. 

It launch Postgres, initialize the databases and launch a CA service required by the deivice manager. 

The tests perform a basic creation, read and update test and check the pagination support. 

It has been required to modify the posgres_test support in order to consider multiple DB connection, one for earch service ( CA and Device Manager). 
