### PR TITLE
feat: DMS: Allow enrollment with expired certificates

### DIFF
--- a/pkg/assemblers/dms-manager_test.go
+++ b/pkg/assemblers/dms-manager_test.go
@@ -754,7 +754,7 @@ func TestESTEnroll(t *testing.T) {
 
 				dms, err := createDMS(func(in *services.CreateDMSInput) {
 					in.Settings.EnrollmentSettings.EnrollmentCA = enrollCA.ID
-					in.Settings.EnrollmentSettings.EnableExpiredRenewal = true
+					in.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthOptionsMTLS.AllowExpired = true
 					in.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthOptionsMTLS.ValidationCAs = []string{
 						bootstrapCA.ID,
 					}
@@ -905,7 +905,7 @@ func TestESTEnroll(t *testing.T) {
 
 				dms, err := createDMS(func(in *services.CreateDMSInput) {
 					in.Settings.EnrollmentSettings.EnrollmentCA = enrollCA.ID
-					in.Settings.EnrollmentSettings.EnableExpiredRenewal = true
+					in.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthOptionsMTLS.AllowExpired = true
 					in.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthOptionsMTLS.ValidationCAs = []string{
 						bootstrapCA.ID,
 					}

--- a/pkg/models/dms.go
+++ b/pkg/models/dms.go
@@ -64,6 +64,7 @@ type EnrollmentSettings struct {
 	DeviceProvisionProfile      DeviceProvisionProfile      `json:"device_provisioning_profile"`
 	EnrollmentCA                string                      `json:"enrollment_ca"`
 	EnableReplaceableEnrollment bool                        `json:"enable_replaceable_enrollment"` //switch-like option that enables enrolling, already enrolled devices
+	EnableExpiredRenewal        bool                        `json:"enable_expired_renewal"`        // switch-like option that enables renewing expired certificates
 	RegistrationMode            RegistrationMode            `json:"registration_mode"`
 }
 

--- a/pkg/models/dms.go
+++ b/pkg/models/dms.go
@@ -64,7 +64,6 @@ type EnrollmentSettings struct {
 	DeviceProvisionProfile      DeviceProvisionProfile      `json:"device_provisioning_profile"`
 	EnrollmentCA                string                      `json:"enrollment_ca"`
 	EnableReplaceableEnrollment bool                        `json:"enable_replaceable_enrollment"` //switch-like option that enables enrolling, already enrolled devices
-	EnableExpiredRenewal        bool                        `json:"enable_expired_renewal"`        // switch-like option that enables renewing expired certificates
 	RegistrationMode            RegistrationMode            `json:"registration_mode"`
 }
 
@@ -76,6 +75,7 @@ type EnrollmentOptionsESTRFC7030 struct {
 type AuthOptionsClientCertificate struct {
 	ValidationCAs        []string `json:"validation_cas"`
 	ChainLevelValidation int      `json:"chain_level_validation"`
+	AllowExpired         bool     `json:"allow_expired"` // switch-like option that allows the use of expired certificates
 }
 
 type ReEnrollmentSettings struct {

--- a/pkg/services/dmsmanager.go
+++ b/pkg/services/dmsmanager.go
@@ -292,7 +292,7 @@ func (svc DMSManagerServiceBackend) Enroll(ctx context.Context, csr *x509.Certif
 
 		// Allow enrolment with expired certificates
 		allowExpiredEnroll := false
-		if dms.Settings.EnrollmentSettings.EnableExpiredRenewal {
+		if dms.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthOptionsMTLS.AllowExpired {
 			lFunc.Warnf("Enrollment with expired certificates is allowed at %s", dms.ID)
 			allowExpiredEnroll = true
 		}

--- a/pkg/services/dmsmanager.go
+++ b/pkg/services/dmsmanager.go
@@ -289,6 +289,14 @@ func (svc DMSManagerServiceBackend) Enroll(ctx context.Context, csr *x509.Certif
 		validCertificate := false
 		var validationCA *models.CACertificate
 		estEnrollOpts := dms.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030
+
+		// Allow enrolment with expired certificates
+		allowExpiredEnroll := false
+		if dms.Settings.EnrollmentSettings.EnableExpiredRenewal {
+			lFunc.Warnf("Enrollment with expired certificates is allowed at %s", dms.ID)
+			allowExpiredEnroll = true
+		}
+
 		for _, caID := range estEnrollOpts.AuthOptionsMTLS.ValidationCAs {
 			ca, err := svc.caClient.GetCAByID(ctx, GetCAByIDInput{CAID: caID})
 			if err != nil {
@@ -296,7 +304,7 @@ func (svc DMSManagerServiceBackend) Enroll(ctx context.Context, csr *x509.Certif
 				continue
 			}
 
-			err = helpers.ValidateCertificate((*x509.Certificate)(ca.Certificate.Certificate), clientCert, true)
+			err = helpers.ValidateCertificate((*x509.Certificate)(ca.Certificate.Certificate), clientCert, !allowExpiredEnroll)
 			if err != nil {
 				lFunc.Debugf("invalid validation using CA [%s] with CommonName '%s', SerialNumber '%s'", ca.ID, ca.Subject.CommonName, ca.SerialNumber)
 			} else {


### PR DESCRIPTION
## Description
This PR introduces a new feature that allows the enrollment of devices using expired certificates. This behavior can be configured at the DMS level, providing flexibility in device onboarding processes. The change enhances our system's capability to handle various certificate scenarios, potentially improving device management in environments where certificate renewal might be challenging.

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation
- [x] REQUIRES updating the documentation
- [ ] DOES NOT require updating the documentation

### Sections to update
If documentation changes are required, indicate which sections should be updated

The following documentation sections should be updated:
- DMS Configuration

## Helm Chart
Note that image bumping (updating a pod/container image tag) DOES NOT require updating the helm chart, since this is related to the Release lifecycle
- [ ] REQUIRES updating the helm chart
- [x] DOES NOT require updating the helm chart 

## UI
- [x] REQUIRES updating the UI with new fuctionalities
- [ ] DOES NOT require updating UI with new fuctionalities

### Sections to update
If UI changes are required, indicate which sections should be updated

The UI changes should include:
- DMS Configuration page: Add a new option to enable/disable enrollment with expired certificates
