### PR TITLE
Storage engine refactor - Decouple assemblers from storage engines

### DIFF
--- a/pkg/storage/builder/builder.go
+++ b/pkg/storage/builder/builder.go
@@ -1,0 +1,31 @@
+package builder
+
+import (
+	"fmt"
+
+	"github.com/lamassuiot/lamassuiot/v2/pkg/config"
+	"github.com/lamassuiot/lamassuiot/v2/pkg/storage"
+	"github.com/lamassuiot/lamassuiot/v2/pkg/storage/couchdb"
+	"github.com/lamassuiot/lamassuiot/v2/pkg/storage/postgres"
+	log "github.com/sirupsen/logrus"
+)
+
+func BuildStorageEngine(logger *log.Entry, conf config.PluggableStorageEngine) (storage.StorageEngine, error) {
+
+	switch conf.Provider {
+	case config.Postgres:
+		storageEngine, err := postgres.NewStorageEngine(logger, conf.Postgres)
+		if err != nil {
+			return nil, err
+		}
+		return storageEngine, err
+	case config.CouchDB:
+		storageEngine, err := couchdb.NewStorageEngine(logger, conf.CouchDB)
+		if err != nil {
+			return nil, err
+		}
+		return storageEngine, err
+	default:
+		return nil, fmt.Errorf("no storage engine of type %s", conf.Provider)
+	}
+}

