### PR TITLE
Bugfix: Add  filters in bookmark when requestd with bookmark already containing filters

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1,0 +1,39 @@
+name: "DEV Release Workflow: (ONLY creates docker images with dev tag)"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build_docker_image:
+    strategy:
+      matrix:
+        service: [ca, devmanager, dmsmanager, va, alerts, aws-connector]
+    name: ${{ matrix.service }} - Release docker images
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: main
+      - run: |
+          echo "SHA1VER=dev-$(git rev-parse HEAD)" >> $GITHUB_ENV
+          
+      - name: Login to Github Registry
+        uses: docker/login-action@v3 
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build ${{ matrix.service }} DEV docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ci/${{ matrix.service }}.dockerfile
+          build-args: |
+            BASE_IMAGE=alpine:3.14
+            SHA1VER=${{ env.SHA1VER }}
+            VERSION=dev
+          tags: |
+            ghcr.io/lamassuiot/lamassu-${{ matrix.service }}:dev
+          push: true

--- a/pkg/storage/postgres/utils.go
+++ b/pkg/storage/postgres/utils.go
@@ -220,6 +220,8 @@ func (db *postgresDBQuerier[E]) SelectAll(ctx context.Context, queryParams *reso
 							FilterOperation: resources.FilterOperation(operand),
 							Value:           string(value),
 						}, tx)
+
+						nextBookmark = nextBookmark + fmt.Sprintf("filter:%s-%d-%s;", base64.StdEncoding.EncodeToString([]byte(filter.Field)), filter.FilterOperation, base64.StdEncoding.EncodeToString([]byte(filter.Value)))
 					}
 				}
 				if sortMode != "" && sortBy != "" {
@@ -229,7 +231,7 @@ func (db *postgresDBQuerier[E]) SelectAll(ctx context.Context, queryParams *reso
 			nextBookmark = fmt.Sprintf("off:%d;lim:%d;", offset+limit, limit)
 			if queryParams.Sort.SortField != "" {
 				sortBy = queryParams.Sort.SortField
-				nextBookmark = nextBookmark + fmt.Sprintf("sortM:%s;sortB:%s", sortMode, sortBy)
+				nextBookmark = nextBookmark + fmt.Sprintf("sortM:%s;sortB:%s;", sortMode, sortBy)
 			}
 		}
 	}


### PR DESCRIPTION
# Pull Request Template

## Description

Currently, if a bookmark contains a filter, it would be not included on the newly generated bookmark, rendering the newly string "usless" .

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation

- [ ] REQUIRES updating the documentation
- [X] DOES NOT require updating the documentation

### Sections to update

If documentation changes are required, indicate which sections should be updated

## Helm Chart

Note that image bumping (updating a pod/container image tag) DOES NOT require updating the helm chart, since this is related to the Release lifecycle

- [ ] REQUIRES updating the helm chart
- [X] DOES NOT require updating the helm chart 

## UI

- [ ] REQUIRES updating the UI with new fuctionalities
- [X] DOES NOT require updating UI with new fuctionalities

### Sections to update

If UI changes are required, indicate which sections should be updated
