### PR TITLE
Fix tests: Signature Sign & Verify

### DIFF
--- a/backend/pkg/x509engines/x509engine.go
+++ b/backend/pkg/x509engines/x509engine.go
@@ -337,7 +337,7 @@ func (engine X509Engine) Sign(cAssetType CryptoAssetType, certificate *x509.Cert
 				Hash:       hashFunc,
 			})
 			if err != nil {
-				return nil, errs.ErrEngineHashAlgInconsistency
+				return nil, err
 			}
 			return signature, nil
 		} else {


### PR DESCRIPTION
This pull request includes several changes to the `backend/pkg/assemblers/ca_test.go` and `backend/pkg/x509engines/x509engine.go` files, focusing on improving the reliability and accuracy of the certificate authority (CA) testing and signature verification processes. The most important changes include removing an unused import, re-enabling a previously skipped test, and updating the signature verification tests to handle different algorithms and message types.

### Improvements to CA Testing:

* Removed the unused `base64` import in `backend/pkg/assemblers/ca_test.go`.
* Re-enabled the `TestSignatureVerify` test by removing the `t.Skip` call, allowing it to run during testing.

### Enhancements to Signature Verification:

* Updated the `TestSignatureVerify` test to include new test cases for `RSASSA_PSS_SHA_256` and `RSASSA_PKCS1_V1_5_SHA_384` algorithms, and adjusted the message handling to use raw and hashed message types appropriately.
* Modified the error handling in the `Sign` method of `X509Engine` to return the actual error instead of a generic inconsistency error.