### PR TITLE
fix: DMS Manager: return empty struct instead of nil for non-configured ServerKeyGen settings

### DIFF
--- a/pkg/assemblers/dms-manager_test.go
+++ b/pkg/assemblers/dms-manager_test.go
@@ -1395,7 +1395,7 @@ func TestESTServerKeyGen(t *testing.T) {
 			Name:     "MyIotFleet",
 			Metadata: map[string]any{},
 			Settings: models.DMSSettings{
-				ServerKeyGen: &models.ServerKeyGenSettings{
+				ServerKeyGen: models.ServerKeyGenSettings{
 					Enabled: true,
 					Key: models.ServerKeyGenKey{
 						Type: models.KeyType(x509.RSA),
@@ -1653,7 +1653,9 @@ func TestESTServerKeyGen(t *testing.T) {
 				}
 
 				dms, err := createDMS(func(in *services.CreateDMSInput) {
-					in.Settings.ServerKeyGen = nil
+					in.Settings.ServerKeyGen = models.ServerKeyGenSettings{
+						Enabled: false,
+					}
 
 					in.Settings.EnrollmentSettings.EnrollmentCA = enrollCA.ID
 					in.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthOptionsMTLS.ValidationCAs = []string{

--- a/pkg/models/dms.go
+++ b/pkg/models/dms.go
@@ -22,7 +22,7 @@ type DMS struct {
 }
 
 type DMSSettings struct {
-	ServerKeyGen           *ServerKeyGenSettings  `json:"server_keygen_settings"`
+	ServerKeyGen           ServerKeyGenSettings   `json:"server_keygen_settings"`
 	EnrollmentSettings     EnrollmentSettings     `json:"enrollment_settings"`
 	ReEnrollmentSettings   ReEnrollmentSettings   `json:"reenrollment_settings"`
 	CADistributionSettings CADistributionSettings `json:"ca_distribution_settings"`

--- a/pkg/services/dmsmanager.go
+++ b/pkg/services/dmsmanager.go
@@ -697,7 +697,7 @@ func (svc DMSManagerServiceBackend) ServerKeyGen(ctx context.Context, csr *x509.
 		return nil, nil, err
 	}
 
-	if dms.Settings.ServerKeyGen == nil || !dms.Settings.ServerKeyGen.Enabled {
+	if !dms.Settings.ServerKeyGen.Enabled {
 		lFunc.Errorf("server key generation not enabled for DMS: %s", aps)
 		return nil, nil, fmt.Errorf("server key generation not enabled")
 	}


### PR DESCRIPTION
# Pull Request Template

## Description

Nil should't be used to indicate non-setted values. Instead rely on the `enabled` property within the struct object to check if the prop is correctly configured.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation

- [ ] REQUIRES updating the documentation
- [X] DOES NOT require updating the documentation

### Sections to update

If documentation changes are required, indicate which sections should be updated

## Helm Chart

Note that image bumping (updating a pod/container image tag) DOES NOT require updating the helm chart, since this is related to the Release lifecycle

- [ ] REQUIRES updating the helm chart
- [X] DOES NOT require updating the helm chart 

## UI

- [ ] REQUIRES updating the UI with new fuctionalities
- [X] DOES NOT require updating UI with new fuctionalities

### Sections to update

If UI changes are required, indicate which sections should be updated
