### PR TITLE
Update DMS Update event key

### DIFF
--- a/pkg/assemblers/aws-iot.go
+++ b/pkg/assemblers/aws-iot.go
@@ -286,7 +286,7 @@ func mainAwsConnectorEventHandler(event *event.Event, svc iot.AWSCloudConnectorS
 
 		return nil
 
-	case string(models.EventCreateDMSKey), string(models.EventUpdateDMSMetadataKey):
+	case string(models.EventCreateDMSKey), string(models.EventUpdateDMSKey):
 		var dms *models.DMS
 		var err error
 

--- a/pkg/middlewares/eventpub/dms.go
+++ b/pkg/middlewares/eventpub/dms.go
@@ -47,7 +47,7 @@ func (mw dmsEventPublisher) UpdateDMS(ctx context.Context, input services.Update
 	}
 	defer func() {
 		if err == nil {
-			mw.eventMWPub.PublishCloudEvent(ctx, models.EventUpdateDMSMetadataKey, models.UpdateModel[models.DMS]{
+			mw.eventMWPub.PublishCloudEvent(ctx, models.EventUpdateDMSKey, models.UpdateModel[models.DMS]{
 				Previous: *prev,
 				Updated:  *output,
 			})

--- a/pkg/models/events.go
+++ b/pkg/models/events.go
@@ -35,7 +35,7 @@ const (
 	EventUpdateCertificateMetadataKey EventType = "certificate.metadata.update"
 
 	EventCreateDMSKey          EventType = "dms.create"
-	EventUpdateDMSMetadataKey  EventType = "dms.metadata.update"
+	EventUpdateDMSKey          EventType = "dms.update"
 	EventEnrollKey             EventType = "dms.enroll"
 	EventReEnrollKey           EventType = "dms.reenroll"
 	EventBindDeviceIdentityKey EventType = "dms.bind-device-id"


### PR DESCRIPTION
The EventUpdateDMSKey event type, now truly represents the actual usage of such event. The previous event name was missleading as it would imply that it was only triggered when the metadata section of a DMS was updated, when in reality, the event was triggered even if the metadata was not modified.

**WARN** this can lead to errors while upgrading future lamassu versions if this PR is approved as it changes the event key. Non processed events using the older event type won't be handeled