### PR TITLE
fix: add json serialization tags to CACertificate struct

### DIFF
--- a/core/pkg/models/ca.go
+++ b/core/pkg/models/ca.go
@@ -58,8 +58,8 @@ type IssuerCAMetadata struct {
 
 type CACertificate struct {
 	ID                      string                 `json:"id"`
-	Certificate             Certificate            `gorm:"foreignKey:CertificateSerialNumber;references:SerialNumber"`
-	CertificateSerialNumber string                 `gorm:"column:serial_number"`
+	Certificate             Certificate            `json:"certificate" gorm:"foreignKey:CertificateSerialNumber;references:SerialNumber"`
+	CertificateSerialNumber string                 `json:"serial_number" gorm:"column:serial_number"`
 	Metadata                map[string]interface{} `json:"metadata" gorm:"serializer:json"`
 	Validity                Validity               `json:"validity" gorm:"embedded;embeddedPrefix:validity_"`
 	CreationTS              time.Time              `json:"creation_ts"`


### PR DESCRIPTION
## Description

This PR fixes an issue introduced at PR #197 where the json encoding tags were not defined.
 