### PR TITLE
test: EST: add new test to the EST routes and controller

### DIFF
--- a/pkg/controllers/est.go
+++ b/pkg/controllers/est.go
@@ -48,7 +48,11 @@ type aps struct {
 
 func (r *estHttpRoutes) GetCACerts(ctx *gin.Context) {
 	var params aps
-	ctx.ShouldBindUri(&params)
+	err := ctx.ShouldBindUri(&params)
+	if err != nil {
+		ctx.JSON(400, gin.H{"err": err.Error()})
+		return
+	}
 
 	cacerts, err := r.svc.CACerts(ctx, params.APS)
 	if err != nil {

--- a/pkg/routes/est_test.go
+++ b/pkg/routes/est_test.go
@@ -1,0 +1,415 @@
+package routes
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	smock "github.com/lamassuiot/lamassuiot/v2/pkg/services/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestEnrollReenroll(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	csr, err := os.ReadFile("../helpers/testdata/samplecsr.pem")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	csrDERBlock, _ := pem.Decode(csr)
+
+	tests := []struct {
+		name           string
+		url            string
+		contentType    string
+		accept         string
+		body           string
+		expectedStatus int
+		expectedError  string
+		mockSetup      func(*smock.MockESTService)
+		resultCheck    func(*testing.T, *smock.MockESTService, *http.Response)
+	}{
+		{
+			name:           "Enroll success pkcs7",
+			url:            "/.well-known/est/aps/simpleenroll",
+			accept:         "",
+			contentType:    "application/pkcs10",
+			body:           base64.StdEncoding.EncodeToString(csrDERBlock.Bytes),
+			expectedStatus: http.StatusOK,
+			mockSetup: func(m *smock.MockESTService) {
+				m.On("Enroll", mock.Anything, mock.Anything, "aps").Return(&x509.Certificate{}, nil)
+			},
+			resultCheck: func(t *testing.T, m *smock.MockESTService, res *http.Response) {
+				assert.Equal(t, "application/pkcs7-mime; smime-type=certs-only", res.Header.Get("Content-Type"))
+				m.AssertExpectations(t)
+			},
+		},
+		{
+			name:           "Enroll error without aps",
+			url:            "/.well-known/est/simpleenroll",
+			accept:         "",
+			contentType:    "application/pkcs10",
+			body:           base64.StdEncoding.EncodeToString(csrDERBlock.Bytes),
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "Field validation for 'APS'",
+			mockSetup: func(m *smock.MockESTService) {
+				m.On("Enroll", mock.Anything, mock.Anything, "aps").Return(&x509.Certificate{}, nil)
+			},
+			resultCheck: func(t *testing.T, m *smock.MockESTService, res *http.Response) {
+				m.AssertNotCalled(t, "Enroll")
+			},
+		},
+		{
+			name:           "Enroll success pem",
+			url:            "/.well-known/est/aps/simpleenroll",
+			accept:         "application/x-pem-file",
+			contentType:    "application/pkcs10",
+			body:           base64.StdEncoding.EncodeToString(csrDERBlock.Bytes),
+			expectedStatus: http.StatusOK,
+			mockSetup: func(m *smock.MockESTService) {
+				m.On("Enroll", mock.Anything, mock.Anything, "aps").Return(&x509.Certificate{}, nil)
+			},
+			resultCheck: func(t *testing.T, m *smock.MockESTService, res *http.Response) {
+				assert.Equal(t, "application/x-pem-file", res.Header.Get("Content-Type"))
+				m.AssertExpectations(t)
+			},
+		},
+		{
+			name:           "ReEnroll success pkcs7",
+			url:            "/.well-known/est/aps/simplereenroll",
+			accept:         "",
+			contentType:    "application/pkcs10",
+			body:           base64.StdEncoding.EncodeToString(csrDERBlock.Bytes),
+			expectedStatus: http.StatusOK,
+			mockSetup: func(m *smock.MockESTService) {
+				m.On("Reenroll", mock.Anything, mock.Anything, "aps").Return(&x509.Certificate{}, nil)
+			},
+			resultCheck: func(t *testing.T, m *smock.MockESTService, res *http.Response) {
+				assert.Equal(t, "application/pkcs7-mime; smime-type=certs-only", res.Header.Get("Content-Type"))
+				m.AssertExpectations(t)
+			},
+		},
+		{
+			name:           "ReEnroll error without aps",
+			url:            "/.well-known/est/simplereenroll",
+			accept:         "",
+			contentType:    "application/pkcs10",
+			body:           base64.StdEncoding.EncodeToString(csrDERBlock.Bytes),
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "Field validation for 'APS'",
+			mockSetup: func(m *smock.MockESTService) {
+				m.On("Enroll", mock.Anything, mock.Anything, "aps").Return(&x509.Certificate{}, nil)
+			},
+			resultCheck: func(t *testing.T, m *smock.MockESTService, res *http.Response) {
+				m.AssertNotCalled(t, "Enroll")
+			},
+		},
+		{
+			name:           "ReEnroll success pem",
+			url:            "/.well-known/est/aps/simplereenroll",
+			accept:         "application/x-pem-file",
+			contentType:    "application/pkcs10",
+			body:           base64.StdEncoding.EncodeToString(csrDERBlock.Bytes),
+			expectedStatus: http.StatusOK,
+			mockSetup: func(m *smock.MockESTService) {
+				m.On("Reenroll", mock.Anything, mock.Anything, "aps").Return(&x509.Certificate{}, nil)
+			},
+			resultCheck: func(t *testing.T, m *smock.MockESTService, res *http.Response) {
+				assert.Equal(t, "application/x-pem-file", res.Header.Get("Content-Type"))
+				m.AssertExpectations(t)
+			},
+		},
+		{
+			name:           "Invalid content type",
+			url:            "/.well-known/est/aps/simpleenroll",
+			accept:         "",
+			contentType:    "application/json",
+			body:           base64.StdEncoding.EncodeToString(csrDERBlock.Bytes),
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "content-type must be application/pkcs10",
+			mockSetup:      func(m *smock.MockESTService) {},
+			resultCheck:    func(t *testing.T, m *smock.MockESTService, res *http.Response) {},
+		},
+		{
+			name:           "Enroll error",
+			url:            "/.well-known/est/aps/simpleenroll",
+			accept:         "",
+			contentType:    "application/pkcs10",
+			body:           base64.StdEncoding.EncodeToString(csrDERBlock.Bytes),
+			expectedStatus: http.StatusInternalServerError,
+			expectedError:  "enroll error",
+			mockSetup: func(m *smock.MockESTService) {
+				m.On("Enroll", mock.Anything, mock.Anything, "aps").Return((*x509.Certificate)(nil), errors.New("enroll error"))
+			},
+			resultCheck: func(t *testing.T, m *smock.MockESTService, res *http.Response) {},
+		},
+		{
+			name:           "Invalid content type",
+			url:            "/.well-known/est/aps/simplereenroll",
+			accept:         "",
+			contentType:    "application/json",
+			body:           base64.StdEncoding.EncodeToString(csrDERBlock.Bytes),
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "content-type must be application/pkcs10",
+			mockSetup:      func(m *smock.MockESTService) {},
+			resultCheck:    func(t *testing.T, m *smock.MockESTService, res *http.Response) {},
+		},
+		{
+			name:           "Enroll error",
+			url:            "/.well-known/est/aps/simplereenroll",
+			accept:         "",
+			contentType:    "application/pkcs10",
+			body:           base64.StdEncoding.EncodeToString(csrDERBlock.Bytes),
+			expectedStatus: http.StatusInternalServerError,
+			expectedError:  "reenroll error",
+			mockSetup: func(m *smock.MockESTService) {
+				m.On("Reenroll", mock.Anything, mock.Anything, "aps").Return((*x509.Certificate)(nil), errors.New("reenroll error"))
+			},
+			resultCheck: func(t *testing.T, m *smock.MockESTService, res *http.Response) {},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockSvc := new(smock.MockESTService)
+			tt.mockSetup(mockSvc)
+
+			r := gin.Default()
+			baseGrp := r.Group(("/"))
+			NewESTHttpRoutes(nil, baseGrp, mockSvc)
+
+			req, _ := http.NewRequest(http.MethodPost, tt.url, bytes.NewBufferString(tt.body))
+			if tt.accept != "" {
+				req.Header.Set("Accept", tt.accept)
+			}
+			if tt.contentType != "" {
+				req.Header.Set("Content-Type", tt.contentType)
+			}
+			w := httptest.NewRecorder()
+
+			r.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			if tt.expectedError != "" {
+				assert.Contains(t, w.Body.String(), tt.expectedError)
+			}
+			tt.resultCheck(t, mockSvc, w.Result())
+		})
+	}
+}
+
+func TestServerKeyGen(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	csr, err := os.ReadFile("../helpers/testdata/samplecsr.pem")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	csrDERBlock, _ := pem.Decode(csr)
+
+	tests := []struct {
+		name           string
+		url            string
+		contentType    string
+		accept         string
+		body           string
+		expectedStatus int
+		expectedError  string
+		mockSetup      func(*smock.MockESTService)
+		resultCheck    func(*testing.T, *smock.MockESTService, *http.Response)
+	}{
+		{
+			name:           "ServerKeyGen success",
+			url:            "/.well-known/est/aps/serverkeygen",
+			accept:         "",
+			contentType:    "application/pkcs10",
+			body:           base64.StdEncoding.EncodeToString(csrDERBlock.Bytes),
+			expectedStatus: http.StatusOK,
+			mockSetup: func(m *smock.MockESTService) {
+				privkey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err)
+				}
+				m.On("ServerKeyGen", mock.Anything, mock.Anything, "aps").Return(&x509.Certificate{}, privkey, nil)
+			},
+			resultCheck: func(t *testing.T, m *smock.MockESTService, res *http.Response) {
+				assert.Equal(t, "multipart/mixed; boundary=estServerLamassuBoundary", res.Header.Get("Content-Type"))
+
+				_, params, _ := mime.ParseMediaType(res.Header.Get("Content-Type"))
+				mr := multipart.NewReader(res.Body, params["boundary"])
+				part, err := mr.NextPart()
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err)
+				}
+				assert.Equal(t, "application/pkcs8", part.Header.Get("Content-Type"))
+
+				part, err = mr.NextPart()
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err)
+				}
+				assert.Equal(t, "application/pkcs7-mime; smime-type=certs-only", part.Header.Get("Content-Type"))
+
+				m.AssertExpectations(t)
+			},
+		},
+		{
+			name:           "ServerKeyGen error without aps",
+			url:            "/.well-known/est/serverkeygen",
+			accept:         "",
+			contentType:    "application/pkcs10",
+			body:           base64.StdEncoding.EncodeToString(csrDERBlock.Bytes),
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "Field validation for 'APS'",
+			mockSetup: func(m *smock.MockESTService) {
+				privkey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err)
+				}
+				m.On("ServerKeyGen", mock.Anything, mock.Anything, "aps").Return(&x509.Certificate{}, privkey, nil)
+			},
+			resultCheck: func(t *testing.T, m *smock.MockESTService, res *http.Response) {
+				m.AssertNotCalled(t, "ServerKeyGen")
+			},
+		},
+		{
+			name:           "Invalid content type",
+			url:            "/.well-known/est/aps/serverkeygen",
+			accept:         "",
+			contentType:    "application/json",
+			body:           base64.StdEncoding.EncodeToString(csrDERBlock.Bytes),
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "content-type must be application/pkcs10",
+			mockSetup:      func(m *smock.MockESTService) {},
+			resultCheck:    func(t *testing.T, m *smock.MockESTService, res *http.Response) {},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockSvc := new(smock.MockESTService)
+			tt.mockSetup(mockSvc)
+
+			r := gin.Default()
+			baseGrp := r.Group(("/"))
+			NewESTHttpRoutes(nil, baseGrp, mockSvc)
+
+			req, _ := http.NewRequest(http.MethodPost, tt.url, bytes.NewBufferString(tt.body))
+			if tt.accept != "" {
+				req.Header.Set("Accept", tt.accept)
+			}
+			if tt.contentType != "" {
+				req.Header.Set("Content-Type", tt.contentType)
+			}
+			w := httptest.NewRecorder()
+
+			r.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			if tt.expectedError != "" {
+				assert.Contains(t, w.Body.String(), tt.expectedError)
+			}
+			tt.resultCheck(t, mockSvc, w.Result())
+		})
+	}
+}
+
+func TestCACerts(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name           string
+		url            string
+		contentType    string
+		accept         string
+		expectedStatus int
+		expectedError  string
+		mockSetup      func(*smock.MockESTService)
+		resultCheck    func(*testing.T, *smock.MockESTService, *http.Response)
+	}{
+		{
+			name:           "cacerts success",
+			url:            "/.well-known/est/aps/cacerts",
+			accept:         "",
+			contentType:    "",
+			expectedStatus: http.StatusOK,
+			mockSetup: func(m *smock.MockESTService) {
+				m.On("CACerts", mock.Anything, "aps").Return([]*x509.Certificate{}, nil)
+			},
+			resultCheck: func(t *testing.T, m *smock.MockESTService, res *http.Response) {
+				assert.Equal(t, "application/pkcs7-mime; smime-type=certs-only", res.Header.Get("Content-Type"))
+				m.AssertExpectations(t)
+			},
+		},
+		{
+			name:           "cacerts success pem",
+			url:            "/.well-known/est/aps/cacerts",
+			accept:         "application/x-pem-file",
+			contentType:    "",
+			expectedStatus: http.StatusOK,
+			mockSetup: func(m *smock.MockESTService) {
+				m.On("CACerts", mock.Anything, "aps").Return([]*x509.Certificate{}, nil)
+			},
+			resultCheck: func(t *testing.T, m *smock.MockESTService, res *http.Response) {
+				assert.Equal(t, "application/x-pem-file", res.Header.Get("Content-Type"))
+				m.AssertExpectations(t)
+			},
+		},
+		{
+			name:           "cacerts error without aps",
+			url:            "/.well-known/est/cacerts",
+			accept:         "",
+			contentType:    "",
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "Field validation for 'APS'",
+			mockSetup: func(m *smock.MockESTService) {
+				m.On("CACerts", mock.Anything, "aps").Return([]*x509.Certificate{}, nil)
+			},
+			resultCheck: func(t *testing.T, m *smock.MockESTService, res *http.Response) {
+				m.AssertNotCalled(t, "CACerts")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockSvc := new(smock.MockESTService)
+			tt.mockSetup(mockSvc)
+
+			r := gin.Default()
+			baseGrp := r.Group(("/"))
+			NewESTHttpRoutes(nil, baseGrp, mockSvc)
+
+			req, _ := http.NewRequest(http.MethodGet, tt.url, nil)
+			if tt.accept != "" {
+				req.Header.Set("Accept", tt.accept)
+			}
+			if tt.contentType != "" {
+				req.Header.Set("Content-Type", tt.contentType)
+			}
+			w := httptest.NewRecorder()
+
+			r.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			if tt.expectedError != "" {
+				assert.Contains(t, w.Body.String(), tt.expectedError)
+			}
+			tt.resultCheck(t, mockSvc, w.Result())
+		})
+	}
+}