--- a/pkg/storage/couchdb/engine.go
+++ b/pkg/storage/couchdb/engine.go
@@ -1,0 +1,83 @@
+package couchdb
+
+import (
+	"fmt"
+
+	kivik "github.com/go-kivik/kivik/v4"
+	config "github.com/lamassuiot/lamassuiot/v2/pkg/config"
+	"github.com/lamassuiot/lamassuiot/v2/pkg/storage"
+	log "github.com/sirupsen/logrus"
+)
+
+type CouchDBStorageEngine struct {
+	storage.CommonStorageEngine
+	Config        config.CouchDBPSEConfig
+	logger        *log.Entry
+	couchdbClient *kivik.Client
+}
+
+func NewStorageEngine(logger *log.Entry, config config.CouchDBPSEConfig) (storage.StorageEngine, error) {
+	couchdbClient, err := CreateCouchDBConnection(logger, config)
+	if err != nil {
+		return nil, fmt.Errorf("could not create couchdb client: %s", err)
+	}
+
+	return &CouchDBStorageEngine{
+		Config:        config,
+		logger:        logger,
+		couchdbClient: couchdbClient,
+	}, nil
+}
+
+func (s *CouchDBStorageEngine) GetCAStorage() (storage.CACertificatesRepo, error) {
+
+	if s.CA == nil {
+		caStore, err := NewCouchCARepository(s.couchdbClient)
+		s.CA = caStore
+		if err != nil {
+			return nil, fmt.Errorf("could not initialize couchdb CA client: %s", err)
+		}
+	}
+	return s.CA, nil
+}
+
+func (s *CouchDBStorageEngine) GetCertstorage() (storage.CertificatesRepo, error) {
+	if s.Cert == nil {
+		certStore, err := NewCouchCertificateRepository(s.couchdbClient)
+		s.Cert = certStore
+		if err != nil {
+			return nil, fmt.Errorf("could not initialize couchdb Cert client: %s", err)
+		}
+	}
+	return s.Cert, nil
+}
+
+func (s *CouchDBStorageEngine) GetDeviceStorage() (storage.DeviceManagerRepo, error) {
+	if s.Device == nil {
+		deviceStore, err := NewCouchDeviceRepository(s.couchdbClient)
+		s.Device = deviceStore
+		if err != nil {
+			return nil, fmt.Errorf("could not initialize couchdb Device client: %s", err)
+		}
+	}
+	return s.Device, nil
+}
+
+func (s *CouchDBStorageEngine) GetDMSStorage() (storage.DMSRepo, error) {
+	if s.DMS == nil {
+		dmsStore, err := NewCouchDMSRepository(s.couchdbClient)
+		s.DMS = dmsStore
+		if err != nil {
+			return nil, fmt.Errorf("could not initialize couchdb DMS client: %s", err)
+		}
+	}
+	return s.DMS, nil
+}
+
+func (s *CouchDBStorageEngine) GetEnventsStorage() (storage.EventRepository, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (s *CouchDBStorageEngine) GetSubscriptionsStorage() (storage.SubscriptionsRepository, error) {
+	return nil, fmt.Errorf("not implemented")
+}

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -1,0 +1,19 @@
+package storage
+
+type CommonStorageEngine struct {
+	CA            CACertificatesRepo
+	Cert          CertificatesRepo
+	Device        DeviceManagerRepo
+	DMS           DMSRepo
+	Events        EventRepository
+	Subscriptions SubscriptionsRepository
+}
+
+type StorageEngine interface {
+	GetCAStorage() (CACertificatesRepo, error)
+	GetCertstorage() (CertificatesRepo, error)
+	GetDeviceStorage() (DeviceManagerRepo, error)
+	GetDMSStorage() (DMSRepo, error)
+	GetEnventsStorage() (EventRepository, error)
+	GetSubscriptionsStorage() (SubscriptionsRepository, error)
+}

--- a/pkg/storage/postgres/engine.go
+++ b/pkg/storage/postgres/engine.go
@@ -1,0 +1,143 @@
+package postgres
+
+import (
+	"fmt"
+
+	"github.com/lamassuiot/lamassuiot/v2/pkg/config"
+	"github.com/lamassuiot/lamassuiot/v2/pkg/storage"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	CA_DB_NAME     = "ca"
+	DEVICE_DB_NAME = "devicemanager"
+	DMS_DB_NAME    = "dmsmanager"
+	ALERTS_DB_NAME = "alerts"
+)
+
+type PostgresStorageEngine struct {
+	storage.CommonStorageEngine
+	Config config.PostgresPSEConfig
+	logger *log.Entry
+}
+
+func NewStorageEngine(logger *log.Entry, config config.PostgresPSEConfig) (storage.StorageEngine, error) {
+	return &PostgresStorageEngine{
+		Config: config,
+		logger: logger,
+	}, nil
+}
+
+func (s *PostgresStorageEngine) GetCAStorage() (storage.CACertificatesRepo, error) {
+	if s.CA == nil {
+		err := s.initialiceCACertStorage()
+		if err != nil {
+			return nil, fmt.Errorf("could not initialize postgres CA and Cert clients: %s", err)
+		}
+	}
+
+	return s.CA, nil
+}
+
+func (s *PostgresStorageEngine) initialiceCACertStorage() error {
+	psqlCli, err := CreatePostgresDBConnection(s.logger, s.Config, CA_DB_NAME)
+	if err != nil {
+		return err
+	}
+
+	if s.CA == nil {
+		s.CA, err = NewCAPostgresRepository(psqlCli)
+		if err != nil {
+			return err
+		}
+	}
+
+	if s.Cert == nil {
+		s.Cert, err = NewCertificateRepository(psqlCli)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *PostgresStorageEngine) GetCertstorage() (storage.CertificatesRepo, error) {
+	if s.Cert == nil {
+		err := s.initialiceCACertStorage()
+		if err != nil {
+			return nil, fmt.Errorf("could not initialize postgres CA and Cert clients: %s", err)
+		}
+	}
+
+	return s.Cert, nil
+}
+
+func (s *PostgresStorageEngine) GetDeviceStorage() (storage.DeviceManagerRepo, error) {
+
+	if s.Device == nil {
+		psqlCli, err := CreatePostgresDBConnection(s.logger, s.Config, DEVICE_DB_NAME)
+		if err != nil {
+			return nil, fmt.Errorf("could not create postgres client: %s", err)
+		}
+
+		deviceStore, err := NewDeviceManagerRepository(psqlCli)
+		if err != nil {
+			return nil, fmt.Errorf("could not initialize postgres Device client: %s", err)
+		}
+		s.Device = deviceStore
+	}
+	return s.Device, nil
+}
+
+func (s *PostgresStorageEngine) GetDMSStorage() (storage.DMSRepo, error) {
+	if s.DMS == nil {
+		psqlCli, err := CreatePostgresDBConnection(s.logger, s.Config, DMS_DB_NAME)
+		if err != nil {
+			return nil, fmt.Errorf("could not create postgres client: %s", err)
+		}
+
+		dmsStore, err := NewDMSManagerRepository(psqlCli)
+		if err != nil {
+			return nil, fmt.Errorf("could not initialize postgres DMS client: %s", err)
+		}
+		s.DMS = dmsStore
+	}
+	return s.DMS, nil
+}
+
+func (s *PostgresStorageEngine) GetEnventsStorage() (storage.EventRepository, error) {
+	if s.Events == nil {
+		s.initialiceSubscriptionsStorage()
+	}
+	return s.Events, nil
+}
+
+func (s *PostgresStorageEngine) GetSubscriptionsStorage() (storage.SubscriptionsRepository, error) {
+	if s.Subscriptions == nil {
+		s.initialiceSubscriptionsStorage()
+	}
+	return s.Subscriptions, nil
+}
+
+func (s *PostgresStorageEngine) initialiceSubscriptionsStorage() error {
+	psqlCli, err := CreatePostgresDBConnection(s.logger, s.Config, ALERTS_DB_NAME)
+	if err != nil {
+		return err
+	}
+
+	if s.Subscriptions == nil {
+		s.Subscriptions, err = NewSubscriptionsPostgresRepository(psqlCli)
+		if err != nil {
+			return err
+		}
+	}
+
+	if s.Events == nil {
+		s.Events, err = NewEventsPostgresRepository(psqlCli)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This pull request (PR) presents a significant refactor of our current storage engine implementation, aiming to improve the overall structure and functionality of our system. The primary focus of this refactor is to decouple the storage engines from the assemblers, a change that will bring about a more modular and flexible architecture.

In the existing setup, the assembler is responsible for selecting the Storage Engine implementation to be used. This tight coupling between the assembler and the storage engine can lead to limitations in scalability and maintainability, as changes in one component often require corresponding changes in the other.

With the proposed refactor, the selection of the Storage Engine implementation is no longer a responsibility of the assembler. Instead, this task is now internally handled by the Storage Engine implementation itself. This shift in responsibility allows for a more independent and self-contained storage engine, which can be updated, modified, or replaced without necessitating changes in the assembler.
