### PR TITLE
fix: Alerts: add missing SMTP config to service builder

### DIFF
--- a/pkg/assemblers/alerts.go
+++ b/pkg/assemblers/alerts.go
@@ -45,9 +45,10 @@ func AssembleAlertsService(conf config.AlertsConfig) (*services.AlertsService, e
 	}
 
 	svc := services.NewAlertsService(services.AlertsServiceBuilder{
-		Logger:       lSvc,
-		SubsStorage:  subStorage,
-		EventStorage: eventStore,
+		Logger:           lSvc,
+		SubsStorage:      subStorage,
+		EventStorage:     eventStore,
+		SmtpServerConfig: conf.SMTPConfig,
 	})
 
 	if conf.SubscriberEventBus.Enabled {


### PR DESCRIPTION
# Pull Request Template

## Description

This PR adds the missing SMTP configuration that the Alerts service builder needs on the assembler.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Documentation

- [ ] DOES NOT require updating the documentation

## Helm Chart

Note that image bumping (updating a pod/container image tag) DOES NOT require updating the helm chart, since this is related to the Release lifecycle

- [ ] DOES NOT require updating the helm chart 

## UI

- [ ] DOES NOT require updating UI with new fuctionalities
