### PR TITLE
Use golang build tags to customize build 

### DIFF
--- a/pkg/cryptoengines/pkcs11.go
+++ b/pkg/cryptoengines/pkcs11.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 package cryptoengines
 
 import (

--- a/pkg/cryptoengines/pkcs11w.go
+++ b/pkg/cryptoengines/pkcs11w.go
@@ -1,0 +1,15 @@
+//go:build windows
+// +build windows
+
+package cryptoengines
+
+import (
+	"fmt"
+
+	"github.com/lamassuiot/lamassuiot/v2/pkg/config"
+	"github.com/sirupsen/logrus"
+)
+
+func NewPKCS11Engine(logger *logrus.Entry, conf config.PKCS11EngineConfig) (CryptoEngine, error) {
+	return nil, fmt.Errorf("PKCS11 engine is not supported on Windows")
+}

--- a/pkg/storage/builder/builder.go
+++ b/pkg/storage/builder/builder.go
@@ -5,27 +5,14 @@ import (
 
 	"github.com/lamassuiot/lamassuiot/v2/pkg/config"
 	"github.com/lamassuiot/lamassuiot/v2/pkg/storage"
-	"github.com/lamassuiot/lamassuiot/v2/pkg/storage/couchdb"
-	"github.com/lamassuiot/lamassuiot/v2/pkg/storage/postgres"
 	log "github.com/sirupsen/logrus"
 )
 
 func BuildStorageEngine(logger *log.Entry, conf config.PluggableStorageEngine) (storage.StorageEngine, error) {
 
-	switch conf.Provider {
-	case config.Postgres:
-		storageEngine, err := postgres.NewStorageEngine(logger, conf.Postgres)
-		if err != nil {
-			return nil, err
-		}
-		return storageEngine, err
-	case config.CouchDB:
-		storageEngine, err := couchdb.NewStorageEngine(logger, conf.CouchDB)
-		if err != nil {
-			return nil, err
-		}
-		return storageEngine, err
-	default:
+	builder := storage.GetEngineBuilder(conf.Provider)
+	if builder == nil {
 		return nil, fmt.Errorf("no storage engine of type %s", conf.Provider)
 	}
+	return builder(logger, conf)
 }

--- a/pkg/storage/builder/builder_couchdb_test.go
+++ b/pkg/storage/builder/builder_couchdb_test.go
@@ -1,0 +1,40 @@
+//go:build experimental
+// +build experimental
+
+package builder
+
+import (
+	"testing"
+
+	"github.com/lamassuiot/lamassuiot/v2/pkg/config"
+	"github.com/lamassuiot/lamassuiot/v2/pkg/storage/couchdb"
+	couchdb_test "github.com/lamassuiot/lamassuiot/v2/pkg/test/subsystems/storage/couchdb"
+	log "github.com/sirupsen/logrus"
+)
+
+func TestBuildStorageEngineCouchDB(t *testing.T) {
+	cleanfunc, cdbconfig, err := couchdb_test.RunCouchDBDocker()
+	if err != nil {
+		t.Fatalf("could not run couchdb docker container: %s", err)
+	}
+	t.Cleanup(func() { _ = cleanfunc() })
+
+	logger := log.WithField("test", "BuildStorageEngine_CouchDB")
+	conf := config.PluggableStorageEngine{
+		Provider: config.CouchDB,
+		CouchDB:  *cdbconfig,
+	}
+
+	// Call the BuildStorageEngine function
+	storageEngine, err := BuildStorageEngine(logger, conf)
+
+	// Verify the result
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	_, ok := storageEngine.(*couchdb.CouchDBStorageEngine)
+	if !ok {
+		t.Error("expected storage engine of type *couchdb.StorageEngine")
+	}
+}

--- a/pkg/storage/builder/builder_experimental_test.go
+++ b/pkg/storage/builder/builder_experimental_test.go
@@ -1,0 +1,31 @@
+//go:build !experimental
+// +build !experimental
+
+package builder
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/lamassuiot/lamassuiot/v2/pkg/config"
+	log "github.com/sirupsen/logrus"
+)
+
+func TestBuildStorageEngineCouchDBMissing(t *testing.T) {
+	logger := log.WithField("test", "BuildStorageEngine_InvalidProvider")
+	conf := config.PluggableStorageEngine{
+		Provider: config.CouchDB,
+	}
+
+	// Call the BuildStorageEngine function
+	_, err := BuildStorageEngine(logger, conf)
+
+	// Verify the result
+	if err == nil {
+		t.Error("expected an error, but got nil")
+	}
+
+	if err.Error() != fmt.Sprintf("no storage engine of type %s", config.CouchDB) {
+		t.Errorf("unexpected error: %s", err)
+	}
+}

--- a/pkg/storage/builder/builder_test.go
+++ b/pkg/storage/builder/builder_test.go
@@ -4,9 +4,7 @@ import (
 	"testing"
 
 	"github.com/lamassuiot/lamassuiot/v2/pkg/config"
-	"github.com/lamassuiot/lamassuiot/v2/pkg/storage/couchdb"
 	"github.com/lamassuiot/lamassuiot/v2/pkg/storage/postgres"
-	couchdb_test "github.com/lamassuiot/lamassuiot/v2/pkg/test/subsystems/storage/couchdb"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -30,33 +28,6 @@ func TestBuildStorageEnginePostgres(t *testing.T) {
 	_, ok := storageEngine.(*postgres.PostgresStorageEngine)
 	if !ok {
 		t.Error("expected storage engine of type *postgres.StorageEngine")
-	}
-}
-
-func TestBuildStorageEngineCouchDB(t *testing.T) {
-	cleanfunc, cdbconfig, err := couchdb_test.RunCouchDBDocker()
-	if err != nil {
-		t.Fatalf("could not run couchdb docker container: %s", err)
-	}
-	t.Cleanup(func() { _ = cleanfunc() })
-
-	logger := log.WithField("test", "BuildStorageEngine_CouchDB")
-	conf := config.PluggableStorageEngine{
-		Provider: config.CouchDB,
-		CouchDB:  *cdbconfig,
-	}
-
-	// Call the BuildStorageEngine function
-	storageEngine, err := BuildStorageEngine(logger, conf)
-
-	// Verify the result
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
-	}
-
-	_, ok := storageEngine.(*couchdb.CouchDBStorageEngine)
-	if !ok {
-		t.Error("expected storage engine of type *couchdb.StorageEngine")
 	}
 }
 

--- a/pkg/storage/couchdb/castore.go
+++ b/pkg/storage/couchdb/castore.go
@@ -1,3 +1,6 @@
+//go:build experimental
+// +build experimental
+
 package couchdb
 
 import (

--- a/pkg/storage/couchdb/certstore.go
+++ b/pkg/storage/couchdb/certstore.go
@@ -1,3 +1,6 @@
+//go:build experimental
+// +build experimental
+
 package couchdb
 
 import (

--- a/pkg/storage/couchdb/devicemanager.go
+++ b/pkg/storage/couchdb/devicemanager.go
@@ -1,3 +1,6 @@
+//go:build experimental
+// +build experimental
+
 package couchdb
 
 import (

--- a/pkg/storage/couchdb/dmsmanger.go
+++ b/pkg/storage/couchdb/dmsmanger.go
@@ -1,3 +1,6 @@
+//go:build experimental
+// +build experimental
+
 package couchdb
 
 import (

--- a/pkg/storage/couchdb/engine.go
+++ b/pkg/storage/couchdb/engine.go
@@ -1,3 +1,6 @@
+//go:build experimental
+// +build experimental
+
 package couchdb
 
 import (
@@ -8,6 +11,12 @@ import (
 	"github.com/lamassuiot/lamassuiot/v2/pkg/storage"
 	log "github.com/sirupsen/logrus"
 )
+
+func init() {
+	storage.RegisterStorageEngine(config.CouchDB, func(logger *log.Entry, conf config.PluggableStorageEngine) (storage.StorageEngine, error) {
+		return NewStorageEngine(logger, conf.CouchDB)
+	})
+}
 
 type CouchDBStorageEngine struct {
 	storage.CommonStorageEngine

--- a/pkg/storage/couchdb/placeholder.go
+++ b/pkg/storage/couchdb/placeholder.go
@@ -1,0 +1,1 @@
+package couchdb

--- a/pkg/storage/couchdb/utils.go
+++ b/pkg/storage/couchdb/utils.go
@@ -1,3 +1,6 @@
+//go:build experimental
+// +build experimental
+
 package couchdb
 
 import (

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -1,5 +1,10 @@
 package storage
 
+import (
+	"github.com/lamassuiot/lamassuiot/v2/pkg/config"
+	"github.com/sirupsen/logrus"
+)
+
 type CommonStorageEngine struct {
 	CA            CACertificatesRepo
 	Cert          CertificatesRepo
@@ -16,4 +21,16 @@ type StorageEngine interface {
 	GetDMSStorage() (DMSRepo, error)
 	GetEnventsStorage() (EventRepository, error)
 	GetSubscriptionsStorage() (SubscriptionsRepository, error)
+}
+
+// map of available storage engines with config.StorageProvider as key and function to build the storage engine as value
+var storageEngineBuilders = make(map[config.StorageProvider]func(*logrus.Entry, config.PluggableStorageEngine) (StorageEngine, error))
+
+// RegisterStorageEngine registers a new storage engine
+func RegisterStorageEngine(name config.StorageProvider, builder func(*logrus.Entry, config.PluggableStorageEngine) (StorageEngine, error)) {
+	storageEngineBuilders[name] = builder
+}
+
+func GetEngineBuilder(name config.StorageProvider) func(*logrus.Entry, config.PluggableStorageEngine) (StorageEngine, error) {
+	return storageEngineBuilders[name]
 }

--- a/pkg/storage/postgres/engine.go
+++ b/pkg/storage/postgres/engine.go
@@ -8,6 +8,12 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+func init() {
+	storage.RegisterStorageEngine(config.Postgres, func(logger *log.Entry, conf config.PluggableStorageEngine) (storage.StorageEngine, error) {
+		return NewStorageEngine(logger, conf.Postgres)
+	})
+}
+
 const (
 	CA_DB_NAME     = "ca"
 	DEVICE_DB_NAME = "devicemanager"

--- a/pkg/test/subsystems/storage/couchdb/couchdb.go
+++ b/pkg/test/subsystems/storage/couchdb/couchdb.go
@@ -1,3 +1,6 @@
+//go:build experimental
+// +build experimental
+
 package couchdb_test
 
 import (


### PR DESCRIPTION
This pull request aims to provide more flexibility and control over the build process of Lamassu by introducing two new build tags: **experimental** and **windows**.

- **Experimental Tag**: This tag is designed to control the inclusion of experimental features in the build. By default, these features are not included in the build. However, if you want to include them, you can do so by specifying the experimental tag in the build command. Currently, the CouchDB storage engine is considered an experimental feature and will be excluded from the build if the experimental tag is not present.

 `go build -tag experimental` enables experimental features

**- Windows Tag**: This tag is intended to handle platform-specific compatibility issues. When the windows tag is present in the build command, any functionality that is not compatible with Windows will be removed from the build. Currently, the PKCS11 crypto engine is not compatible with Windows and will be excluded from the build when the windows tag is specified.

`go build -tag windows` disables windows incompatible features

These changes will allow developers to customize their Lamassu builds according to their needs and the target platform. It will also help to maintain a more stable and reliable codebase by keeping experimental features separate from the main build.