### PR TITLE
Fix first event storage at eventstore.

### DIFF
--- a/pkg/storage/postgres/eventstore.go
+++ b/pkg/storage/postgres/eventstore.go
@@ -27,7 +27,14 @@ func NewEventsPostgresRepository(db *gorm.DB) (storage.EventRepository, error) {
 }
 
 func (db *PostgresEventsStore) InsertUpdateEvent(ctx context.Context, ev *models.AlertLatestEvent) (*models.AlertLatestEvent, error) {
-	return db.querier.Update(ev, string(ev.EventType))
+	event, err := db.querier.Update(ev, string(ev.EventType))
+	if err == nil {
+		return event, nil
+	}
+	if err == gorm.ErrRecordNotFound {
+		return db.querier.Insert(ev, string(ev.EventType))
+	}
+	return nil, err
 }
 
 func (db *PostgresEventsStore) GetLatestEventByEventType(ctx context.Context, eventType models.EventType) (bool, *models.AlertLatestEvent, error) {


### PR DESCRIPTION
This PR fixes the storage of the first event of each type seen by the alerts service. 

Previously only an update was tried but when the events table is not previously populated with an event of each type an insert is required.