### PR TITLE
Adding basic CAs in docker image + serializing error correctly in EST

### DIFF
--- a/ci/alerts.dockerfile
+++ b/ci/alerts.dockerfile
@@ -23,6 +23,8 @@ ARG USERNAME=lamassu
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
+RUN apt-get update && apt-get --no-install-recommends install -y ca-certificates \
+    && apt-get clean
 RUN groupadd --gid "$USER_GID" "$USERNAME" \
     && useradd --uid "$USER_UID" --gid "$USER_GID" -m "$USERNAME" 
 

--- a/pkg/controllers/est.go
+++ b/pkg/controllers/est.go
@@ -163,7 +163,7 @@ func (r *estHttpRoutes) EnrollReenroll(ctx *gin.Context) {
 		signedCrt, err = r.svc.Enroll(authCtx, csr, params.APS)
 	}
 	if err != nil {
-		ctx.JSON(500, gin.H{"err": err})
+		ctx.JSON(500, gin.H{"err": err.Error()})
 		return
 	}
 
@@ -175,7 +175,7 @@ func (r *estHttpRoutes) EnrollReenroll(ctx *gin.Context) {
 
 	body, err := pkcs7.DegenerateCertificate(signedCrt.Raw)
 	if err != nil {
-		ctx.JSON(500, gin.H{"err": err})
+		ctx.JSON(500, gin.H{"err": err.Error()})
 		return
 	}
 


### PR DESCRIPTION
I've experienced Issues while sending a webhook to sites that have public certificates. This should address that