--- a/pkg/services/mock/est_mock.go
+++ b/pkg/services/mock/est_mock.go
@@ -1,0 +1,32 @@
+package mock
+
+import (
+	"context"
+	"crypto/x509"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type MockESTService struct {
+	mock.Mock
+}
+
+func (m *MockESTService) Enroll(ctx context.Context, csr *x509.CertificateRequest, aps string) (*x509.Certificate, error) {
+	args := m.Called(ctx, csr, aps)
+	return args.Get(0).(*x509.Certificate), args.Error(1)
+}
+
+func (m *MockESTService) Reenroll(ctx context.Context, csr *x509.CertificateRequest, aps string) (*x509.Certificate, error) {
+	args := m.Called(ctx, csr, aps)
+	return args.Get(0).(*x509.Certificate), args.Error(1)
+}
+
+func (m *MockESTService) CACerts(ctx context.Context, aps string) ([]*x509.Certificate, error) {
+	args := m.Called(ctx, aps)
+	return args.Get(0).([]*x509.Certificate), args.Error(1)
+}
+
+func (m *MockESTService) ServerKeyGen(ctx context.Context, csr *x509.CertificateRequest, aps string) (*x509.Certificate, interface{}, error) {
+	args := m.Called(ctx, csr, aps)
+	return args.Get(0).(*x509.Certificate), args.Get(1), args.Error(2)
+}


### PR DESCRIPTION
## Description

This PR mainly adds new tests on the EST routes and controller using an EST mock service. It ensures that the EST endpoints respond with the correct headers. 

A minor fix is included in the CACerts endpoint to match to the behaviour of the rest of endpoints. It will now fail if no APS context is provided. 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue) & TESTS
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation

- [ ] REQUIRES updating the documentation
- [ X] DOES NOT require updating the documentation

### Sections to update

No

## Helm Chart

Note that image bumping (updating a pod/container image tag) DOES NOT require updating the helm chart, since this is related to the Release lifecycle

- [ ] REQUIRES updating the helm chart
- [ X] DOES NOT require updating the helm chart 

## UI

- [ ] REQUIRES updating the UI with new fuctionalities
- [ X] DOES NOT require updating UI with new fuctionalities

### Sections to update

No
