### PR TITLE
chore(ci): Upgrade actions to node 20

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '^1.20.0' # The Go version to download (if necessary) and use.
 

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -17,14 +17,14 @@ jobs:
       GO111MODULE: on
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Gosec Security Scanner
         uses: securego/gosec@master
         with:
           # we let the report trigger content trigger a failure using the GitHub Security features.
           args: '-no-fail -fmt sarif -out results.sarif -exclude G104,G601 ./...'
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           # Path to SARIF file relative to the root of the repository
           sarif_file: results.sarif

--- a/.github/workflows/main-release.yaml
+++ b/.github/workflows/main-release.yaml
@@ -76,7 +76,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '^1.20.0' # The Go version to download (if necessary) and use.
       - name: Build release assets # This would actually build your project, using zip for an example artifact


### PR DESCRIPTION
This PR upgrades workflow actions to the node 20 version. Actions supported on node 16 will be deprecated on December 2024