### PR TITLE
chore: simplify relese to just one. Remove releases per each module

### DIFF
--- a/.github/workflows/main-release.yaml
+++ b/.github/workflows/main-release.yaml
@@ -203,18 +203,6 @@ jobs:
         with:
           ref: ${{ matrix.module }}/${{ needs.version_info.outputs.release_version_with_v }}
 
-      - name: Create Github Release
-        uses: actions/create-release@v1
-        id: create_release
-        with:
-          draft: false
-          prerelease: false
-          release_name: ${{ matrix.module }}/${{ needs.version_info.outputs.release_version_with_v }}
-          tag_name: ${{ matrix.module }}/${{ needs.version_info.outputs.release_version_with_v }}
-          body_path: RELEASE-NOTES.md
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
   create_gopkg_release:
     name: "Create Go package release"
     needs: [create_module_release, version_info]


### PR DESCRIPTION
This pull request makes changes to the GitHub Actions workflow for the main release process. The primary change is the removal of the step that creates a GitHub release for each module.

Go only requires tagging for each module, not a release per module