### PR TITLE
Add test to storage engine builder

### DIFF
--- a/pkg/config/aws_sdk.go
+++ b/pkg/config/aws_sdk.go
@@ -59,8 +59,6 @@ func GetAwsSdkConfig(conf AWSSDKConfig) (*aws.Config, error) {
 			return nil, fmt.Errorf("cannot load the AWS configs: %s", err)
 		}
 		return &awsCfg, nil
-	case Default:
-		return loadAWSDefaultConfig(conf, customResolver)
 	default:
 		return loadAWSDefaultConfig(conf, customResolver)
 	}

--- a/pkg/config/aws_sdk_test.go
+++ b/pkg/config/aws_sdk_test.go
@@ -1,0 +1,66 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/lamassuiot/lamassuiot/v2/pkg/config"
+	awskmssm_test "github.com/lamassuiot/lamassuiot/v2/pkg/test/subsystems/cryptoengines/aws-kms-sm"
+)
+
+func TestGetAwsSdkConfig(t *testing.T) {
+
+	containerCleanup, conf, err := awskmssm_test.RunAWSEmulationLocalStackDocker()
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	t.Cleanup(func() { _ = containerCleanup() })
+
+	conf.AWSAuthenticationMethod = config.Static
+	// Test Static authentication method
+	awsCfg, err := config.GetAwsSdkConfig(*conf)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	if awsCfg.Region != conf.Region {
+		t.Errorf("unexpected region, got: %s, want: %s", awsCfg.Region, conf.Region)
+	}
+	if awsCfg.Credentials == nil {
+		t.Errorf("unexpected credentials, got: nil")
+	}
+
+	endpoint, err := awsCfg.EndpointResolverWithOptions.ResolveEndpoint("s3", conf.Region)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	if (endpoint.URL != conf.EndpointURL) || (endpoint.SigningRegion != conf.Region) {
+		t.Errorf("unexpected endpoint, got: %s, want: %s", endpoint.URL, conf.EndpointURL)
+	}
+
+	// reset endpoint
+	conf.EndpointURL = ""
+	awsCfg, err = config.GetAwsSdkConfig(*conf)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	_, err = awsCfg.EndpointResolverWithOptions.ResolveEndpoint("s3", conf.Region)
+	if _, ok := err.(*aws.EndpointNotFoundError); !ok {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	// Test AssumeRole authentication method
+	conf.AWSAuthenticationMethod = config.AssumeRole
+	awsCfg, err = config.GetAwsSdkConfig(*conf)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	if awsCfg.Region != conf.Region {
+		t.Errorf("unexpected region, got: %s, want: %s", awsCfg.Region, conf.Region)
+	}
+
+	if awsCfg.Credentials == nil {
+		t.Errorf("unexpected credentials, got: nil")
+	}
+}

--- a/pkg/storage/builder/builder_test.go
+++ b/pkg/storage/builder/builder_test.go
@@ -1,0 +1,80 @@
+package builder
+
+import (
+	"testing"
+
+	"github.com/lamassuiot/lamassuiot/v2/pkg/config"
+	"github.com/lamassuiot/lamassuiot/v2/pkg/storage/couchdb"
+	"github.com/lamassuiot/lamassuiot/v2/pkg/storage/postgres"
+	couchdb_test "github.com/lamassuiot/lamassuiot/v2/pkg/test/subsystems/storage/couchdb"
+	log "github.com/sirupsen/logrus"
+)
+
+func TestBuildStorageEnginePostgres(t *testing.T) {
+	logger := log.WithField("test", "BuildStorageEngine_Postgres")
+	conf := config.PluggableStorageEngine{
+		Provider: config.Postgres,
+		Postgres: config.PostgresPSEConfig{
+			// Set Postgres configuration here
+		},
+	}
+
+	// Call the BuildStorageEngine function
+	storageEngine, err := BuildStorageEngine(logger, conf)
+
+	// Verify the result
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	_, ok := storageEngine.(*postgres.PostgresStorageEngine)
+	if !ok {
+		t.Error("expected storage engine of type *postgres.StorageEngine")
+	}
+}
+
+func TestBuildStorageEngineCouchDB(t *testing.T) {
+	cleanfunc, cdbconfig, err := couchdb_test.RunCouchDBDocker()
+	if err != nil {
+		t.Fatalf("could not run couchdb docker container: %s", err)
+	}
+	t.Cleanup(func() { _ = cleanfunc() })
+
+	logger := log.WithField("test", "BuildStorageEngine_CouchDB")
+	conf := config.PluggableStorageEngine{
+		Provider: config.CouchDB,
+		CouchDB:  *cdbconfig,
+	}
+
+	// Call the BuildStorageEngine function
+	storageEngine, err := BuildStorageEngine(logger, conf)
+
+	// Verify the result
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	_, ok := storageEngine.(*couchdb.CouchDBStorageEngine)
+	if !ok {
+		t.Error("expected storage engine of type *couchdb.StorageEngine")
+	}
+}
+
+func TestBuildStorageEngineInvalidProvider(t *testing.T) {
+	logger := log.WithField("test", "BuildStorageEngine_InvalidProvider")
+	conf := config.PluggableStorageEngine{
+		Provider: "invalid_provider",
+	}
+
+	// Call the BuildStorageEngine function
+	_, err := BuildStorageEngine(logger, conf)
+
+	// Verify the result
+	if err == nil {
+		t.Error("expected an error, but got nil")
+	}
+
+	if err.Error() != "no storage engine of type invalid_provider" {
+		t.Errorf("unexpected error: %s", err)
+	}
+}

--- a/pkg/test/subsystems/storage/couchdb/couchdb.go
+++ b/pkg/test/subsystems/storage/couchdb/couchdb.go
@@ -1,0 +1,73 @@
+package couchdb_test
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/lamassuiot/lamassuiot/v2/pkg/config"
+	"github.com/lamassuiot/lamassuiot/v2/pkg/helpers"
+	"github.com/lamassuiot/lamassuiot/v2/pkg/test/dockerunner"
+	"github.com/ory/dockertest/v3"
+	"github.com/ory/dockertest/v3/docker"
+	logger "github.com/sirupsen/logrus"
+)
+
+const (
+	admin  = "admin"
+	passwd = "test"
+)
+
+func RunCouchDBDocker() (func() error, *config.CouchDBPSEConfig, error) {
+	containerCleanup, container, dockerHost, err := dockerunner.RunDocker(dockertest.RunOptions{
+		Repository: "couchdb", // image
+		Tag:        "3.3.3",   // version
+		Env:        []string{"COUCHDB_USER=" + admin, "COUCHDB_PASSWORD=" + passwd},
+	}, func(hc *docker.HostConfig) {
+		hc.PortBindings = map[docker.Port][]docker.PortBinding{
+			"5984/tcp": {{HostIP: "", HostPort: "5984"}},
+		}
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	p, _ := strconv.Atoi(container.GetPort("5984/tcp"))
+
+	address := fmt.Sprintf("%s://%s:%s@%s:%d%s", "http", admin, passwd, "localhost", p, "/_up")
+	httpCli, err := helpers.BuildHTTPClientWithTLSOptions(&http.Client{}, config.TLSConfig{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	lCouch := logger.WithField("subsystem-provider", "CouchDB")
+	httpCli, err = helpers.BuildHTTPClientWithTracerLogger(httpCli, lCouch)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	dockerHost.Retry(func() error {
+		resp, err := httpCli.Get(address)
+		if err != nil {
+			return err
+		}
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("couchdb not ready yet")
+		}
+		return nil
+	})
+
+	return containerCleanup, &config.CouchDBPSEConfig{
+		HTTPConnection: config.HTTPConnection{
+			Protocol: "http",
+			BasePath: "/",
+			BasicConnection: config.BasicConnection{
+				Hostname: "localhost",
+				Port:     p,
+			},
+		},
+		Username: admin,
+		Password: passwd,
+	}, nil
+
+}


### PR DESCRIPTION
This PR adds a basic test of the new storage engine builder. It also includes new testing support for CouchDB container launch.