### PR TITLE
Minor code cleanup

### DIFF
--- a/pkg/helpers/cryptoutils.go
+++ b/pkg/helpers/cryptoutils.go
@@ -44,10 +44,6 @@ func GenerateSelfSignedCA(keyType x509.PublicKeyAlgorithm, expirationTime time.D
 		pubKey = &eccKey.PublicKey
 	}
 
-	if err != nil {
-		return nil, nil, err
-	}
-
 	sn, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 160))
 	template := x509.Certificate{
 		SerialNumber: sn,
@@ -74,7 +70,6 @@ func GenerateSelfSignedCA(keyType x509.PublicKeyAlgorithm, expirationTime time.D
 	}
 
 	return cert, key, nil
-
 }
 
 // defined to generate certificates with RSA and ECDSA keys

--- a/pkg/helpers/cryptoutils_test.go
+++ b/pkg/helpers/cryptoutils_test.go
@@ -28,15 +28,13 @@ func TestGenerateSelfSignedCA(t *testing.T) {
 	}
 
 	// Verificar que el certificado tenga la clave privada correspondiente
-	switch key.(type) {
+	switch key := key.(type) {
 	case *rsa.PrivateKey:
-		rsaKey := key.(*rsa.PrivateKey)
-		if !reflect.DeepEqual(&rsaKey.PublicKey, cert.PublicKey) {
+		if !reflect.DeepEqual(&key.PublicKey, cert.PublicKey) {
 			t.Errorf("La clave privada no coincide con la clave pública del certificado")
 		}
 	case *ecdsa.PrivateKey:
-		ecdsaKey := key.(*ecdsa.PrivateKey)
-		if !reflect.DeepEqual(&ecdsaKey.PublicKey, cert.PublicKey) {
+		if !reflect.DeepEqual(&key.PublicKey, cert.PublicKey) {
 			t.Errorf("La clave privada no coincide con la clave pública del certificado")
 		}
 	default:
@@ -55,15 +53,13 @@ func TestGenerateSelfSignedCA(t *testing.T) {
 	}
 
 	// Verificar que el certificado tenga la clave privada correspondiente
-	switch key.(type) {
+	switch key := key.(type) {
 	case *rsa.PrivateKey:
-		rsaKey := key.(*rsa.PrivateKey)
-		if !reflect.DeepEqual(&rsaKey.PublicKey, cert.PublicKey) {
+		if !reflect.DeepEqual(&key.PublicKey, cert.PublicKey) {
 			t.Errorf("La clave privada no coincide con la clave pública del certificado")
 		}
 	case *ecdsa.PrivateKey:
-		ecdsaKey := key.(*ecdsa.PrivateKey)
-		if !reflect.DeepEqual(&ecdsaKey.PublicKey, cert.PublicKey) {
+		if !reflect.DeepEqual(&key.PublicKey, cert.PublicKey) {
 			t.Errorf("La clave privada no coincide con la clave pública del certificado")
 		}
 	default:


### PR DESCRIPTION
This PR proposes a minor code cleanup at:

 pkg/helpers/cryptoutils.go 
   
   - Removed `err != nill` check as it should be allways nill at thet point.
   - 
 pkg/helpers/cryptoutils_test.go   
   - Optimize shwitch to avoid type casting 