### PR TITLE
test: add mock based test to event publisher middelwares 

### DIFF
--- a/pkg/assemblers/ca.go
+++ b/pkg/assemblers/ca.go
@@ -84,11 +84,13 @@ func AssembleCAService(conf config.CAConfig) (*services.CAService, *jobs.JobSche
 			return nil, nil, fmt.Errorf("could not create Event Bus publisher: %s", err)
 		}
 
-		svc = eventpub.NewCAEventBusPublisher(eventpub.CloudEventMiddlewarePublisher{
+		eventpublisher := &eventpub.CloudEventMiddlewarePublisher{
 			Publisher: pub,
 			ServiceID: "ca",
 			Logger:    lMessage,
-		})(svc)
+		}
+
+		svc = eventpub.NewCAEventBusPublisher(eventpublisher)(svc)
 	}
 
 	var scheduler *jobs.JobScheduler

--- a/pkg/assemblers/device-manager.go
+++ b/pkg/assemblers/device-manager.go
@@ -65,7 +65,7 @@ func AssembleDeviceManagerService(conf config.DeviceManagerConfig, caService ser
 			return nil, fmt.Errorf("could not create Event Bus publisher: %s", err)
 		}
 
-		svc = eventpub.NewDeviceEventPublisher(eventpub.CloudEventMiddlewarePublisher{
+		svc = eventpub.NewDeviceEventPublisher(&eventpub.CloudEventMiddlewarePublisher{
 			Publisher: pub,
 			ServiceID: serviceID,
 			Logger:    lMessaging,

--- a/pkg/assemblers/dms-manager.go
+++ b/pkg/assemblers/dms-manager.go
@@ -66,7 +66,7 @@ func AssembleDMSManagerService(conf config.DMSconfig, caService services.CAServi
 			return nil, fmt.Errorf("could not create Event Bus publisher: %s", err)
 		}
 
-		svc = eventpub.NewDMSEventPublisher(eventpub.CloudEventMiddlewarePublisher{
+		svc = eventpub.NewDMSEventPublisher(&eventpub.CloudEventMiddlewarePublisher{
 			Publisher: pub,
 			ServiceID: "dms-manager",
 			Logger:    lMessaging,

--- a/pkg/jobs/crypto-monitor-job_test.go
+++ b/pkg/jobs/crypto-monitor-job_test.go
@@ -1,0 +1,240 @@
+package jobs
+
+import (
+	"context"
+	"crypto/x509"
+	"testing"
+	"time"
+
+	"github.com/lamassuiot/lamassuiot/v2/pkg/models"
+	svcmock "github.com/lamassuiot/lamassuiot/v2/pkg/services/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestUpdateCertificateIfNeededExpiredNoMetadata(t *testing.T) {
+
+	mockService := new(svcmock.MockCAService)
+
+	// Create a new CryptoMonitor instance with the mock service
+	cryptoMonitor := NewCryptoMonitor(mockService, nil)
+
+	// Create a sample expired certificate
+	certExpired := models.Certificate{
+		SerialNumber: "123456",
+		ValidTo:      time.Now().AddDate(0, 0, -1), // Expired in 1 day ago,
+		Metadata:     map[string]interface{}{},
+		Certificate:  &models.X509Certificate{},
+	}
+
+	// Set up expectations for UpdateCertificateStatus
+	mockService.On("UpdateCertificateStatus", mock.Anything, mock.Anything).Return(&certExpired, nil)
+
+	// Call the function under test
+	cryptoMonitor.updateCertificateIfNeeded(certExpired, time.Now(), context.Background())
+
+	// Assert that the expected methods were called
+	mockService.AssertCalled(t, "UpdateCertificateStatus", mock.Anything, mock.Anything)
+	mockService.AssertNotCalled(t, "UpdateCertificateMetadata", mock.Anything, mock.Anything)
+
+	// Create a sample expired certificate
+	certValid := models.Certificate{
+		SerialNumber: "123456",
+		ValidTo:      time.Now().AddDate(0, 0, 1), // Expires in 1 day,
+		Metadata:     map[string]interface{}{},
+		Certificate:  &models.X509Certificate{},
+	}
+
+	cryptoMonitor.updateCertificateIfNeeded(certValid, time.Now(), context.Background())
+
+	// Assert that the expected methods were called
+	mockService.AssertCalled(t, "UpdateCertificateStatus", mock.Anything, mock.Anything)
+	mockService.AssertNotCalled(t, "UpdateCertificateMetadata", mock.Anything, mock.Anything)
+
+}
+
+func TestUpdateCACertificateIfNeededExpiredNoMetadata(t *testing.T) {
+
+	mockService := new(svcmock.MockCAService)
+
+	// Create a new CryptoMonitor instance with the mock service
+	cryptoMonitor := NewCryptoMonitor(mockService, nil)
+
+	// Create a sample expired certificate
+	certExpired := models.CACertificate{
+		ID:       "123456",
+		Metadata: map[string]interface{}{},
+		Certificate: models.Certificate{
+			Status:       models.StatusActive,
+			SerialNumber: "123456",
+			ValidTo:      time.Now().AddDate(0, 0, -1), // Expired in 1 day ago,
+			Metadata:     map[string]interface{}{},
+			Certificate:  &models.X509Certificate{},
+		},
+	}
+
+	// Set up expectations for UpdateCertificateStatus
+	mockService.On("UpdateCAStatus", mock.Anything, mock.Anything).Return(&certExpired, nil)
+
+	// Call the function under test
+	cryptoMonitor.updateCAIfNeeded(certExpired, time.Now(), context.Background())
+
+	// Assert that the expected methods were called
+	mockService.AssertCalled(t, "UpdateCAStatus", mock.Anything, mock.Anything)
+	mockService.AssertNotCalled(t, "UpdateCAMetadata", mock.Anything, mock.Anything)
+
+	// Create a sample expired certificate
+	certValid := models.CACertificate{
+		ID:       "123456",
+		Metadata: map[string]interface{}{},
+		Certificate: models.Certificate{
+			Status:       models.StatusActive,
+			SerialNumber: "123456",
+			ValidTo:      time.Now().AddDate(0, 0, -1), // Expired in 1 day ago,
+			Metadata:     map[string]interface{}{},
+			Certificate:  &models.X509Certificate{},
+		},
+	}
+
+	cryptoMonitor.updateCAIfNeeded(certValid, time.Now(), context.Background())
+
+	// Assert that the expected methods were called
+	mockService.AssertCalled(t, "UpdateCAStatus", mock.Anything, mock.Anything)
+	mockService.AssertNotCalled(t, "UpdateCAMetadata", mock.Anything, mock.Anything)
+}
+func TestShouldUpdateMonitoringDeltas(t *testing.T) {
+	svc := NewCryptoMonitor(nil, nil)
+
+	// Test case 1: Additional deltas exist and expiration is triggered
+	metadata := map[string]interface{}{
+		models.CAMetadataMonitoringExpirationDeltasKey: []models.MonitoringExpirationDelta{
+			{
+				Name:      "Delta1",
+				Delta:     models.TimeDuration(24 * time.Hour),
+				Triggered: false,
+			},
+			{
+				Name:      "Delta2",
+				Delta:     models.TimeDuration(12 * time.Hour),
+				Triggered: false,
+			},
+		},
+	}
+	certificate := x509.Certificate{
+		NotAfter: time.Now().Add(23 * time.Hour),
+	}
+	shouldUpdate, updatedMetadata := svc.shouldUpdateMonitoringDeltas(metadata, certificate)
+	assert.True(t, shouldUpdate)
+	// Delta 2 should be triggered
+	assert.Equal(t, false, updatedMetadata[models.CAMetadataMonitoringExpirationDeltasKey].(models.CAMetadataMonitoringExpirationDeltas)[0].Triggered)
+	// Delta 1 should not be triggered
+	assert.Equal(t, true, updatedMetadata[models.CAMetadataMonitoringExpirationDeltasKey].(models.CAMetadataMonitoringExpirationDeltas)[1].Triggered)
+
+	// Test case 2: Additional deltas exist but expiration is not triggered
+	metadata = map[string]interface{}{
+		models.CAMetadataMonitoringExpirationDeltasKey: []models.MonitoringExpirationDelta{
+			{
+				Name:      "Delta1",
+				Delta:     models.TimeDuration(24 * time.Hour),
+				Triggered: false,
+			},
+			{
+				Name:      "Delta2",
+				Delta:     models.TimeDuration(48 * time.Hour),
+				Triggered: false,
+			},
+		},
+	}
+	certificate = x509.Certificate{
+		NotAfter: time.Now().Add(49 * time.Hour),
+	}
+	shouldUpdate, updatedMetadata = svc.shouldUpdateMonitoringDeltas(metadata, certificate)
+	assert.False(t, shouldUpdate)
+	assert.Empty(t, updatedMetadata)
+
+	// Test case 3: Additional deltas do not exist
+	metadata = map[string]interface{}{}
+	certificate = x509.Certificate{
+		NotAfter: time.Now().Add(-25 * time.Hour),
+	}
+	shouldUpdate, updatedMetadata = svc.shouldUpdateMonitoringDeltas(metadata, certificate)
+	assert.False(t, shouldUpdate)
+	assert.Empty(t, updatedMetadata)
+}
+
+func TestUpdateCertificateIfNeededExpiredwithMetadata(t *testing.T) {
+
+	mockService := new(svcmock.MockCAService)
+
+	// Create a new CryptoMonitor instance with the mock service
+	cryptoMonitor := NewCryptoMonitor(mockService, nil)
+
+	// Create a sample expired certificate
+	certExpired := models.Certificate{
+		SerialNumber: "123456",
+		ValidTo:      time.Now().AddDate(0, 0, 10), // Expired in 1 day ago,
+		Metadata: map[string]interface{}{
+			models.CAMetadataMonitoringExpirationDeltasKey: []models.MonitoringExpirationDelta{
+				{
+					Name:      "Delta1",
+					Delta:     models.TimeDuration(24 * time.Hour),
+					Triggered: false,
+				},
+			},
+		},
+		Certificate: &models.X509Certificate{
+			NotAfter: time.Now().AddDate(0, 0, -1),
+		},
+	}
+
+	// Set up expectations for UpdateCertificateStatus
+	mockService.On("UpdateCertificateStatus", mock.Anything, mock.Anything).Return(&certExpired, nil)
+	mockService.On("UpdateCertificateMetadata", mock.Anything, mock.Anything).Return(&certExpired, nil)
+
+	// Call the function under test
+	cryptoMonitor.updateCertificateIfNeeded(certExpired, time.Now(), context.Background())
+
+	// Assert that the expected methods were called
+	mockService.AssertNotCalled(t, "UpdateCertificateStatus", mock.Anything, mock.Anything)
+	mockService.AssertCalled(t, "UpdateCertificateMetadata", mock.Anything, mock.Anything)
+}
+
+func TestUpdateCACertificateIfNeededNotExpiredWithMetadata(t *testing.T) {
+
+	mockService := new(svcmock.MockCAService)
+
+	// Create a new CryptoMonitor instance with the mock service
+	cryptoMonitor := NewCryptoMonitor(mockService, nil)
+
+	// Create a sample expired certificate
+	certExpired := models.CACertificate{
+		ID: "123456",
+		Metadata: map[string]interface{}{
+			models.CAMetadataMonitoringExpirationDeltasKey: []models.MonitoringExpirationDelta{
+				{
+					Name:      "Delta1",
+					Delta:     models.TimeDuration(24 * time.Hour),
+					Triggered: false,
+				},
+			},
+		},
+		Certificate: models.Certificate{
+			Status:       models.StatusActive,
+			SerialNumber: "123456",
+			ValidTo:      time.Now().AddDate(0, 0, 10), // Expired in 1 day ago,
+			Metadata:     map[string]interface{}{},
+			Certificate:  &models.X509Certificate{},
+		},
+	}
+
+	// Set up expectations for UpdateCertificateStatus
+	mockService.On("UpdateCAStatus", mock.Anything, mock.Anything).Return(&certExpired, nil)
+	mockService.On("UpdateCAMetadata", mock.Anything, mock.Anything).Return(&certExpired, nil)
+
+	// Call the function under test
+	cryptoMonitor.updateCAIfNeeded(certExpired, time.Now(), context.Background())
+
+	// Assert that the expected methods were called
+	mockService.AssertNotCalled(t, "UpdateCAStatus", mock.Anything, mock.Anything)
+	mockService.AssertCalled(t, "UpdateCAMetadata", mock.Anything, mock.Anything)
+}

--- a/pkg/middlewares/eventpub/ca.go
+++ b/pkg/middlewares/eventpub/ca.go
@@ -130,7 +130,7 @@ func (mw CAEventPublisher) CreateCertificate(ctx context.Context, input services
 func (mw CAEventPublisher) ImportCertificate(ctx context.Context, input services.ImportCertificateInput) (output *models.Certificate, err error) {
 	defer func() {
 		if err == nil {
-			mw.eventMWPub.PublishCloudEvent(ctx, "ca.certificate.import", output)
+			mw.eventMWPub.PublishCloudEvent(ctx, models.EventImportCACertificateKey, output)
 		}
 	}()
 	return mw.Next.ImportCertificate(ctx, input)

--- a/pkg/middlewares/eventpub/ca.go
+++ b/pkg/middlewares/eventpub/ca.go
@@ -10,10 +10,10 @@ import (
 
 type CAEventPublisher struct {
 	Next       services.CAService
-	eventMWPub CloudEventMiddlewarePublisher
+	eventMWPub ICloudEventMiddlewarePublisher
 }
 
-func NewCAEventBusPublisher(eventMWPub CloudEventMiddlewarePublisher) services.CAMiddleware {
+func NewCAEventBusPublisher(eventMWPub ICloudEventMiddlewarePublisher) services.CAMiddleware {
 	return func(next services.CAService) services.CAService {
 		return &CAEventPublisher{
 			Next:       next,

--- a/pkg/middlewares/eventpub/ca_publisher_test.go
+++ b/pkg/middlewares/eventpub/ca_publisher_test.go
@@ -1,0 +1,69 @@
+package eventpub
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/lamassuiot/lamassuiot/v2/pkg/models"
+	"github.com/lamassuiot/lamassuiot/v2/pkg/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type CloudEventMiddlewarePublisherMock struct {
+	mock.Mock
+}
+
+func (m *CloudEventMiddlewarePublisherMock) PublishCloudEvent(ctx context.Context, eventType models.EventType, payload interface{}) {
+	m.Called(ctx, eventType, payload)
+}
+
+func TestCAEventPublisherImportCA(t *testing.T) {
+	// Create a mock implementation of the CAService interface
+	mockCAService := &mockCAService{}
+
+	// Create a mock implementation of the CloudEventMiddlewarePublisher interface
+	mockEventMWPub := new(CloudEventMiddlewarePublisherMock)
+
+	// Create a new instance of the CAEventPublisher with the mock dependencies
+	caEventPublisherMw := NewCAEventBusPublisher(mockEventMWPub)
+	//TODO: Create CAService Mock
+	caEventPublisher := caEventPublisherMw(nil)
+
+	// Define the input for the ImportCA function
+	input := services.ImportCAInput{
+		// Set the necessary fields for the input
+	}
+
+	// Define the expected output and error
+	expectedOutput := &models.CACertificate{}
+	expectedError := errors.New("some error")
+
+	// Set the expectations for the mock CAService's ImportCA function
+	mockCAService.On("ImportCA", context.Background(), input).Return(expectedOutput, expectedError)
+
+	// Set the expectations for the mock EventMWPub's PublishCloudEvent function
+	mockEventMWPub.On("PublishCloudEvent", context.Background(), models.EventImportCAKey, expectedOutput).Return()
+
+	// Call the ImportCA function on the CAEventPublisher
+	output, err := caEventPublisher.ImportCA(context.Background(), input)
+
+	// Assert that the output and error match the expected values
+	assert.Equal(t, expectedOutput, output)
+	assert.Equal(t, expectedError, err)
+
+	// Assert that the expectations for the mock CAService and mock EventMWPub were met
+	mockCAService.AssertExpectations(t)
+	mockEventMWPub.AssertExpectations(t)
+}
+
+// Define a mock implementation of the CAService interface
+type mockCAService struct {
+	mock.Mock
+}
+
+func (m *mockCAService) ImportCA(ctx context.Context, input services.ImportCAInput) (*models.CACertificate, error) {
+	args := m.Called(ctx, input)
+	return args.Get(0).(*models.CACertificate), args.Error(1)
+}

--- a/pkg/middlewares/eventpub/ca_publisher_test.go
+++ b/pkg/middlewares/eventpub/ca_publisher_test.go
@@ -3,10 +3,12 @@ package eventpub
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/lamassuiot/lamassuiot/v2/pkg/models"
 	"github.com/lamassuiot/lamassuiot/v2/pkg/services"
+	svcmock "github.com/lamassuiot/lamassuiot/v2/pkg/services/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -19,51 +21,275 @@ func (m *CloudEventMiddlewarePublisherMock) PublishCloudEvent(ctx context.Contex
 	m.Called(ctx, eventType, payload)
 }
 
-func TestCAEventPublisherImportCA(t *testing.T) {
-	// Create a mock implementation of the CAService interface
-	mockCAService := &mockCAService{}
-
-	// Create a mock implementation of the CloudEventMiddlewarePublisher interface
+func eventChecker(event models.EventType, expectations []func(*svcmock.MockCAService), operation func(services.CAService), assertions func(*CloudEventMiddlewarePublisherMock, *svcmock.MockCAService)) {
+	mockCAService := new(svcmock.MockCAService)
 	mockEventMWPub := new(CloudEventMiddlewarePublisherMock)
-
-	// Create a new instance of the CAEventPublisher with the mock dependencies
 	caEventPublisherMw := NewCAEventBusPublisher(mockEventMWPub)
-	//TODO: Create CAService Mock
-	caEventPublisher := caEventPublisherMw(nil)
+	caEventPublisher := caEventPublisherMw(mockCAService)
 
-	// Define the input for the ImportCA function
-	input := services.ImportCAInput{
-		// Set the necessary fields for the input
+	for _, expectation := range expectations {
+		expectation(mockCAService)
 	}
 
-	// Define the expected output and error
-	expectedOutput := &models.CACertificate{}
-	expectedError := errors.New("some error")
+	mockEventMWPub.On("PublishCloudEvent", context.Background(), event, mock.Anything)
+	operation(caEventPublisher)
 
-	// Set the expectations for the mock CAService's ImportCA function
-	mockCAService.On("ImportCA", context.Background(), input).Return(expectedOutput, expectedError)
-
-	// Set the expectations for the mock EventMWPub's PublishCloudEvent function
-	mockEventMWPub.On("PublishCloudEvent", context.Background(), models.EventImportCAKey, expectedOutput).Return()
-
-	// Call the ImportCA function on the CAEventPublisher
-	output, err := caEventPublisher.ImportCA(context.Background(), input)
-
-	// Assert that the output and error match the expected values
-	assert.Equal(t, expectedOutput, output)
-	assert.Equal(t, expectedError, err)
-
-	// Assert that the expectations for the mock CAService and mock EventMWPub were met
-	mockCAService.AssertExpectations(t)
-	mockEventMWPub.AssertExpectations(t)
+	assertions(mockEventMWPub, mockCAService)
 }
 
-// Define a mock implementation of the CAService interface
-type mockCAService struct {
-	mock.Mock
+func withoutErrors[E any, O any](t *testing.T, method string, input E, event models.EventType, expectedOutput O, extra ...func(*svcmock.MockCAService)) {
+	expectations := []func(*svcmock.MockCAService){
+		func(mockCAService *svcmock.MockCAService) {
+			mockCAService.On(method, context.Background(), mock.Anything).Return(expectedOutput, nil)
+		},
+	}
+	expectations = append(expectations, extra...)
+
+	operation := func(caMiddleware services.CAService) {
+		m := reflect.ValueOf(caMiddleware).MethodByName(method)
+		r := m.Call([]reflect.Value{reflect.ValueOf(context.Background()), reflect.ValueOf(input)})
+		assert.Nil(t, r[1].Interface())
+	}
+
+	assertions := func(mockEventMWPub *CloudEventMiddlewarePublisherMock, mockCAService *svcmock.MockCAService) {
+		mockCAService.AssertExpectations(t)
+		mockEventMWPub.AssertExpectations(t)
+	}
+
+	eventChecker(event, expectations, operation, assertions)
+}
+func withErrors[E any, O any](t *testing.T, method string, input E, event models.EventType, expectedOutput O, extra ...func(*svcmock.MockCAService)) {
+	expectations := []func(*svcmock.MockCAService){
+		func(mockCAService *svcmock.MockCAService) {
+			mockCAService.On(method, context.Background(), mock.Anything).Return(expectedOutput, errors.New("some error"))
+		},
+	}
+	expectations = append(expectations, extra...)
+
+	operation := func(caMiddleware services.CAService) {
+		m := reflect.ValueOf(caMiddleware).MethodByName(method)
+		r := m.Call([]reflect.Value{reflect.ValueOf(context.Background()), reflect.ValueOf(input)})
+		assert.NotNil(t, r[1].Interface())
+	}
+
+	assertions := func(mockEventMWPub *CloudEventMiddlewarePublisherMock, mockCAService *svcmock.MockCAService) {
+		mockCAService.AssertExpectations(t)
+		mockEventMWPub.AssertNotCalled(t, "PublishCloudEvent")
+	}
+
+	eventChecker(event, expectations, operation, assertions)
 }
 
-func (m *mockCAService) ImportCA(ctx context.Context, input services.ImportCAInput) (*models.CACertificate, error) {
-	args := m.Called(ctx, input)
-	return args.Get(0).(*models.CACertificate), args.Error(1)
+func withoutErrorsSingleResult[E any](t *testing.T, method string, input E, event models.EventType, extra ...func(*svcmock.MockCAService)) {
+	expectations := []func(*svcmock.MockCAService){
+		func(mockCAService *svcmock.MockCAService) {
+			mockCAService.On(method, context.Background(), mock.Anything).Return(nil)
+		},
+	}
+	expectations = append(expectations, extra...)
+
+	operation := func(caMiddleware services.CAService) {
+		m := reflect.ValueOf(caMiddleware).MethodByName(method)
+		r := m.Call([]reflect.Value{reflect.ValueOf(context.Background()), reflect.ValueOf(input)})
+		assert.Nil(t, r[0].Interface())
+	}
+
+	assertions := func(mockEventMWPub *CloudEventMiddlewarePublisherMock, mockCAService *svcmock.MockCAService) {
+		mockCAService.AssertExpectations(t)
+		mockEventMWPub.AssertExpectations(t)
+	}
+
+	eventChecker(event, expectations, operation, assertions)
+}
+
+func withErrorsSingleResult[E any](t *testing.T, method string, input E, event models.EventType, extra ...func(*svcmock.MockCAService)) {
+	expectations := []func(*svcmock.MockCAService){
+		func(mockCAService *svcmock.MockCAService) {
+			mockCAService.On(method, context.Background(), mock.Anything).Return(errors.New("some error"))
+		},
+	}
+	expectations = append(expectations, extra...)
+
+	operation := func(caMiddleware services.CAService) {
+		m := reflect.ValueOf(caMiddleware).MethodByName(method)
+		r := m.Call([]reflect.Value{reflect.ValueOf(context.Background()), reflect.ValueOf(input)})
+		assert.NotNil(t, r[0].Interface())
+	}
+
+	assertions := func(mockEventMWPub *CloudEventMiddlewarePublisherMock, mockCAService *svcmock.MockCAService) {
+		mockCAService.AssertExpectations(t)
+		mockEventMWPub.AssertNotCalled(t, "PublishCloudEvent")
+	}
+
+	eventChecker(event, expectations, operation, assertions)
+}
+
+func TestCAEventPublisher(t *testing.T) {
+
+	var testcases = []struct {
+		name string
+		test func(t *testing.T)
+	}{
+		{
+			name: "ImportCA with errors - Not fire event",
+			test: func(t *testing.T) {
+				withErrors(t, "ImportCA", services.ImportCAInput{}, models.EventImportCAKey, &models.CACertificate{})
+			},
+		},
+		{
+			name: "ImportCA without errors - fire event",
+			test: func(t *testing.T) {
+				withoutErrors(t, "ImportCA", services.ImportCAInput{}, models.EventImportCAKey, &models.CACertificate{})
+			},
+		},
+		{
+			name: "CreateCA with errors - Not fire event",
+			test: func(t *testing.T) {
+				withErrors(t, "CreateCA", services.CreateCAInput{}, models.EventCreateCAKey, &models.CACertificate{})
+			},
+		},
+		{
+			name: "CreateCA without errors - fire event",
+			test: func(t *testing.T) {
+				withoutErrors(t, "CreateCA", services.CreateCAInput{}, models.EventCreateCAKey, &models.CACertificate{})
+			},
+		},
+		{
+			name: "SingCertificate with errors - Not fire event",
+			test: func(t *testing.T) {
+				withErrors(t, "SignCertificate", services.SignCertificateInput{}, models.EventSignCertificateKey, &models.Certificate{})
+			},
+		},
+		{
+			name: "SingCertificate without errors - fire event",
+			test: func(t *testing.T) {
+				withoutErrors(t, "SignCertificate", services.SignCertificateInput{}, models.EventSignCertificateKey, &models.Certificate{})
+			},
+		},
+		{
+			name: "CreateCertificate with errors - Not fire event",
+			test: func(t *testing.T) {
+				withErrors(t, "CreateCertificate", services.CreateCertificateInput{}, models.EventCreateCertificateKey, &models.Certificate{})
+			},
+		},
+		{
+			name: "CreateCertificate without errors - fire event",
+			test: func(t *testing.T) {
+				withoutErrors(t, "CreateCertificate", services.CreateCertificateInput{}, models.EventCreateCertificateKey, &models.Certificate{})
+			},
+		},
+		{
+			name: "ImportCertificate with errors - Not fire event",
+			test: func(t *testing.T) {
+				withErrors(t, "ImportCertificate", services.ImportCertificateInput{}, models.EventImportCACertificateKey, &models.Certificate{})
+			},
+		},
+		{
+			name: "ImportCertificate without errors - fire event",
+			test: func(t *testing.T) {
+				withoutErrors(t, "ImportCertificate", services.ImportCertificateInput{}, "ca.certificate.import", &models.Certificate{})
+			},
+		},
+		{
+			name: "SignatureSign with errors - Not fire event",
+			test: func(t *testing.T) {
+				withErrors(t, "SignatureSign", services.SignatureSignInput{}, models.EventSignatureSignKey, new([]byte))
+			},
+		},
+		{
+			name: "SignatureSign without errors - fire event",
+			test: func(t *testing.T) {
+				withoutErrors(t, "SignatureSign", services.SignatureSignInput{}, models.EventSignatureSignKey, new([]byte))
+			},
+		},
+		{
+			name: "UpdateCAStatus with errors - Not fire event",
+			test: func(t *testing.T) {
+				withErrors(t, "UpdateCAStatus", services.UpdateCAStatusInput{}, models.EventUpdateCAStatusKey, &models.CACertificate{},
+					func(mockCAService *svcmock.MockCAService) {
+						mockCAService.On("GetCAByID", context.Background(), mock.Anything).Return(&models.CACertificate{}, nil)
+					})
+			},
+		},
+		{
+			name: "UpdateCAStatus without errors - fire event",
+			test: func(t *testing.T) {
+				withoutErrors(t, "UpdateCAStatus", services.UpdateCAStatusInput{}, models.EventUpdateCAStatusKey, &models.CACertificate{},
+					func(mockCAService *svcmock.MockCAService) {
+						mockCAService.On("GetCAByID", context.Background(), mock.Anything).Return(&models.CACertificate{}, nil)
+					})
+			},
+		},
+		{
+			name: "UpdateCAMetadata with errors - Not fire event",
+			test: func(t *testing.T) {
+				withErrors(t, "UpdateCAMetadata", services.UpdateCAMetadataInput{}, models.EventUpdateCAMetadataKey, &models.CACertificate{},
+					func(mockCAService *svcmock.MockCAService) {
+						mockCAService.On("GetCAByID", context.Background(), mock.Anything).Return(&models.CACertificate{}, nil)
+					})
+			},
+		},
+		{
+			name: "UpdateCAMetadata without errors - fire event",
+			test: func(t *testing.T) {
+				withoutErrors(t, "UpdateCAMetadata", services.UpdateCAMetadataInput{}, models.EventUpdateCAMetadataKey, &models.CACertificate{},
+					func(mockCAService *svcmock.MockCAService) {
+						mockCAService.On("GetCAByID", context.Background(), mock.Anything).Return(&models.CACertificate{}, nil)
+					})
+			},
+		},
+		{
+			name: "UpdateCertificateStatus with errors - Not fire event",
+			test: func(t *testing.T) {
+				withErrors(t, "UpdateCertificateStatus", services.UpdateCertificateStatusInput{}, models.EventUpdateCertificateStatusKey, &models.Certificate{},
+					func(mockCAService *svcmock.MockCAService) {
+						mockCAService.On("GetCertificateBySerialNumber", context.Background(), mock.Anything).Return(&models.Certificate{}, nil)
+					})
+			},
+		},
+		{
+			name: "UpdateCertificateStatus without errors - fire event",
+			test: func(t *testing.T) {
+				withoutErrors(t, "UpdateCertificateStatus", services.UpdateCertificateStatusInput{}, models.EventUpdateCertificateStatusKey, &models.Certificate{},
+					func(mockCAService *svcmock.MockCAService) {
+						mockCAService.On("GetCertificateBySerialNumber", context.Background(), mock.Anything).Return(&models.Certificate{}, nil)
+					})
+			},
+		},
+		{
+			name: "UpdateCertificateMetadata with errors - Not fire event",
+			test: func(t *testing.T) {
+				withErrors(t, "UpdateCertificateMetadata", services.UpdateCertificateMetadataInput{}, models.EventUpdateCertificateMetadataKey, &models.Certificate{},
+					func(mockCAService *svcmock.MockCAService) {
+						mockCAService.On("GetCertificateBySerialNumber", context.Background(), mock.Anything).Return(&models.Certificate{}, nil)
+					})
+			},
+		},
+		{
+			name: "UpdateCertificateMetadata without errors - fire event",
+			test: func(t *testing.T) {
+				withoutErrors(t, "UpdateCertificateMetadata", services.UpdateCertificateMetadataInput{}, models.EventUpdateCertificateMetadataKey, &models.Certificate{},
+					func(mockCAService *svcmock.MockCAService) {
+						mockCAService.On("GetCertificateBySerialNumber", context.Background(), mock.Anything).Return(&models.Certificate{}, nil)
+					})
+			},
+		},
+		{
+			name: "DeleteCA with errors - Not fire event",
+			test: func(t *testing.T) {
+				withErrorsSingleResult(t, "DeleteCA", services.DeleteCAInput{}, models.EventDeleteCAKey)
+			},
+		},
+		{
+			name: "DeleteCA without errors - fire event",
+			test: func(t *testing.T) {
+				withoutErrorsSingleResult(t, "DeleteCA", services.DeleteCAInput{}, models.EventDeleteCAKey)
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, tc.test)
+	}
 }

--- a/pkg/middlewares/eventpub/devices.go
+++ b/pkg/middlewares/eventpub/devices.go
@@ -10,10 +10,10 @@ import (
 
 type deviceEventPublisher struct {
 	next       services.DeviceManagerService
-	eventMWPub CloudEventMiddlewarePublisher
+	eventMWPub ICloudEventMiddlewarePublisher
 }
 
-func NewDeviceEventPublisher(eventMWPub CloudEventMiddlewarePublisher) services.DeviceMiddleware {
+func NewDeviceEventPublisher(eventMWPub ICloudEventMiddlewarePublisher) services.DeviceMiddleware {
 	return func(next services.DeviceManagerService) services.DeviceManagerService {
 		return &deviceEventPublisher{
 			next:       next,

--- a/pkg/middlewares/eventpub/devices_publisher_test.go
+++ b/pkg/middlewares/eventpub/devices_publisher_test.go
@@ -1,0 +1,153 @@
+package eventpub
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/lamassuiot/lamassuiot/v2/pkg/models"
+	"github.com/lamassuiot/lamassuiot/v2/pkg/services"
+	svcmock "github.com/lamassuiot/lamassuiot/v2/pkg/services/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func devicesEventChecker(event models.EventType, expectations []func(*svcmock.MockDeviceManagerService), operation func(services.DeviceManagerService), assertions func(*CloudEventMiddlewarePublisherMock, *svcmock.MockDeviceManagerService)) {
+	mockDeviceManagerService := new(svcmock.MockDeviceManagerService)
+	mockEventMWPub := new(CloudEventMiddlewarePublisherMock)
+	caEventPublisherMw := NewDeviceEventPublisher(mockEventMWPub)
+	caEventPublisher := caEventPublisherMw(mockDeviceManagerService)
+
+	for _, expectation := range expectations {
+		expectation(mockDeviceManagerService)
+	}
+
+	mockEventMWPub.On("PublishCloudEvent", context.Background(), event, mock.Anything)
+	operation(caEventPublisher)
+
+	assertions(mockEventMWPub, mockDeviceManagerService)
+}
+
+func devicesWithoutErrors[E any, O any](t *testing.T, method string, input E, event models.EventType, expectedOutput O, extra ...func(*svcmock.MockDeviceManagerService)) {
+	expectations := []func(*svcmock.MockDeviceManagerService){
+		func(mockCAService *svcmock.MockDeviceManagerService) {
+			mockCAService.On(method, context.Background(), mock.Anything).Return(expectedOutput, nil)
+		},
+	}
+	expectations = append(expectations, extra...)
+
+	operation := func(caMiddleware services.DeviceManagerService) {
+		m := reflect.ValueOf(caMiddleware).MethodByName(method)
+		r := m.Call([]reflect.Value{reflect.ValueOf(context.Background()), reflect.ValueOf(input)})
+		assert.Nil(t, r[1].Interface())
+	}
+
+	assertions := func(mockEventMWPub *CloudEventMiddlewarePublisherMock, mockCAService *svcmock.MockDeviceManagerService) {
+		mockCAService.AssertExpectations(t)
+		mockEventMWPub.AssertExpectations(t)
+	}
+
+	devicesEventChecker(event, expectations, operation, assertions)
+}
+func devicesWithErrors[E any, O any](t *testing.T, method string, input E, event models.EventType, expectedOutput O, extra ...func(*svcmock.MockDeviceManagerService)) {
+	expectations := []func(*svcmock.MockDeviceManagerService){
+		func(mockCAService *svcmock.MockDeviceManagerService) {
+			mockCAService.On(method, context.Background(), mock.Anything).Return(expectedOutput, errors.New("some error"))
+		},
+	}
+	expectations = append(expectations, extra...)
+
+	operation := func(deviceMiddleware services.DeviceManagerService) {
+		m := reflect.ValueOf(deviceMiddleware).MethodByName(method)
+		r := m.Call([]reflect.Value{reflect.ValueOf(context.Background()), reflect.ValueOf(input)})
+		assert.NotNil(t, r[1].Interface())
+	}
+
+	assertions := func(mockEventMWPub *CloudEventMiddlewarePublisherMock, mockCAService *svcmock.MockDeviceManagerService) {
+		mockCAService.AssertExpectations(t)
+		mockEventMWPub.AssertNotCalled(t, "PublishCloudEvent")
+	}
+
+	devicesEventChecker(event, expectations, operation, assertions)
+}
+
+func TestDevicesEventPublisher(t *testing.T) {
+
+	var testcases = []struct {
+		name string
+		test func(t *testing.T)
+	}{
+		{
+			name: "CreateDevice with errors - Not fire event",
+			test: func(t *testing.T) {
+				devicesWithErrors(t, "CreateDevice", services.CreateDeviceInput{}, models.EventCreateDeviceKey, &models.Device{})
+			},
+		},
+		{
+			name: "CreateDevice without errors - fire event",
+			test: func(t *testing.T) {
+				devicesWithoutErrors(t, "CreateDevice", services.CreateDeviceInput{}, models.EventCreateDeviceKey, &models.Device{})
+			},
+		},
+		{
+			name: "UpdateDeviceStatus with errors - Not fire event",
+			test: func(t *testing.T) {
+				devicesWithErrors(t, "UpdateDeviceStatus", services.UpdateDeviceStatusInput{}, models.EventUpdateDeviceStatusKey, &models.Device{},
+					func(mockCAService *svcmock.MockDeviceManagerService) {
+						mockCAService.On("GetDeviceByID", context.Background(), mock.Anything).Return(&models.Device{}, nil)
+					})
+			},
+		},
+		{
+			name: "UpdateDeviceStatus without errors - fire event",
+			test: func(t *testing.T) {
+				devicesWithoutErrors(t, "UpdateDeviceStatus", services.UpdateDeviceStatusInput{}, models.EventUpdateDeviceStatusKey, &models.Device{},
+					func(mockCAService *svcmock.MockDeviceManagerService) {
+						mockCAService.On("GetDeviceByID", context.Background(), mock.Anything).Return(&models.Device{}, nil)
+					})
+			},
+		},
+		{
+			name: "UpdateDeviceIdentitySlot with errors - Not fire event",
+			test: func(t *testing.T) {
+				devicesWithErrors(t, "UpdateDeviceIdentitySlot", services.UpdateDeviceIdentitySlotInput{}, models.EventUpdateDeviceIDSlotKey, &models.Device{},
+					func(mockCAService *svcmock.MockDeviceManagerService) {
+						mockCAService.On("GetDeviceByID", context.Background(), mock.Anything).Return(&models.Device{}, nil)
+					})
+			},
+		},
+		{
+			name: "UpdateDeviceIdentitySlot without errors - fire event",
+			test: func(t *testing.T) {
+				devicesWithoutErrors(t, "UpdateDeviceIdentitySlot", services.UpdateDeviceIdentitySlotInput{}, models.EventUpdateDeviceIDSlotKey, &models.Device{},
+					func(mockCAService *svcmock.MockDeviceManagerService) {
+						mockCAService.On("GetDeviceByID", context.Background(), mock.Anything).Return(&models.Device{}, nil)
+					})
+			},
+		},
+		{
+			name: "UpdateDeviceMetadata with errors - Not fire event",
+			test: func(t *testing.T) {
+				devicesWithErrors(t, "UpdateDeviceMetadata", services.UpdateDeviceMetadataInput{}, models.EventUpdateDeviceMetadataKey, &models.Device{},
+					func(mockCAService *svcmock.MockDeviceManagerService) {
+						mockCAService.On("GetDeviceByID", context.Background(), mock.Anything).Return(&models.Device{}, nil)
+					})
+			},
+		},
+		{
+			name: "UpdateDeviceMetadata without errors - fire event",
+			test: func(t *testing.T) {
+				devicesWithoutErrors(t, "UpdateDeviceMetadata", services.UpdateDeviceMetadataInput{}, models.EventUpdateDeviceMetadataKey, &models.Device{},
+					func(mockCAService *svcmock.MockDeviceManagerService) {
+						mockCAService.On("GetDeviceByID", context.Background(), mock.Anything).Return(&models.Device{}, nil)
+					})
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, tc.test)
+	}
+}

--- a/pkg/middlewares/eventpub/dms.go
+++ b/pkg/middlewares/eventpub/dms.go
@@ -11,12 +11,10 @@ import (
 
 type dmsEventPublisher struct {
 	next       services.DMSManagerService
-	eventMWPub CloudEventMiddlewarePublisher
+	eventMWPub ICloudEventMiddlewarePublisher
 }
 
-const dmsSource = "lamassuiot.dms-manager"
-
-func NewDMSEventPublisher(eventMWPub CloudEventMiddlewarePublisher) services.DMSManagerMiddleware {
+func NewDMSEventPublisher(eventMWPub ICloudEventMiddlewarePublisher) services.DMSManagerMiddleware {
 	return func(next services.DMSManagerService) services.DMSManagerService {
 		return &dmsEventPublisher{
 			next:       next,

--- a/pkg/middlewares/eventpub/dms_publisher_test.go
+++ b/pkg/middlewares/eventpub/dms_publisher_test.go
@@ -1,0 +1,198 @@
+package eventpub
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/lamassuiot/lamassuiot/v2/pkg/models"
+	"github.com/lamassuiot/lamassuiot/v2/pkg/services"
+	svcmock "github.com/lamassuiot/lamassuiot/v2/pkg/services/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func dmsEventChecker(event models.EventType, expectations []func(*svcmock.MockDMSManagerService), operation func(services.DMSManagerService), assertions func(*CloudEventMiddlewarePublisherMock, *svcmock.MockDMSManagerService)) {
+	mockDMSManagerService := new(svcmock.MockDMSManagerService)
+	mockEventMWPub := new(CloudEventMiddlewarePublisherMock)
+	caEventPublisherMw := NewDMSEventPublisher(mockEventMWPub)
+	dmsEventPublisher := caEventPublisherMw(mockDMSManagerService)
+
+	for _, expectation := range expectations {
+		expectation(mockDMSManagerService)
+	}
+
+	mockEventMWPub.On("PublishCloudEvent", context.Background(), event, mock.Anything)
+	operation(dmsEventPublisher)
+
+	assertions(mockEventMWPub, mockDMSManagerService)
+}
+
+func dmsWithoutErrors[E any, O any](t *testing.T, method string, input E, event models.EventType, expectedOutput O, extra ...func(*svcmock.MockDMSManagerService)) {
+	expectations := []func(*svcmock.MockDMSManagerService){
+		func(mockCAService *svcmock.MockDMSManagerService) {
+			mockCAService.On(method, context.Background(), mock.Anything).Return(expectedOutput, nil)
+		},
+	}
+	expectations = append(expectations, extra...)
+
+	operation := func(caMiddleware services.DMSManagerService) {
+		m := reflect.ValueOf(caMiddleware).MethodByName(method)
+		r := m.Call([]reflect.Value{reflect.ValueOf(context.Background()), reflect.ValueOf(input)})
+		assert.Nil(t, r[1].Interface())
+	}
+
+	assertions := func(mockEventMWPub *CloudEventMiddlewarePublisherMock, mockCAService *svcmock.MockDMSManagerService) {
+		mockCAService.AssertExpectations(t)
+		mockEventMWPub.AssertExpectations(t)
+	}
+
+	dmsEventChecker(event, expectations, operation, assertions)
+}
+func dmsWithErrors[E any, O any](t *testing.T, method string, input E, event models.EventType, expectedOutput O, extra ...func(*svcmock.MockDMSManagerService)) {
+	expectations := []func(*svcmock.MockDMSManagerService){
+		func(mockCAService *svcmock.MockDMSManagerService) {
+			mockCAService.On(method, context.Background(), mock.Anything).Return(expectedOutput, errors.New("some error"))
+		},
+	}
+	expectations = append(expectations, extra...)
+
+	operation := func(deviceMiddleware services.DMSManagerService) {
+		m := reflect.ValueOf(deviceMiddleware).MethodByName(method)
+		r := m.Call([]reflect.Value{reflect.ValueOf(context.Background()), reflect.ValueOf(input)})
+		assert.NotNil(t, r[1].Interface())
+	}
+
+	assertions := func(mockEventMWPub *CloudEventMiddlewarePublisherMock, mockCAService *svcmock.MockDMSManagerService) {
+		mockCAService.AssertExpectations(t)
+		mockEventMWPub.AssertNotCalled(t, "PublishCloudEvent")
+	}
+
+	dmsEventChecker(event, expectations, operation, assertions)
+}
+
+func estWithoutErrors[E any, O any](t *testing.T, method string, input E, event models.EventType, expectedOutput O, extra ...func(*svcmock.MockDMSManagerService)) {
+	expectations := []func(*svcmock.MockDMSManagerService){
+		func(mockCAService *svcmock.MockDMSManagerService) {
+			mockCAService.On(method, context.Background(), mock.Anything, "").Return(expectedOutput, nil)
+		},
+	}
+	expectations = append(expectations, extra...)
+
+	operation := func(caMiddleware services.DMSManagerService) {
+		m := reflect.ValueOf(caMiddleware).MethodByName(method)
+		r := m.Call([]reflect.Value{reflect.ValueOf(context.Background()), reflect.ValueOf(input), reflect.ValueOf("")})
+		assert.Nil(t, r[1].Interface())
+	}
+
+	assertions := func(mockEventMWPub *CloudEventMiddlewarePublisherMock, mockCAService *svcmock.MockDMSManagerService) {
+		mockCAService.AssertExpectations(t)
+		mockEventMWPub.AssertExpectations(t)
+	}
+
+	dmsEventChecker(event, expectations, operation, assertions)
+}
+
+func estWithErrors[E any, O any](t *testing.T, method string, input E, event models.EventType, expectedOutput O, extra ...func(*svcmock.MockDMSManagerService)) {
+	expectations := []func(*svcmock.MockDMSManagerService){
+		func(mockCAService *svcmock.MockDMSManagerService) {
+			mockCAService.On(method, context.Background(), mock.Anything, "").Return(expectedOutput, errors.New("some error"))
+		},
+	}
+	expectations = append(expectations, extra...)
+
+	operation := func(deviceMiddleware services.DMSManagerService) {
+		m := reflect.ValueOf(deviceMiddleware).MethodByName(method)
+		r := m.Call([]reflect.Value{reflect.ValueOf(context.Background()), reflect.ValueOf(input), reflect.ValueOf("")})
+		assert.NotNil(t, r[1].Interface())
+	}
+
+	assertions := func(mockEventMWPub *CloudEventMiddlewarePublisherMock, mockCAService *svcmock.MockDMSManagerService) {
+		mockCAService.AssertExpectations(t)
+		mockEventMWPub.AssertNotCalled(t, "PublishCloudEvent")
+	}
+
+	dmsEventChecker(event, expectations, operation, assertions)
+}
+
+func TestDMSEventPublisher(t *testing.T) {
+
+	var testcases = []struct {
+		name string
+		test func(t *testing.T)
+	}{
+		{
+			name: "CreateDMS with errors - Not fire event",
+			test: func(t *testing.T) {
+				dmsWithErrors(t, "CreateDMS", services.CreateDMSInput{}, models.EventCreateDMSKey, &models.DMS{})
+			},
+		},
+		{
+			name: "CreateDMS without errors - fire event",
+			test: func(t *testing.T) {
+				dmsWithoutErrors(t, "CreateDMS", services.CreateDMSInput{}, models.EventCreateDMSKey, &models.DMS{})
+			},
+		},
+		{
+			name: "UpdateDMS with errors - Not fire event",
+			test: func(t *testing.T) {
+				dmsWithErrors(t, "UpdateDMS", services.UpdateDMSInput{}, models.EventUpdateDMSMetadataKey, &models.DMS{},
+					func(mockCAService *svcmock.MockDMSManagerService) {
+						mockCAService.On("GetDMSByID", context.Background(), mock.Anything).Return(&models.DMS{}, nil)
+					})
+			},
+		},
+		{
+			name: "UpdateDMS without errors - fire event",
+			test: func(t *testing.T) {
+				dmsWithoutErrors(t, "UpdateDMS", services.UpdateDMSInput{}, models.EventUpdateDMSMetadataKey, &models.DMS{},
+					func(mockCAService *svcmock.MockDMSManagerService) {
+						mockCAService.On("GetDMSByID", context.Background(), mock.Anything).Return(&models.DMS{}, nil)
+					})
+			},
+		},
+		{
+			name: "Enroll with errors - Not fire event",
+			test: func(t *testing.T) {
+				estWithErrors(t, "Enroll", &x509.CertificateRequest{}, models.EventEnrollKey, &x509.Certificate{})
+			},
+		},
+		{
+			name: "Enroll without errors - fire event",
+			test: func(t *testing.T) {
+				estWithoutErrors(t, "Enroll", &x509.CertificateRequest{}, models.EventEnrollKey, &x509.Certificate{})
+			},
+		},
+		{
+			name: "Reenroll with errors - Not fire event",
+			test: func(t *testing.T) {
+				estWithErrors(t, "Reenroll", &x509.CertificateRequest{}, models.EventReEnrollKey, &x509.Certificate{})
+			},
+		},
+		{
+			name: "Reenroll without errors - fire event",
+			test: func(t *testing.T) {
+				estWithoutErrors(t, "Reenroll", &x509.CertificateRequest{}, models.EventReEnrollKey, &x509.Certificate{})
+			},
+		},
+		{
+			name: "BindIdentityToDevice with errors - Not fire event",
+			test: func(t *testing.T) {
+				dmsWithErrors(t, "BindIdentityToDevice", services.BindIdentityToDeviceInput{}, models.EventBindDeviceIdentityKey, &models.BindIdentityToDeviceOutput{})
+			},
+		},
+		{
+			name: "BindIdentityToDevice without errors - fire event",
+			test: func(t *testing.T) {
+				dmsWithoutErrors(t, "BindIdentityToDevice", services.BindIdentityToDeviceInput{}, models.EventBindDeviceIdentityKey, &models.BindIdentityToDeviceOutput{})
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, tc.test)
+	}
+}

--- a/pkg/middlewares/eventpub/utils.go
+++ b/pkg/middlewares/eventpub/utils.go
@@ -11,6 +11,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+type ICloudEventMiddlewarePublisher interface {
+	PublishCloudEvent(ctx context.Context, eventType models.EventType, payload interface{})
+}
+
 type CloudEventMiddlewarePublisher struct {
 	Publisher message.Publisher
 	ServiceID string

--- a/pkg/models/events.go
+++ b/pkg/models/events.go
@@ -21,13 +21,14 @@ type UpdateModel[E any] struct {
 type EventType string
 
 const (
-	EventCreateCAKey         EventType = "ca.create"
-	EventImportCAKey         EventType = "ca.import"
-	EventUpdateCAStatusKey   EventType = "ca.status.update"
-	EventUpdateCAMetadataKey EventType = "ca.metadata.update"
-	EventSignCertificateKey  EventType = "ca.sign.certificate"
-	EventSignatureSignKey    EventType = "ca.sign.signature"
-	EventDeleteCAKey         EventType = "ca.delete"
+	EventCreateCAKey            EventType = "ca.create"
+	EventImportCAKey            EventType = "ca.import"
+	EventImportCACertificateKey EventType = "ca.certificate.import"
+	EventUpdateCAStatusKey      EventType = "ca.status.update"
+	EventUpdateCAMetadataKey    EventType = "ca.metadata.update"
+	EventSignCertificateKey     EventType = "ca.sign.certificate"
+	EventSignatureSignKey       EventType = "ca.sign.signature"
+	EventDeleteCAKey            EventType = "ca.delete"
 
 	EventCreateCertificateKey         EventType = "certificate.create"
 	EventImportCertificateKey         EventType = "certificate.import"

--- a/pkg/services/mock/caservice_mock.go
+++ b/pkg/services/mock/caservice_mock.go
@@ -1,0 +1,125 @@
+package mock
+
+import (
+	"context"
+
+	"github.com/lamassuiot/lamassuiot/v2/pkg/models"
+	"github.com/lamassuiot/lamassuiot/v2/pkg/services"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockCAService struct {
+	mock.Mock
+}
+
+func (m *MockCAService) UpdateCertificateStatus(ctx context.Context, input services.UpdateCertificateStatusInput) (*models.Certificate, error) {
+	args := m.Called(ctx, input)
+	return args.Get(0).(*models.Certificate), args.Error(1)
+}
+func (m *MockCAService) UpdateCertificateMetadata(ctx context.Context, input services.UpdateCertificateMetadataInput) (*models.Certificate, error) {
+	args := m.Called(ctx, input)
+	return args.Get(0).(*models.Certificate), args.Error(1)
+}
+
+func (m *MockCAService) GetStats(ctx context.Context) (*models.CAStats, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(*models.CAStats), args.Error(1)
+}
+
+func (m *MockCAService) GetStatsByCAID(ctx context.Context, input services.GetStatsByCAIDInput) (map[models.CertificateStatus]int, error) {
+	args := m.Called(ctx, input)
+	return args.Get(0).(map[models.CertificateStatus]int), args.Error(1)
+}
+
+func (m *MockCAService) GetCryptoEngineProvider(ctx context.Context) ([]*models.CryptoEngineProvider, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]*models.CryptoEngineProvider), args.Error(1)
+}
+
+func (m *MockCAService) CreateCA(ctx context.Context, input services.CreateCAInput) (*models.CACertificate, error) {
+	args := m.Called(ctx, input)
+	return args.Get(0).(*models.CACertificate), args.Error(1)
+}
+func (m *MockCAService) ImportCA(ctx context.Context, input services.ImportCAInput) (*models.CACertificate, error) {
+	args := m.Called(ctx, input)
+	return args.Get(0).(*models.CACertificate), args.Error(1)
+}
+func (m *MockCAService) GetCAByID(ctx context.Context, input services.GetCAByIDInput) (*models.CACertificate, error) {
+	args := m.Called(ctx, input)
+	return args.Get(0).(*models.CACertificate), args.Error(1)
+}
+func (m *MockCAService) GetCAs(ctx context.Context, input services.GetCAsInput) (string, error) {
+	args := m.Called(ctx, input)
+	return args.String(0), args.Error(1)
+}
+func (m *MockCAService) GetCAsByCommonName(ctx context.Context, input services.GetCAsByCommonNameInput) (string, error) {
+	args := m.Called(ctx, input)
+	return args.String(0), args.Error(1)
+
+}
+func (m *MockCAService) UpdateCAStatus(ctx context.Context, input services.UpdateCAStatusInput) (*models.CACertificate, error) {
+	args := m.Called(ctx, input)
+	return args.Get(0).(*models.CACertificate), args.Error(1)
+}
+func (m *MockCAService) UpdateCAMetadata(ctx context.Context, input services.UpdateCAMetadataInput) (*models.CACertificate, error) {
+	args := m.Called(ctx, input)
+	return args.Get(0).(*models.CACertificate), args.Error(1)
+
+}
+func (m *MockCAService) DeleteCA(ctx context.Context, input services.DeleteCAInput) error {
+	args := m.Called(ctx, input)
+	return args.Error(0)
+}
+
+func (m *MockCAService) SignatureSign(ctx context.Context, input services.SignatureSignInput) ([]byte, error) {
+	args := m.Called(ctx, input)
+	val := args.Get(0).(*[]byte)
+	if val != nil {
+		return *val, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockCAService) SignatureVerify(ctx context.Context, input services.SignatureVerifyInput) (bool, error) {
+	args := m.Called(ctx, input)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockCAService) SignCertificate(ctx context.Context, input services.SignCertificateInput) (*models.Certificate, error) {
+	args := m.Called(ctx, input)
+	return args.Get(0).(*models.Certificate), args.Error(1)
+}
+
+func (m *MockCAService) CreateCertificate(ctx context.Context, input services.CreateCertificateInput) (*models.Certificate, error) {
+	args := m.Called(ctx, input)
+	return args.Get(0).(*models.Certificate), args.Error(1)
+}
+func (m *MockCAService) ImportCertificate(ctx context.Context, input services.ImportCertificateInput) (*models.Certificate, error) {
+	args := m.Called(ctx, input)
+	return args.Get(0).(*models.Certificate), args.Error(1)
+}
+
+func (m *MockCAService) GetCertificateBySerialNumber(ctx context.Context, input services.GetCertificatesBySerialNumberInput) (*models.Certificate, error) {
+	args := m.Called(ctx, input)
+	return args.Get(0).(*models.Certificate), args.Error(1)
+}
+func (m *MockCAService) GetCertificates(ctx context.Context, input services.GetCertificatesInput) (string, error) {
+	args := m.Called(ctx, input)
+	return args.String(0), args.Error(1)
+}
+func (m *MockCAService) GetCertificatesByCA(ctx context.Context, input services.GetCertificatesByCAInput) (string, error) {
+	args := m.Called(ctx, input)
+	return args.String(0), args.Error(1)
+}
+func (m *MockCAService) GetCertificatesByExpirationDate(ctx context.Context, input services.GetCertificatesByExpirationDateInput) (string, error) {
+	args := m.Called(ctx, input)
+	return args.String(0), args.Error(1)
+}
+func (m *MockCAService) GetCertificatesByCaAndStatus(ctx context.Context, input services.GetCertificatesByCaAndStatusInput) (string, error) {
+	args := m.Called(ctx, input)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockCAService) GetCertificatesByStatus(ctx context.Context, input services.GetCertificatesByStatusInput) (string, error) {
+	args := m.Called(ctx, input)
+	return args.String(0), args.Error(1)
+}

--- a/pkg/services/mock/devicemanager_mock.go
+++ b/pkg/services/mock/devicemanager_mock.go
@@ -1,0 +1,53 @@
+package mock
+
+import (
+	"context"
+
+	"github.com/lamassuiot/lamassuiot/v2/pkg/models"
+	"github.com/lamassuiot/lamassuiot/v2/pkg/services"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockDeviceManagerService struct {
+	mock.Mock
+}
+
+func (dm *MockDeviceManagerService) GetDevicesStats(ctx context.Context, input services.GetDevicesStatsInput) (*models.DevicesStats, error) {
+	args := dm.Called(ctx, input)
+	return args.Get(0).(*models.DevicesStats), args.Error(1)
+}
+
+func (dm *MockDeviceManagerService) CreateDevice(ctx context.Context, input services.CreateDeviceInput) (*models.Device, error) {
+	args := dm.Called(ctx, input)
+	return args.Get(0).(*models.Device), args.Error(1)
+}
+
+func (dm *MockDeviceManagerService) GetDeviceByID(ctx context.Context, input services.GetDeviceByIDInput) (*models.Device, error) {
+	args := dm.Called(ctx, input)
+	return args.Get(0).(*models.Device), args.Error(1)
+}
+
+func (dm *MockDeviceManagerService) GetDevices(ctx context.Context, input services.GetDevicesInput) (string, error) {
+	args := dm.Called(ctx, input)
+	return args.String(0), args.Error(1)
+}
+
+func (dm *MockDeviceManagerService) GetDeviceByDMS(ctx context.Context, input services.GetDevicesByDMSInput) (string, error) {
+	args := dm.Called(ctx, input)
+	return args.String(0), args.Error(1)
+}
+
+func (dm *MockDeviceManagerService) UpdateDeviceStatus(ctx context.Context, input services.UpdateDeviceStatusInput) (*models.Device, error) {
+	args := dm.Called(ctx, input)
+	return args.Get(0).(*models.Device), args.Error(1)
+}
+
+func (dm *MockDeviceManagerService) UpdateDeviceIdentitySlot(ctx context.Context, input services.UpdateDeviceIdentitySlotInput) (*models.Device, error) {
+	args := dm.Called(ctx, input)
+	return args.Get(0).(*models.Device), args.Error(1)
+}
+
+func (dm *MockDeviceManagerService) UpdateDeviceMetadata(ctx context.Context, input services.UpdateDeviceMetadataInput) (*models.Device, error) {
+	args := dm.Called(ctx, input)
+	return args.Get(0).(*models.Device), args.Error(1)
+}

--- a/pkg/services/mock/dms_mock.go
+++ b/pkg/services/mock/dms_mock.go
@@ -1,0 +1,64 @@
+package mock
+
+import (
+	"context"
+	"crypto/x509"
+
+	"github.com/lamassuiot/lamassuiot/v2/pkg/models"
+	"github.com/lamassuiot/lamassuiot/v2/pkg/services"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockDMSManagerService struct {
+	mock.Mock
+}
+
+func (m *MockDMSManagerService) CACerts(ctx context.Context, aps string) ([]*x509.Certificate, error) {
+	args := m.Called(ctx, aps)
+	return args.Get(0).([]*x509.Certificate), args.Error(1)
+}
+
+func (m *MockDMSManagerService) ServerKeyGen(ctx context.Context, csr *x509.CertificateRequest, aps string) (*x509.Certificate, interface{}, error) {
+	args := m.Called(ctx, csr, aps)
+	return args.Get(0).(*x509.Certificate), args.Get(1), args.Error(2)
+}
+
+func (m *MockDMSManagerService) Enroll(ctx context.Context, csr *x509.CertificateRequest, aps string) (*x509.Certificate, error) {
+	args := m.Called(ctx, csr, aps)
+	return args.Get(0).(*x509.Certificate), args.Error(1)
+}
+
+func (m *MockDMSManagerService) Reenroll(ctx context.Context, csr *x509.CertificateRequest, aps string) (*x509.Certificate, error) {
+	args := m.Called(ctx, csr, aps)
+	return args.Get(0).(*x509.Certificate), args.Error(1)
+}
+
+func (m *MockDMSManagerService) GetDMSStats(ctx context.Context, input services.GetDMSStatsInput) (*models.DMSStats, error) {
+	args := m.Called(ctx, input)
+	return args.Get(0).(*models.DMSStats), args.Error(1)
+}
+
+func (m *MockDMSManagerService) CreateDMS(ctx context.Context, input services.CreateDMSInput) (*models.DMS, error) {
+	args := m.Called(ctx, input)
+	return args.Get(0).(*models.DMS), args.Error(1)
+}
+
+func (m *MockDMSManagerService) UpdateDMS(ctx context.Context, input services.UpdateDMSInput) (*models.DMS, error) {
+	args := m.Called(ctx, input)
+	return args.Get(0).(*models.DMS), args.Error(1)
+}
+
+func (m *MockDMSManagerService) GetDMSByID(ctx context.Context, input services.GetDMSByIDInput) (*models.DMS, error) {
+	args := m.Called(ctx, input)
+	return args.Get(0).(*models.DMS), args.Error(1)
+}
+
+func (m *MockDMSManagerService) GetAll(ctx context.Context, input services.GetAllInput) (string, error) {
+	args := m.Called(ctx, input)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockDMSManagerService) BindIdentityToDevice(ctx context.Context, input services.BindIdentityToDeviceInput) (*models.BindIdentityToDeviceOutput, error) {
+	args := m.Called(ctx, input)
+	return args.Get(0).(*models.BindIdentityToDeviceOutput), args.Error(1)
+}


### PR DESCRIPTION
This pull request introduces the following changes to improve the testability and maintainability of our codebase:

1. **Mock-Based Tests for Event Publishers Middleware**: To ensure the reliability and correctness of our event publishing functionality, I've added a suite of mock-based tests for the event publishers middleware. These tests the event firing when no error is produced by the underlying service logic.
2. **Creation of Mocks for Services**: To enable effective unit testing, I've created mocks for our services. These mocks mimic the behavior of the actual services, allowing us to test the interactions between our components in isolation, without relying on external dependencies or affecting other parts of the system.
