### PR TITLE
Extends AWS Authentication methods

### DIFF
--- a/pkg/config/aws_sdk.go
+++ b/pkg/config/aws_sdk.go
@@ -39,15 +39,6 @@ func GetAwsSdkConfig(conf AWSSDKConfig) (*aws.Config, error) {
 		}
 
 		return &awsCfg, nil
-	case Default:
-		awsCfg, err := config.LoadDefaultConfig(context.TODO(),
-			config.WithRegion(conf.Region),
-			config.WithEndpointResolverWithOptions(customResolver),
-		)
-		if err != nil {
-			return nil, fmt.Errorf("cannot load the AWS configs: %s", err)
-		}
-		return &awsCfg, nil
 	case AssumeRole:
 		stsCfg, err := config.LoadDefaultConfig(context.TODO(),
 			config.WithRegion(conf.Region),
@@ -68,8 +59,24 @@ func GetAwsSdkConfig(conf AWSSDKConfig) (*aws.Config, error) {
 			return nil, fmt.Errorf("cannot load the AWS configs: %s", err)
 		}
 		return &awsCfg, nil
+	case Default:
+		awsCfg, err := config.LoadDefaultConfig(context.TODO(),
+			config.WithRegion(conf.Region),
+			config.WithEndpointResolverWithOptions(customResolver),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("cannot load the AWS configs: %s", err)
+		}
+		return &awsCfg, nil
 	default:
-		return nil, fmt.Errorf("cannot load the AWS configs: %s authentication method not supported", conf.AWSAuthenticationMethod)
+		awsCfg, err := config.LoadDefaultConfig(context.TODO(),
+			config.WithRegion(conf.Region),
+			config.WithEndpointResolverWithOptions(customResolver),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("cannot load the AWS configs: %s", err)
+		}
+		return &awsCfg, nil
 	}
 
 }

--- a/pkg/config/aws_sdk.go
+++ b/pkg/config/aws_sdk.go
@@ -60,23 +60,20 @@ func GetAwsSdkConfig(conf AWSSDKConfig) (*aws.Config, error) {
 		}
 		return &awsCfg, nil
 	case Default:
-		awsCfg, err := config.LoadDefaultConfig(context.TODO(),
-			config.WithRegion(conf.Region),
-			config.WithEndpointResolverWithOptions(customResolver),
-		)
-		if err != nil {
-			return nil, fmt.Errorf("cannot load the AWS configs: %s", err)
-		}
-		return &awsCfg, nil
+		return loadAWSDefaultConfig(conf, customResolver)
 	default:
-		awsCfg, err := config.LoadDefaultConfig(context.TODO(),
-			config.WithRegion(conf.Region),
-			config.WithEndpointResolverWithOptions(customResolver),
-		)
-		if err != nil {
-			return nil, fmt.Errorf("cannot load the AWS configs: %s", err)
-		}
-		return &awsCfg, nil
+		return loadAWSDefaultConfig(conf, customResolver)
 	}
 
+}
+
+func loadAWSDefaultConfig(conf AWSSDKConfig, customResolver aws.EndpointResolverWithOptionsFunc) (*aws.Config, error) {
+	awsCfg, err := config.LoadDefaultConfig(context.TODO(),
+		config.WithRegion(conf.Region),
+		config.WithEndpointResolverWithOptions(customResolver),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load the AWS configs: %s", err)
+	}
+	return &awsCfg, nil
 }

--- a/pkg/config/ca.go
+++ b/pkg/config/ca.go
@@ -67,6 +67,7 @@ type AWSSDKConfig struct {
 	AccessKeyID             string                  `mapstructure:"access_key_id"`
 	SecretAccessKey         Password                `mapstructure:"secret_access_key"`
 	Region                  string                  `mapstructure:"region"`
+	RoleARN                 string                  `mapstructure:"role_arn"`
 }
 
 type CryptoMonitoring struct {

--- a/pkg/config/ca.go
+++ b/pkg/config/ca.go
@@ -62,10 +62,11 @@ type AWSCryptoEngine struct {
 }
 
 type AWSSDKConfig struct {
-	EndpointURL     string   `mapstructure:"endpoint_url"`
-	AccessKeyID     string   `mapstructure:"access_key_id"`
-	SecretAccessKey Password `mapstructure:"secret_access_key"`
-	Region          string   `mapstructure:"region"`
+	AWSAuthenticationMethod AWSAuthenticationMethod `mapstructure:"auth_method"`
+	EndpointURL             string                  `mapstructure:"endpoint_url"`
+	AccessKeyID             string                  `mapstructure:"access_key_id"`
+	SecretAccessKey         Password                `mapstructure:"secret_access_key"`
+	Region                  string                  `mapstructure:"region"`
 }
 
 type CryptoMonitoring struct {

--- a/pkg/config/enums.go
+++ b/pkg/config/enums.go
@@ -49,6 +49,7 @@ const (
 type AWSAuthenticationMethod string
 
 const (
-	Static    AWSAuthenticationMethod = "static"
-	Temporary AWSAuthenticationMethod = "temporary"
+	Static     AWSAuthenticationMethod = "static"
+	Default    AWSAuthenticationMethod = "default"
+	AssumeRole AWSAuthenticationMethod = "role"
 )

--- a/pkg/config/enums.go
+++ b/pkg/config/enums.go
@@ -45,3 +45,10 @@ const (
 	CouchDB  StorageProvider = "couch_db"
 	DynamoDB StorageProvider = "dynamo_db"
 )
+
+type AWSAuthenticationMethod string
+
+const (
+	Static    AWSAuthenticationMethod = "static"
+	Temporary AWSAuthenticationMethod = "temporary"
+)


### PR DESCRIPTION
I think that rather than using always static AWS credentials to authenticate, using short-term credentials could be a more robust and secure solution.

I have included the next options to authenticate with AWS:

- Default: This option follows the default credential chain specified by AWS in their SDK: [https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/#specifying-credentials](https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/#specifying-credentials). This option may be interesting when running Lamassu in an EC2 machine with an instance profile configured or a Lambda function with a role.
- AssumeRole: This option allows assuming a role to perform the AWS actions, instead of using the static credentials.
- Static: This is "default" option nowadays.

@haritzsaiz Maybe these changes involve changes also in [lamassu-helm](https://github.com/lamassuiot/lamassu-helm) repo to align with the new configuration parameters. Let me now if you need any other change to apply the PR! 

Thanks!