### PR TITLE
Bug: Missing bookmark filter separator

### DIFF
--- a/pkg/storage/postgres/utils.go
+++ b/pkg/storage/postgres/utils.go
@@ -153,13 +153,13 @@ func (db *postgresDBQuerier[E]) SelectAll(ctx context.Context, queryParams *reso
 
 			if queryParams.Sort.SortField != "" {
 				sortBy = queryParams.Sort.SortField
-				nextBookmark = nextBookmark + fmt.Sprintf("sortM:%s;sortB:%s", sortMode, sortBy)
+				nextBookmark = nextBookmark + fmt.Sprintf("sortM:%s;sortB:%s;", sortMode, sortBy)
 				tx = tx.Order(sortBy + " " + sortMode)
 			}
 
 			for _, filter := range queryParams.Filters {
 				tx = FilterOperandToWhereClause(filter, tx)
-				nextBookmark = nextBookmark + fmt.Sprintf("filter:%s-%d-%s", base64.StdEncoding.EncodeToString([]byte(filter.Field)), filter.FilterOperation, base64.StdEncoding.EncodeToString([]byte(filter.Value)))
+				nextBookmark = nextBookmark + fmt.Sprintf("filter:%s-%d-%s;", base64.StdEncoding.EncodeToString([]byte(filter.Field)), filter.FilterOperation, base64.StdEncoding.EncodeToString([]byte(filter.Value)))
 			}
 
 		} else {


### PR DESCRIPTION
# Pull Request Template

## Description

Currently, if a bookmark contained a filter, it would generate an invalid bookmark such as: off:1;lim:1;sortM:desc;sortB:creation_timestampfilter:aWQ=-3-dGVzdA== 

Instead, the bookmark should be:
off:1;lim:1;sortM:desc;sortB:creation_timestamp;filter:aWQ=-3-dGVzdA== 

Note the missing **;** between sortB and filter key words

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation

- [ ] REQUIRES updating the documentation
- [X] DOES NOT require updating the documentation

## Helm Chart

Note that image bumping (updating a pod/container image tag) DOES NOT require updating the helm chart, since this is related to the Release lifecycle

- [ ] REQUIRES updating the helm chart
- [X] DOES NOT require updating the helm chart 

## UI

- [ ] REQUIRES updating the UI with new fuctionalities
- [X] DOES NOT require updating UI with new fuctionalities