### PR TITLE
Bugfix: Update device status when certifiate is updated to Active from Revoked status

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1,0 +1,39 @@
+name: "DEV Release Workflow: (ONLY creates docker images with dev tag)"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build_docker_image:
+    strategy:
+      matrix:
+        service: [ca, devmanager, dmsmanager, va, alerts, aws-connector]
+    name: ${{ matrix.service }} - Release docker images
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: main
+      - run: |
+          echo "SHA1VER=dev-$(git rev-parse HEAD)" >> $GITHUB_ENV
+          
+      - name: Login to Github Registry
+        uses: docker/login-action@v3 
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build ${{ matrix.service }} DEV docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ci/${{ matrix.service }}.dockerfile
+          build-args: |
+            BASE_IMAGE=alpine:3.14
+            SHA1VER=${{ env.SHA1VER }}
+            VERSION=dev
+          tags: |
+            ghcr.io/lamassuiot/lamassu-${{ matrix.service }}:dev
+          push: true

--- a/pkg/services/handlers/device-handlers.go
+++ b/pkg/services/handlers/device-handlers.go
@@ -65,9 +65,16 @@ func updateCertStatusHandler(event *event.Event, svc services.DeviceManagerServi
 		updated = true
 		dev.IdentitySlot.Status = models.SlotExpired
 	}
+
 	if cert.Updated.Status == models.StatusRevoked {
 		updated = true
 		dev.IdentitySlot.Status = models.SlotRevoke
+	}
+
+	//This should be the case when the certificate is un-revoked/reinstated (from the OnHold revocation reason)
+	if cert.Updated.Status == models.StatusActive {
+		updated = true
+		dev.IdentitySlot.Status = models.SlotActive
 	}
 
 	if updated {


### PR DESCRIPTION
# Pull Request Template

## Description

Update device status from Revoked to Active when a certificate is reactivated. This can only happen when a certificate was revoked with the "on-hold" status and is then reactivated.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation

- [ ] REQUIRES updating the documentation
- [X] DOES NOT require updating the documentation

## Helm Chart

Note that image bumping (updating a pod/container image tag) DOES NOT require updating the helm chart, since this is related to the Release lifecycle

- [ ] REQUIRES updating the helm chart
- [X] DOES NOT require updating the helm chart 

## UI

- [ ] REQUIRES updating the UI with new fuctionalities
- [X] DOES NOT require updating UI with new fuctionalities