### PR TITLE
Feat: create CAs from external signed CSRs

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   test:
     strategy:
+      max-parallel: 5
       matrix:
         module: 
           - path: core

--- a/backend/pkg/assemblers/ca_csr_test.go
+++ b/backend/pkg/assemblers/ca_csr_test.go
@@ -44,116 +44,7 @@ func getCertificateTemplate(csr x509.CertificateRequest, ec x509.Certificate) x5
 	}
 }
 
-func TestRequestCAWithExternalParent(t *testing.T) {
-	serverTest, err := TestServiceBuilder{}.WithDatabase("ca").WithMonitor().Build(t)
-	if err != nil {
-		t.Fatalf("could not create CA test server: %s", err)
-	}
-
-	externalCACert, privateKey, err := chelpers.GenerateSelfSignedCA(x509.RSA, time.Hour*24, "ExternalCA")
-	if err != nil {
-		t.Fatalf("could not generate external CA: %s", err)
-	}
-
-	ec := models.X509Certificate(*externalCACert)
-
-	importedCACert, err := serverTest.CA.Service.ImportCA(context.Background(), services.ImportCAInput{
-		CACertificate: &ec,
-		CAType:        models.CertificateTypeExternal,
-	})
-	if err != nil {
-		t.Fatalf("could not import external CA: %s", err)
-	}
-
-	requestedCACSR, err := serverTest.CA.Service.RequestCACSR(context.Background(), services.RequestCAInput{
-		KeyMetadata: models.KeyMetadata{Type: models.KeyType(x509.RSA), Bits: 2048},
-		Subject:     models.Subject{CommonName: "MyRequestedCA"},
-		ParentID:    importedCACert.ID,
-	})
-	if err != nil {
-		t.Fatalf("unexpected error. Could not request CA: %s", err)
-	}
-
-	csr := x509.CertificateRequest(requestedCACSR.CSR)
-
-	certificateTemplate := getCertificateTemplate(csr, *externalCACert)
-	certificateTemplate.IsCA = true
-
-	certificateBytes, err := x509.CreateCertificate(rand.Reader, &certificateTemplate, externalCACert, csr.PublicKey, privateKey.(*rsa.PrivateKey))
-	if err != nil {
-		t.Fatalf("could not create the requested CA: %s", err)
-	}
-
-	requestedCertificate, err := x509.ParseCertificate(certificateBytes)
-	if err != nil {
-		t.Fatalf("could not parse the requested CA: %s", err)
-	}
-
-	rcert := models.X509Certificate(*requestedCertificate)
-	importedCertificate, err := serverTest.CA.Service.ImportCA(context.Background(), services.ImportCAInput{
-		CACertificate: &rcert,
-		CARequestID:   requestedCACSR.ID,
-		CAType:        models.CertificateTypeRequested,
-	})
-	if err != nil {
-		t.Fatalf("could not import the requested CA: %s", err)
-	}
-
-	assert.Equal(t, importedCertificate.Certificate.Subject.CommonName, csr.Subject.CommonName)
-	assert.Equal(t, importedCertificate.Certificate.Certificate.Issuer.CommonName, ec.Subject.CommonName)
-}
-
-func TestImportCAWithNoParent(t *testing.T) {
-	serverTest, err := TestServiceBuilder{}.WithDatabase("ca").WithMonitor().Build(t)
-	if err != nil {
-		t.Fatalf("could not create CA test server: %s", err)
-	}
-
-	externalCACert, privateKey, err := chelpers.GenerateSelfSignedCA(x509.RSA, time.Hour*24, "ExternalCA")
-	if err != nil {
-		t.Fatalf("could not generate external CA: %s", err)
-	}
-
-	ec := models.X509Certificate(*externalCACert)
-
-	requestedCACSR, err := serverTest.CA.Service.RequestCACSR(context.Background(), services.RequestCAInput{
-		KeyMetadata: models.KeyMetadata{Type: models.KeyType(x509.RSA), Bits: 2048},
-		Subject:     models.Subject{CommonName: "MyRequestedCA"},
-	})
-	if err != nil {
-		t.Fatalf("unexpected error. Could not request CA: %s", err)
-	}
-
-	csr := x509.CertificateRequest(requestedCACSR.CSR)
-
-	certificateTemplate := getCertificateTemplate(csr, *externalCACert)
-	certificateTemplate.IsCA = true
-
-	certificateBytes, err := x509.CreateCertificate(rand.Reader, &certificateTemplate, externalCACert, csr.PublicKey, privateKey.(*rsa.PrivateKey))
-	if err != nil {
-		t.Fatalf("could not create the requested CA: %s", err)
-	}
-
-	requestedCertificate, err := x509.ParseCertificate(certificateBytes)
-	if err != nil {
-		t.Fatalf("could not parse the requested CA: %s", err)
-	}
-
-	rcert := models.X509Certificate(*requestedCertificate)
-	importedCertificate, err := serverTest.CA.Service.ImportCA(context.Background(), services.ImportCAInput{
-		CACertificate: &rcert,
-		CARequestID:   requestedCACSR.ID,
-		CAType:        models.CertificateTypeRequested,
-	})
-	if err != nil {
-		t.Fatalf("could not import the requested CA: %s", err)
-	}
-
-	assert.Equal(t, importedCertificate.Certificate.Subject.CommonName, csr.Subject.CommonName)
-	assert.Equal(t, importedCertificate.Certificate.Certificate.Issuer.CommonName, ec.Subject.CommonName)
-}
-
-func TestImportCAWithNoRequestAndDiferentCNError(t *testing.T) {
+func TestImportCAWithNoRequestAndDifferentCNError(t *testing.T) {
 	serverTest, err := TestServiceBuilder{}.WithDatabase("ca").WithMonitor().Build(t)
 	if err != nil {
 		t.Fatalf("could not create CA test server: %s", err)
@@ -301,18 +192,9 @@ func TestRequestCADoubleImportError(t *testing.T) {
 
 	ec := models.X509Certificate(*externalCACert)
 
-	importedCACert, err := serverTest.CA.Service.ImportCA(context.Background(), services.ImportCAInput{
-		CACertificate: &ec,
-		CAType:        models.CertificateTypeExternal,
-	})
-	if err != nil {
-		t.Fatalf("could not import external CA: %s", err)
-	}
-
 	requestedCACSR, err := serverTest.CA.Service.RequestCACSR(context.Background(), services.RequestCAInput{
 		KeyMetadata: models.KeyMetadata{Type: models.KeyType(x509.RSA), Bits: 2048},
 		Subject:     models.Subject{CommonName: "MyRequestedCA"},
-		ParentID:    importedCACert.ID,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error. Could not request CA: %s", err)
@@ -366,20 +248,9 @@ func TestImportNonCACertError(t *testing.T) {
 		t.Fatalf("could not generate external CA: %s", err)
 	}
 
-	ec := models.X509Certificate(*externalCACert)
-
-	importedCACert, err := serverTest.CA.Service.ImportCA(context.Background(), services.ImportCAInput{
-		CACertificate: &ec,
-		CAType:        models.CertificateTypeExternal,
-	})
-	if err != nil {
-		t.Fatalf("could not import external CA: %s", err)
-	}
-
 	requestedCACSR, err := serverTest.CA.Service.RequestCACSR(context.Background(), services.RequestCAInput{
 		KeyMetadata: models.KeyMetadata{Type: models.KeyType(x509.RSA), Bits: 2048},
 		Subject:     models.Subject{CommonName: "MyRequestedCA"},
-		ParentID:    importedCACert.ID,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error. Could not request CA: %s", err)
@@ -421,20 +292,9 @@ func TestImportUnexpectedCSRError(t *testing.T) {
 		t.Fatalf("could not generate external CA: %s", err)
 	}
 
-	ec := models.X509Certificate(*externalCACert)
-
-	importedCACert, err := serverTest.CA.Service.ImportCA(context.Background(), services.ImportCAInput{
-		CACertificate: &ec,
-		CAType:        models.CertificateTypeExternal,
-	})
-	if err != nil {
-		t.Fatalf("could not import external CA: %s", err)
-	}
-
 	requestedCACSR, err := serverTest.CA.Service.RequestCACSR(context.Background(), services.RequestCAInput{
 		KeyMetadata: models.KeyMetadata{Type: models.KeyType(x509.RSA), Bits: 2048},
 		Subject:     models.Subject{CommonName: "MyRequestedCA"},
-		ParentID:    importedCACert.ID,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error. Could not request CA: %s", err)
@@ -443,7 +303,6 @@ func TestImportUnexpectedCSRError(t *testing.T) {
 	unexpectedCACSR, err := serverTest.CA.Service.RequestCACSR(context.Background(), services.RequestCAInput{
 		KeyMetadata: models.KeyMetadata{Type: models.KeyType(x509.RSA), Bits: 2048},
 		Subject:     models.Subject{CommonName: "MyRequestedCA"},
-		ParentID:    importedCACert.ID,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error. Could not request CA: %s", err)
@@ -497,37 +356,6 @@ func TestImportNonExistentRequest(t *testing.T) {
 	assert.EqualError(t, err, "CA Request not found")
 }
 
-func TestRequestCAWithManagedParentError(t *testing.T) {
-	serverTest, err := TestServiceBuilder{}.WithDatabase("ca").WithMonitor().Build(t)
-	if err != nil {
-		t.Fatalf("could not create CA test server: %s", err)
-
-	}
-
-	managedCA, err := serverTest.CA.Service.CreateCA(context.Background(), services.CreateCAInput{
-		KeyMetadata: models.KeyMetadata{Type: models.KeyType(x509.RSA), Bits: 2048},
-		Subject:     models.Subject{CommonName: "ManagedCA"},
-		IssuanceExpiration: models.Validity{
-			Type:     models.Duration,
-			Duration: models.TimeDuration(time.Hour * 24),
-		},
-		CAExpiration: models.Validity{
-			Type:     models.Duration,
-			Duration: models.TimeDuration(time.Hour * 24 * 365),
-		},
-	})
-	if err != nil {
-		t.Fatalf("could not create managed CA: %s", err)
-	}
-
-	_, err = serverTest.CA.Service.RequestCACSR(context.Background(), services.RequestCAInput{
-		KeyMetadata: models.KeyMetadata{Type: models.KeyType(x509.RSA), Bits: 2048},
-		Subject:     models.Subject{CommonName: "MyRequestedCA"},
-		ParentID:    managedCA.ID,
-	})
-	assert.EqualError(t, err, "cannot request a CSR for a managed CA")
-}
-
 func TestRequestCAWithoutParent(t *testing.T) {
 	serverTest, err := TestServiceBuilder{}.WithDatabase("ca").WithMonitor().Build(t)
 	if err != nil {
@@ -543,66 +371,6 @@ func TestRequestCAWithoutParent(t *testing.T) {
 	}
 
 	assert.Equal(t, csr.Subject.CommonName, "MyRequestedCA")
-	assert.Empty(t, csr.IssuerCAMetadata.ID)
-}
-
-func TestRequestCAWithDiferentExternalParentError(t *testing.T) {
-	serverTest, err := TestServiceBuilder{}.WithDatabase("ca").WithMonitor().Build(t)
-	if err != nil {
-		t.Fatalf("could not create CA test server: %s", err)
-	}
-
-	toImportCACert, _, err := chelpers.GenerateSelfSignedCA(x509.RSA, time.Hour*24, "ImportedExternalCA")
-	if err != nil {
-		t.Fatalf("could not generate external CA: %s", err)
-	}
-
-	externalCACert, privateKey, err := chelpers.GenerateSelfSignedCA(x509.RSA, time.Hour*24, "ExternalCA")
-	if err != nil {
-		t.Fatalf("could not generate external CA: %s", err)
-	}
-
-	ec := models.X509Certificate(*toImportCACert)
-
-	importedCACert, err := serverTest.CA.Service.ImportCA(context.Background(), services.ImportCAInput{
-		CACertificate: &ec,
-		CAType:        models.CertificateTypeExternal,
-	})
-	if err != nil {
-		t.Fatalf("could not import external CA: %s", err)
-	}
-
-	requestedCACSR, err := serverTest.CA.Service.RequestCACSR(context.Background(), services.RequestCAInput{
-		KeyMetadata: models.KeyMetadata{Type: models.KeyType(x509.RSA), Bits: 2048},
-		Subject:     models.Subject{CommonName: "MyRequestedCA"},
-		ParentID:    importedCACert.ID,
-	})
-	if err != nil {
-		t.Fatalf("unexpected error. Could not request CA: %s", err)
-	}
-
-	csr := x509.CertificateRequest(requestedCACSR.CSR)
-	certificateTemplate := getCertificateTemplate(csr, *externalCACert)
-	certificateTemplate.IsCA = true
-
-	certificateBytes, err := x509.CreateCertificate(rand.Reader, &certificateTemplate, externalCACert, csr.PublicKey, privateKey.(*rsa.PrivateKey))
-	if err != nil {
-		t.Fatalf("could not create the requested CA: %s", err)
-	}
-
-	requestedCertificate, err := x509.ParseCertificate(certificateBytes)
-	if err != nil {
-		t.Fatalf("could not parse the requested CA: %s", err)
-	}
-
-	rcert := models.X509Certificate(*requestedCertificate)
-	_, err = serverTest.CA.Service.ImportCA(context.Background(), services.ImportCAInput{
-		CACertificate: &rcert,
-		CARequestID:   requestedCACSR.ID,
-		CAType:        models.CertificateTypeRequested,
-	})
-
-	assert.EqualError(t, err, "parent CA did not sign the certificate: crypto/rsa: verification error")
 }
 
 func TestRequestCARetrieveAndFilterDelete(t *testing.T) {
@@ -630,7 +398,6 @@ func TestRequestCARetrieveAndFilterDelete(t *testing.T) {
 	requestedCACSR, err := serverTest.CA.Service.RequestCACSR(context.Background(), services.RequestCAInput{
 		KeyMetadata: models.KeyMetadata{Type: models.KeyType(x509.RSA), Bits: 2048},
 		Subject:     models.Subject{CommonName: "MyRequestedCA"},
-		ParentID:    importedCACert.ID,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error. Could not request CA: %s", err)
@@ -643,7 +410,6 @@ func TestRequestCARetrieveAndFilterDelete(t *testing.T) {
 		t.Fatalf("could not retrieve the requested CA: %s", err)
 	}
 	assert.Equal(t, retrievedReq.ID, requestedCACSR.ID)
-	assert.Equal(t, retrievedReq.IssuerCAMetadata, requestedCACSR.IssuerCAMetadata)
 	assert.Equal(t, retrievedReq.Subject, requestedCACSR.Subject)
 	assert.Equal(t, retrievedReq.KeyId, requestedCACSR.KeyId)
 	assert.Equal(t, retrievedReq.CSR, requestedCACSR.CSR)
@@ -655,7 +421,6 @@ func TestRequestCARetrieveAndFilterDelete(t *testing.T) {
 	requestedCACSR2, err := serverTest.CA.Service.RequestCACSR(context.Background(), services.RequestCAInput{
 		KeyMetadata: models.KeyMetadata{Type: models.KeyType(x509.RSA), Bits: 2048},
 		Subject:     models.Subject{CommonName: "MyRequestedCA2"},
-		ParentID:    importedCACert.ID,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error. Could not request CA: %s", err)

--- a/backend/pkg/assemblers/ca_csr_test.go
+++ b/backend/pkg/assemblers/ca_csr_test.go
@@ -1,0 +1,641 @@
+package assemblers
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
+	chelpers "github.com/lamassuiot/lamassuiot/core/v3/pkg/helpers"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/resources"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/services"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestCAWithExternalParent(t *testing.T) {
+	serverTest, err := TestServiceBuilder{}.WithDatabase("ca").WithMonitor().Build(t)
+	if err != nil {
+		t.Fatalf("could not create CA test server: %s", err)
+	}
+
+	externalCACert, privateKey, err := chelpers.GenerateSelfSignedCA(x509.RSA, time.Hour*24, "ExternalCA")
+	if err != nil {
+		t.Fatalf("could not generate external CA: %s", err)
+	}
+
+	ec := models.X509Certificate(*externalCACert)
+
+	importedCACert, err := serverTest.CA.Service.ImportCA(context.Background(), services.ImportCAInput{
+		CACertificate: &ec,
+		CAType:        models.CertificateTypeExternal,
+	})
+	if err != nil {
+		t.Fatalf("could not import external CA: %s", err)
+	}
+
+	requestedCACSR, err := serverTest.CA.Service.RequestCACSR(context.Background(), services.RequestCAInput{
+		KeyMetadata: models.KeyMetadata{Type: models.KeyType(x509.RSA), Bits: 2048},
+		Subject:     models.Subject{CommonName: "MyRequestedCA"},
+		ParentID:    importedCACert.ID,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error. Could not request CA: %s", err)
+	}
+
+	csr := x509.CertificateRequest(requestedCACSR.CSR)
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	sn, _ := rand.Int(rand.Reader, serialNumberLimit)
+
+	certificateTemplate := x509.Certificate{
+		PublicKeyAlgorithm: csr.PublicKeyAlgorithm,
+		PublicKey:          csr.PublicKey,
+		AuthorityKeyId:     ec.SubjectKeyId,
+		SerialNumber:       sn,
+		Issuer:             ec.Subject,
+		Subject:            csr.Subject,
+		NotBefore:          time.Now(),
+		NotAfter:           time.Now().Add(time.Hour * 24),
+		ExtraExtensions:    []pkix.Extension{},
+		OCSPServer: []string{
+			fmt.Sprintf("https://%s/api/va/ocsp", "localhost"),
+		},
+		CRLDistributionPoints: []string{
+			fmt.Sprintf("https://%s/api/va/crl/%s", "localhost", string(ec.SubjectKeyId)),
+		},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsage(x509.ExtKeyUsageOCSPSigning),
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	certificateTemplate.IsCA = true
+
+	certificateBytes, err := x509.CreateCertificate(rand.Reader, &certificateTemplate, externalCACert, csr.PublicKey, privateKey.(*rsa.PrivateKey))
+	if err != nil {
+		t.Fatalf("could not create the requested CA: %s", err)
+	}
+
+	requestedCertificate, err := x509.ParseCertificate(certificateBytes)
+	if err != nil {
+		t.Fatalf("could not parse the requested CA: %s", err)
+	}
+
+	rcert := models.X509Certificate(*requestedCertificate)
+	importedCertificate, err := serverTest.CA.Service.ImportCA(context.Background(), services.ImportCAInput{
+		CACertificate: &rcert,
+		CARequestID:   requestedCACSR.ID,
+		CAType:        models.CertificateTypeRequested,
+	})
+	if err != nil {
+		t.Fatalf("could not import the requested CA: %s", err)
+	}
+
+	assert.Equal(t, importedCertificate.Certificate.Subject.CommonName, csr.Subject.CommonName)
+	assert.Equal(t, importedCertificate.Certificate.Certificate.Issuer.CommonName, ec.Subject.CommonName)
+}
+
+func TestRequestCADoubleImportError(t *testing.T) {
+	serverTest, err := TestServiceBuilder{}.WithDatabase("ca").WithMonitor().Build(t)
+	if err != nil {
+		t.Fatalf("could not create CA test server: %s", err)
+	}
+
+	externalCACert, privateKey, err := chelpers.GenerateSelfSignedCA(x509.RSA, time.Hour*24, "ExternalCA")
+	if err != nil {
+		t.Fatalf("could not generate external CA: %s", err)
+	}
+
+	ec := models.X509Certificate(*externalCACert)
+
+	importedCACert, err := serverTest.CA.Service.ImportCA(context.Background(), services.ImportCAInput{
+		CACertificate: &ec,
+		CAType:        models.CertificateTypeExternal,
+	})
+	if err != nil {
+		t.Fatalf("could not import external CA: %s", err)
+	}
+
+	requestedCACSR, err := serverTest.CA.Service.RequestCACSR(context.Background(), services.RequestCAInput{
+		KeyMetadata: models.KeyMetadata{Type: models.KeyType(x509.RSA), Bits: 2048},
+		Subject:     models.Subject{CommonName: "MyRequestedCA"},
+		ParentID:    importedCACert.ID,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error. Could not request CA: %s", err)
+	}
+
+	csr := x509.CertificateRequest(requestedCACSR.CSR)
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	sn, _ := rand.Int(rand.Reader, serialNumberLimit)
+
+	certificateTemplate := x509.Certificate{
+		PublicKeyAlgorithm: csr.PublicKeyAlgorithm,
+		PublicKey:          csr.PublicKey,
+		AuthorityKeyId:     ec.SubjectKeyId,
+		SerialNumber:       sn,
+		Issuer:             ec.Subject,
+		Subject:            csr.Subject,
+		NotBefore:          time.Now(),
+		NotAfter:           time.Now().Add(time.Hour * 24),
+		ExtraExtensions:    []pkix.Extension{},
+		OCSPServer: []string{
+			fmt.Sprintf("https://%s/api/va/ocsp", "localhost"),
+		},
+		CRLDistributionPoints: []string{
+			fmt.Sprintf("https://%s/api/va/crl/%s", "localhost", string(ec.SubjectKeyId)),
+		},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsage(x509.ExtKeyUsageOCSPSigning),
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	certificateTemplate.IsCA = true
+
+	certificateBytes, err := x509.CreateCertificate(rand.Reader, &certificateTemplate, externalCACert, csr.PublicKey, privateKey.(*rsa.PrivateKey))
+	if err != nil {
+		t.Fatalf("could not create the requested CA: %s", err)
+	}
+
+	requestedCertificate, err := x509.ParseCertificate(certificateBytes)
+	if err != nil {
+		t.Fatalf("could not parse the requested CA: %s", err)
+	}
+
+	rcert := models.X509Certificate(*requestedCertificate)
+	importedCertificate, err := serverTest.CA.Service.ImportCA(context.Background(), services.ImportCAInput{
+		CACertificate: &rcert,
+		CARequestID:   requestedCACSR.ID,
+		CAType:        models.CertificateTypeRequested,
+	})
+	if err != nil {
+		t.Fatalf("could not import the requested CA: %s", err)
+	}
+
+	assert.Equal(t, importedCertificate.Certificate.Subject.CommonName, csr.Subject.CommonName)
+	assert.Equal(t, importedCertificate.Certificate.Certificate.Issuer.CommonName, ec.Subject.CommonName)
+
+	_, err = serverTest.CA.Service.ImportCA(context.Background(), services.ImportCAInput{
+		CACertificate: &rcert,
+		CARequestID:   requestedCACSR.ID,
+		CAType:        models.CertificateTypeRequested,
+	})
+
+	assert.EqualError(t, err, "CA Request is not pending")
+}
+
+func TestImportNonCACertError(t *testing.T) {
+	serverTest, err := TestServiceBuilder{}.WithDatabase("ca").WithMonitor().Build(t)
+	if err != nil {
+		t.Fatalf("could not create CA test server: %s", err)
+	}
+
+	externalCACert, privateKey, err := chelpers.GenerateSelfSignedCA(x509.RSA, time.Hour*24, "ExternalCA")
+	if err != nil {
+		t.Fatalf("could not generate external CA: %s", err)
+	}
+
+	ec := models.X509Certificate(*externalCACert)
+
+	importedCACert, err := serverTest.CA.Service.ImportCA(context.Background(), services.ImportCAInput{
+		CACertificate: &ec,
+		CAType:        models.CertificateTypeExternal,
+	})
+	if err != nil {
+		t.Fatalf("could not import external CA: %s", err)
+	}
+
+	requestedCACSR, err := serverTest.CA.Service.RequestCACSR(context.Background(), services.RequestCAInput{
+		KeyMetadata: models.KeyMetadata{Type: models.KeyType(x509.RSA), Bits: 2048},
+		Subject:     models.Subject{CommonName: "MyRequestedCA"},
+		ParentID:    importedCACert.ID,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error. Could not request CA: %s", err)
+	}
+
+	csr := x509.CertificateRequest(requestedCACSR.CSR)
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	sn, _ := rand.Int(rand.Reader, serialNumberLimit)
+
+	certificateTemplate := x509.Certificate{
+		PublicKeyAlgorithm: csr.PublicKeyAlgorithm,
+		PublicKey:          csr.PublicKey,
+		AuthorityKeyId:     ec.SubjectKeyId,
+		SerialNumber:       sn,
+		Issuer:             ec.Subject,
+		Subject:            csr.Subject,
+		NotBefore:          time.Now(),
+		NotAfter:           time.Now().Add(time.Hour * 24),
+		ExtraExtensions:    []pkix.Extension{},
+		OCSPServer: []string{
+			fmt.Sprintf("https://%s/api/va/ocsp", "localhost"),
+		},
+		CRLDistributionPoints: []string{
+			fmt.Sprintf("https://%s/api/va/crl/%s", "localhost", string(ec.SubjectKeyId)),
+		},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsage(x509.ExtKeyUsageOCSPSigning),
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	certificateBytes, err := x509.CreateCertificate(rand.Reader, &certificateTemplate, externalCACert, csr.PublicKey, privateKey.(*rsa.PrivateKey))
+	if err != nil {
+		t.Fatalf("could not create the requested CA: %s", err)
+	}
+
+	requestedCertificate, err := x509.ParseCertificate(certificateBytes)
+	if err != nil {
+		t.Fatalf("could not parse the requested CA: %s", err)
+	}
+
+	rcert := models.X509Certificate(*requestedCertificate)
+	_, err = serverTest.CA.Service.ImportCA(context.Background(), services.ImportCAInput{
+		CACertificate: &rcert,
+		CARequestID:   requestedCACSR.ID,
+		CAType:        models.CertificateTypeRequested,
+	})
+
+	assert.EqualError(t, err, "CA certificate and CSR are not compatible - IsCA")
+
+}
+
+func TestImportUnexpectedCSRError(t *testing.T) {
+	serverTest, err := TestServiceBuilder{}.WithDatabase("ca").WithMonitor().Build(t)
+	if err != nil {
+		t.Fatalf("could not create CA test server: %s", err)
+	}
+
+	externalCACert, privateKey, err := chelpers.GenerateSelfSignedCA(x509.RSA, time.Hour*24, "ExternalCA")
+	if err != nil {
+		t.Fatalf("could not generate external CA: %s", err)
+	}
+
+	ec := models.X509Certificate(*externalCACert)
+
+	importedCACert, err := serverTest.CA.Service.ImportCA(context.Background(), services.ImportCAInput{
+		CACertificate: &ec,
+		CAType:        models.CertificateTypeExternal,
+	})
+	if err != nil {
+		t.Fatalf("could not import external CA: %s", err)
+	}
+
+	requestedCACSR, err := serverTest.CA.Service.RequestCACSR(context.Background(), services.RequestCAInput{
+		KeyMetadata: models.KeyMetadata{Type: models.KeyType(x509.RSA), Bits: 2048},
+		Subject:     models.Subject{CommonName: "MyRequestedCA"},
+		ParentID:    importedCACert.ID,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error. Could not request CA: %s", err)
+	}
+
+	unexpectedCACSR, err := serverTest.CA.Service.RequestCACSR(context.Background(), services.RequestCAInput{
+		KeyMetadata: models.KeyMetadata{Type: models.KeyType(x509.RSA), Bits: 2048},
+		Subject:     models.Subject{CommonName: "MyRequestedCA"},
+		ParentID:    importedCACert.ID,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error. Could not request CA: %s", err)
+	}
+
+	csr := x509.CertificateRequest(unexpectedCACSR.CSR)
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	sn, _ := rand.Int(rand.Reader, serialNumberLimit)
+
+	certificateTemplate := x509.Certificate{
+		PublicKeyAlgorithm: csr.PublicKeyAlgorithm,
+		PublicKey:          csr.PublicKey,
+		AuthorityKeyId:     ec.SubjectKeyId,
+		SerialNumber:       sn,
+		Issuer:             ec.Subject,
+		Subject:            csr.Subject,
+		NotBefore:          time.Now(),
+		NotAfter:           time.Now().Add(time.Hour * 24),
+		ExtraExtensions:    []pkix.Extension{},
+		OCSPServer: []string{
+			fmt.Sprintf("https://%s/api/va/ocsp", "localhost"),
+		},
+		CRLDistributionPoints: []string{
+			fmt.Sprintf("https://%s/api/va/crl/%s", "localhost", string(ec.SubjectKeyId)),
+		},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsage(x509.ExtKeyUsageOCSPSigning),
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	certificateTemplate.IsCA = true
+
+	certificateBytes, err := x509.CreateCertificate(rand.Reader, &certificateTemplate, externalCACert, csr.PublicKey, privateKey.(*rsa.PrivateKey))
+	if err != nil {
+		t.Fatalf("could not create the requested CA: %s", err)
+	}
+
+	requestedCertificate, err := x509.ParseCertificate(certificateBytes)
+	if err != nil {
+		t.Fatalf("could not parse the requested CA: %s", err)
+	}
+
+	rcert := models.X509Certificate(*requestedCertificate)
+	_, err = serverTest.CA.Service.ImportCA(context.Background(), services.ImportCAInput{
+		CACertificate: &rcert,
+		CARequestID:   requestedCACSR.ID,
+		CAType:        models.CertificateTypeRequested,
+	})
+
+	assert.EqualError(t, err, "CA certificate and CSR are not compatible - Public Key")
+
+}
+
+func TestImportNonExistentRequest(t *testing.T) {
+	serverTest, err := TestServiceBuilder{}.WithDatabase("ca").WithMonitor().Build(t)
+	if err != nil {
+		t.Fatalf("could not create CA test server: %s", err)
+	}
+
+	externalCACert, _, err := chelpers.GenerateSelfSignedCA(x509.RSA, time.Hour*24, "ExternalCA")
+	if err != nil {
+		t.Fatalf("could not generate external CA: %s", err)
+	}
+
+	ec := models.X509Certificate(*externalCACert)
+
+	_, err = serverTest.CA.Service.ImportCA(context.Background(), services.ImportCAInput{
+		CACertificate: &ec,
+		CARequestID:   "unknown",
+		CAType:        models.CertificateTypeRequested,
+	})
+
+	assert.Error(t, err, "CA Request not found")
+}
+
+func TestRequestCAWithManagedParentError(t *testing.T) {
+	serverTest, err := TestServiceBuilder{}.WithDatabase("ca").WithMonitor().Build(t)
+	if err != nil {
+		t.Fatalf("could not create CA test server: %s", err)
+
+	}
+
+	managedCA, err := serverTest.CA.Service.CreateCA(context.Background(), services.CreateCAInput{
+		KeyMetadata: models.KeyMetadata{Type: models.KeyType(x509.RSA), Bits: 2048},
+		Subject:     models.Subject{CommonName: "ManagedCA"},
+		IssuanceExpiration: models.Validity{
+			Type:     models.Duration,
+			Duration: models.TimeDuration(time.Hour * 24),
+		},
+		CAExpiration: models.Validity{
+			Type:     models.Duration,
+			Duration: models.TimeDuration(time.Hour * 24 * 365),
+		},
+	})
+	if err != nil {
+		t.Fatalf("could not create managed CA: %s", err)
+	}
+
+	_, err = serverTest.CA.Service.RequestCACSR(context.Background(), services.RequestCAInput{
+		KeyMetadata: models.KeyMetadata{Type: models.KeyType(x509.RSA), Bits: 2048},
+		Subject:     models.Subject{CommonName: "MyRequestedCA"},
+		ParentID:    managedCA.ID,
+	})
+	assert.Error(t, err, "cannot request a CSR for a managed CA")
+}
+
+func TestRequestCAWithoutParentError(t *testing.T) {
+	serverTest, err := TestServiceBuilder{}.WithDatabase("ca").WithMonitor().Build(t)
+	if err != nil {
+		t.Fatalf("could not create CA test server: %s", err)
+
+	}
+	_, err = serverTest.CA.Service.RequestCACSR(context.Background(), services.RequestCAInput{
+		KeyMetadata: models.KeyMetadata{Type: models.KeyType(x509.RSA), Bits: 2048},
+		Subject:     models.Subject{CommonName: "MyRequestedCA"},
+	})
+	assert.Error(t, err, "cannot request a CSR without a parent")
+}
+
+func TestRequestCAWithDiferentExternalParentError(t *testing.T) {
+	serverTest, err := TestServiceBuilder{}.WithDatabase("ca").WithMonitor().Build(t)
+	if err != nil {
+		t.Fatalf("could not create CA test server: %s", err)
+	}
+
+	toImportCACert, _, err := chelpers.GenerateSelfSignedCA(x509.RSA, time.Hour*24, "ImportedExternalCA")
+	if err != nil {
+		t.Fatalf("could not generate external CA: %s", err)
+	}
+
+	externalCACert, privateKey, err := chelpers.GenerateSelfSignedCA(x509.RSA, time.Hour*24, "ExternalCA")
+	if err != nil {
+		t.Fatalf("could not generate external CA: %s", err)
+	}
+
+	ec := models.X509Certificate(*toImportCACert)
+
+	importedCACert, err := serverTest.CA.Service.ImportCA(context.Background(), services.ImportCAInput{
+		CACertificate: &ec,
+		CAType:        models.CertificateTypeExternal,
+	})
+	if err != nil {
+		t.Fatalf("could not import external CA: %s", err)
+	}
+
+	requestedCACSR, err := serverTest.CA.Service.RequestCACSR(context.Background(), services.RequestCAInput{
+		KeyMetadata: models.KeyMetadata{Type: models.KeyType(x509.RSA), Bits: 2048},
+		Subject:     models.Subject{CommonName: "MyRequestedCA"},
+		ParentID:    importedCACert.ID,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error. Could not request CA: %s", err)
+	}
+
+	csr := x509.CertificateRequest(requestedCACSR.CSR)
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	sn, _ := rand.Int(rand.Reader, serialNumberLimit)
+
+	certificateTemplate := x509.Certificate{
+		PublicKeyAlgorithm: csr.PublicKeyAlgorithm,
+		PublicKey:          csr.PublicKey,
+		AuthorityKeyId:     externalCACert.SubjectKeyId,
+		SerialNumber:       sn,
+		Issuer:             externalCACert.Subject,
+		Subject:            csr.Subject,
+		NotBefore:          time.Now(),
+		NotAfter:           time.Now().Add(time.Hour * 24),
+		ExtraExtensions:    []pkix.Extension{},
+		OCSPServer: []string{
+			fmt.Sprintf("https://%s/api/va/ocsp", "localhost"),
+		},
+		CRLDistributionPoints: []string{
+			fmt.Sprintf("https://%s/api/va/crl/%s", "localhost", string(ec.SubjectKeyId)),
+		},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsage(x509.ExtKeyUsageOCSPSigning),
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	certificateTemplate.IsCA = true
+
+	certificateBytes, err := x509.CreateCertificate(rand.Reader, &certificateTemplate, externalCACert, csr.PublicKey, privateKey.(*rsa.PrivateKey))
+	if err != nil {
+		t.Fatalf("could not create the requested CA: %s", err)
+	}
+
+	requestedCertificate, err := x509.ParseCertificate(certificateBytes)
+	if err != nil {
+		t.Fatalf("could not parse the requested CA: %s", err)
+	}
+
+	rcert := models.X509Certificate(*requestedCertificate)
+	_, err = serverTest.CA.Service.ImportCA(context.Background(), services.ImportCAInput{
+		CACertificate: &rcert,
+		CARequestID:   requestedCACSR.ID,
+		CAType:        models.CertificateTypeRequested,
+	})
+
+	assert.Error(t, err, "Parent CA did not sign the certificate: crypto/rsa: verification error")
+}
+
+func TestRequestCARetrieveAndFilterDelete(t *testing.T) {
+	serverTest, err := TestServiceBuilder{}.WithDatabase("ca").WithMonitor().Build(t)
+
+	if err != nil {
+		t.Fatalf("could not create CA test server: %s", err)
+	}
+
+	externalCACert, _, err := chelpers.GenerateSelfSignedCA(x509.RSA, time.Hour*24, "ExternalCA")
+	if err != nil {
+		t.Fatalf("could not generate external CA: %s", err)
+	}
+
+	ec := models.X509Certificate(*externalCACert)
+
+	importedCACert, err := serverTest.CA.Service.ImportCA(context.Background(), services.ImportCAInput{
+		CACertificate: &ec,
+		CAType:        models.CertificateTypeExternal,
+	})
+	if err != nil {
+		t.Fatalf("could not import external CA: %s", err)
+	}
+
+	requestedCACSR, err := serverTest.CA.Service.RequestCACSR(context.Background(), services.RequestCAInput{
+		KeyMetadata: models.KeyMetadata{Type: models.KeyType(x509.RSA), Bits: 2048},
+		Subject:     models.Subject{CommonName: "MyRequestedCA"},
+		ParentID:    importedCACert.ID,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error. Could not request CA: %s", err)
+	}
+
+	retrievedReq, err := serverTest.CA.Service.GetCARequestByID(context.Background(), services.GetByIDInput{
+		ID: requestedCACSR.ID,
+	})
+	if err != nil {
+		t.Fatalf("could not retrieve the requested CA: %s", err)
+	}
+	assert.Equal(t, retrievedReq.ID, requestedCACSR.ID)
+	assert.Equal(t, retrievedReq.IssuerCAMetadata, requestedCACSR.IssuerCAMetadata)
+	assert.Equal(t, retrievedReq.Subject, requestedCACSR.Subject)
+	assert.Equal(t, retrievedReq.KeyId, requestedCACSR.KeyId)
+	assert.Equal(t, retrievedReq.CSR, requestedCACSR.CSR)
+	assert.Equal(t, retrievedReq.Metadata, requestedCACSR.Metadata)
+	assert.Equal(t, retrievedReq.EngineID, requestedCACSR.EngineID)
+	assert.Equal(t, retrievedReq.KeyMetadata, requestedCACSR.KeyMetadata)
+	assert.Equal(t, retrievedReq.Status, requestedCACSR.Status)
+
+	requestedCACSR2, err := serverTest.CA.Service.RequestCACSR(context.Background(), services.RequestCAInput{
+		KeyMetadata: models.KeyMetadata{Type: models.KeyType(x509.RSA), Bits: 2048},
+		Subject:     models.Subject{CommonName: "MyRequestedCA2"},
+		ParentID:    importedCACert.ID,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error. Could not request CA: %s", err)
+	}
+
+	var reqs []models.CACertificateRequest
+
+	_, err = serverTest.CA.Service.GetCARequests(context.Background(), services.GetItemsInput[models.CACertificateRequest]{
+		QueryParameters: nil,
+		ExhaustiveRun:   false,
+		ApplyFunc: func(req models.CACertificateRequest) {
+			reqs = append(reqs, req)
+		},
+	})
+	if err != nil {
+		t.Fatalf("could not retrieve the requested CA: %s", err)
+	}
+
+	assert.Equal(t, len(reqs), 2)
+
+	queryParams := resources.QueryParameters{
+		NextBookmark: "",
+		Filters:      []resources.FilterOption{},
+		PageSize:     25,
+	}
+
+	queryParams.Filters = append(queryParams.Filters, resources.FilterOption{
+		Field:           "subject_common_name",
+		FilterOperation: resources.StringEqual,
+		Value:           "MyRequestedCA",
+	})
+
+	reqs = []models.CACertificateRequest{}
+	_, err = serverTest.CA.Service.GetCARequests(context.Background(), services.GetItemsInput[models.CACertificateRequest]{
+		QueryParameters: &queryParams,
+		ExhaustiveRun:   false,
+		ApplyFunc: func(req models.CACertificateRequest) {
+			reqs = append(reqs, req)
+		},
+	})
+	if err != nil {
+		t.Fatalf("could not retrieve the requested CA: %s", err)
+	}
+
+	assert.Equal(t, len(reqs), 1)
+
+	queryParams = resources.QueryParameters{
+		NextBookmark: "",
+		Filters:      []resources.FilterOption{},
+		PageSize:     25,
+	}
+
+	queryParams.Filters = append(queryParams.Filters, resources.FilterOption{
+		Field:           "issuer_meta_id",
+		FilterOperation: resources.StringEqual,
+		Value:           importedCACert.ID,
+	})
+	reqs = []models.CACertificateRequest{}
+	_, err = serverTest.CA.Service.GetCARequests(context.Background(), services.GetItemsInput[models.CACertificateRequest]{
+		QueryParameters: &queryParams,
+		ExhaustiveRun:   false,
+		ApplyFunc: func(req models.CACertificateRequest) {
+			reqs = append(reqs, req)
+		},
+	})
+	if err != nil {
+		t.Fatalf("could not retrieve the requested CA: %s", err)
+	}
+
+	assert.Equal(t, len(reqs), 2)
+
+	err = serverTest.CA.Service.DeleteCARequestByID(context.Background(), services.GetByIDInput{
+		ID: requestedCACSR2.ID,
+	})
+	if err != nil {
+		t.Fatalf("could not delete the requested CA: %s", err)
+	}
+
+	_, err = serverTest.CA.Service.GetCARequestByID(context.Background(), services.GetByIDInput{
+		ID: requestedCACSR2.ID,
+	})
+	assert.Error(t, err, "CA Request not found")
+
+}

--- a/backend/pkg/assemblers/ca_csr_test.go
+++ b/backend/pkg/assemblers/ca_csr_test.go
@@ -100,6 +100,79 @@ func TestRequestCAWithExternalParent(t *testing.T) {
 	assert.Equal(t, importedCertificate.Certificate.Certificate.Issuer.CommonName, ec.Subject.CommonName)
 }
 
+func TestImportCAWithNoParent(t *testing.T) {
+	serverTest, err := TestServiceBuilder{}.WithDatabase("ca").WithMonitor().Build(t)
+	if err != nil {
+		t.Fatalf("could not create CA test server: %s", err)
+	}
+
+	externalCACert, privateKey, err := chelpers.GenerateSelfSignedCA(x509.RSA, time.Hour*24, "ExternalCA")
+	if err != nil {
+		t.Fatalf("could not generate external CA: %s", err)
+	}
+
+	ec := models.X509Certificate(*externalCACert)
+
+	requestedCACSR, err := serverTest.CA.Service.RequestCACSR(context.Background(), services.RequestCAInput{
+		KeyMetadata: models.KeyMetadata{Type: models.KeyType(x509.RSA), Bits: 2048},
+		Subject:     models.Subject{CommonName: "MyRequestedCA"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error. Could not request CA: %s", err)
+	}
+
+	csr := x509.CertificateRequest(requestedCACSR.CSR)
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	sn, _ := rand.Int(rand.Reader, serialNumberLimit)
+
+	certificateTemplate := x509.Certificate{
+		PublicKeyAlgorithm: csr.PublicKeyAlgorithm,
+		PublicKey:          csr.PublicKey,
+		AuthorityKeyId:     ec.SubjectKeyId,
+		SerialNumber:       sn,
+		Issuer:             ec.Subject,
+		Subject:            csr.Subject,
+		NotBefore:          time.Now(),
+		NotAfter:           time.Now().Add(time.Hour * 24),
+		ExtraExtensions:    []pkix.Extension{},
+		OCSPServer: []string{
+			fmt.Sprintf("https://%s/api/va/ocsp", "localhost"),
+		},
+		CRLDistributionPoints: []string{
+			fmt.Sprintf("https://%s/api/va/crl/%s", "localhost", string(ec.SubjectKeyId)),
+		},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsage(x509.ExtKeyUsageOCSPSigning),
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	certificateTemplate.IsCA = true
+
+	certificateBytes, err := x509.CreateCertificate(rand.Reader, &certificateTemplate, externalCACert, csr.PublicKey, privateKey.(*rsa.PrivateKey))
+	if err != nil {
+		t.Fatalf("could not create the requested CA: %s", err)
+	}
+
+	requestedCertificate, err := x509.ParseCertificate(certificateBytes)
+	if err != nil {
+		t.Fatalf("could not parse the requested CA: %s", err)
+	}
+
+	rcert := models.X509Certificate(*requestedCertificate)
+	importedCertificate, err := serverTest.CA.Service.ImportCA(context.Background(), services.ImportCAInput{
+		CACertificate: &rcert,
+		CARequestID:   requestedCACSR.ID,
+		CAType:        models.CertificateTypeRequested,
+	})
+	if err != nil {
+		t.Fatalf("could not import the requested CA: %s", err)
+	}
+
+	assert.Equal(t, importedCertificate.Certificate.Subject.CommonName, csr.Subject.CommonName)
+	assert.Equal(t, importedCertificate.Certificate.Certificate.Issuer.CommonName, ec.Subject.CommonName)
+}
+
 func TestRequestCADoubleImportError(t *testing.T) {
 	serverTest, err := TestServiceBuilder{}.WithDatabase("ca").WithMonitor().Build(t)
 	if err != nil {
@@ -374,7 +447,7 @@ func TestImportNonExistentRequest(t *testing.T) {
 		CAType:        models.CertificateTypeRequested,
 	})
 
-	assert.Error(t, err, "CA Request not found")
+	assert.EqualError(t, err, "CA Request not found")
 }
 
 func TestRequestCAWithManagedParentError(t *testing.T) {
@@ -405,20 +478,25 @@ func TestRequestCAWithManagedParentError(t *testing.T) {
 		Subject:     models.Subject{CommonName: "MyRequestedCA"},
 		ParentID:    managedCA.ID,
 	})
-	assert.Error(t, err, "cannot request a CSR for a managed CA")
+	assert.EqualError(t, err, "cannot request a CSR for a managed CA")
 }
 
-func TestRequestCAWithoutParentError(t *testing.T) {
+func TestRequestCAWithoutParent(t *testing.T) {
 	serverTest, err := TestServiceBuilder{}.WithDatabase("ca").WithMonitor().Build(t)
 	if err != nil {
 		t.Fatalf("could not create CA test server: %s", err)
 
 	}
-	_, err = serverTest.CA.Service.RequestCACSR(context.Background(), services.RequestCAInput{
+	csr, err := serverTest.CA.Service.RequestCACSR(context.Background(), services.RequestCAInput{
 		KeyMetadata: models.KeyMetadata{Type: models.KeyType(x509.RSA), Bits: 2048},
 		Subject:     models.Subject{CommonName: "MyRequestedCA"},
 	})
-	assert.Error(t, err, "cannot request a CSR without a parent")
+	if err != nil {
+		t.Fatalf("unexpected error. Could not request CA: %s", err)
+	}
+
+	assert.Equal(t, csr.Subject.CommonName, "MyRequestedCA")
+	assert.Empty(t, csr.IssuerCAMetadata.ID)
 }
 
 func TestRequestCAWithDiferentExternalParentError(t *testing.T) {
@@ -501,7 +579,7 @@ func TestRequestCAWithDiferentExternalParentError(t *testing.T) {
 		CAType:        models.CertificateTypeRequested,
 	})
 
-	assert.Error(t, err, "Parent CA did not sign the certificate: crypto/rsa: verification error")
+	assert.EqualError(t, err, "parent CA did not sign the certificate: crypto/rsa: verification error")
 }
 
 func TestRequestCARetrieveAndFilterDelete(t *testing.T) {
@@ -636,6 +714,6 @@ func TestRequestCARetrieveAndFilterDelete(t *testing.T) {
 	_, err = serverTest.CA.Service.GetCARequestByID(context.Background(), services.GetByIDInput{
 		ID: requestedCACSR2.ID,
 	})
-	assert.Error(t, err, "CA Request not found")
+	assert.EqualError(t, err, "CA not found")
 
 }

--- a/backend/pkg/controllers/ca.go
+++ b/backend/pkg/controllers/ca.go
@@ -196,7 +196,6 @@ func (r *caHttpRoutes) RequestCA(ctx *gin.Context) {
 
 	caRequest, err := r.svc.RequestCACSR(ctx, services.RequestCAInput{
 		ID:          requestBody.ID,
-		ParentID:    requestBody.ParentID,
 		KeyMetadata: requestBody.KeyMetadata,
 		Subject:     requestBody.Subject,
 		EngineID:    requestBody.EngineID,

--- a/backend/pkg/controllers/ca.go
+++ b/backend/pkg/controllers/ca.go
@@ -7,11 +7,9 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/errs"
-	chelpers "github.com/lamassuiot/lamassuiot/core/v3/pkg/helpers"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/helpers"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
-	cmodels "github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/resources"
-	cresources "github.com/lamassuiot/lamassuiot/core/v3/pkg/resources"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/services"
 )
 
@@ -127,6 +125,97 @@ func (r *caHttpRoutes) GetStatsByCAID(ctx *gin.Context) {
 	ctx.JSON(200, stats)
 }
 
+func (r *caHttpRoutes) GetCARequestByID(ctx *gin.Context) {
+	type uriParams struct {
+		ID string `uri:"id" binding:"required"`
+	}
+
+	var params uriParams
+	if err := ctx.ShouldBindUri(&params); err != nil {
+		ctx.JSON(400, gin.H{"err": err.Error()})
+		return
+	}
+
+	ca, err := r.svc.GetCARequestByID(ctx, services.GetByIDInput{
+		ID: params.ID,
+	})
+
+	if err != nil {
+		switch err {
+		case errs.ErrCANotFound:
+			ctx.JSON(404, gin.H{"err": err.Error()})
+		case errs.ErrValidateBadRequest:
+			ctx.JSON(400, gin.H{"err": err.Error()})
+		default:
+			ctx.JSON(500, gin.H{"err": err.Error()})
+		}
+
+		return
+	}
+
+	ctx.JSON(200, ca)
+}
+
+func (r *caHttpRoutes) DeleteCARequestByID(ctx *gin.Context) {
+	type uriParams struct {
+		ID string `uri:"id" binding:"required"`
+	}
+
+	var params uriParams
+	if err := ctx.ShouldBindUri(&params); err != nil {
+		ctx.JSON(400, gin.H{"err": err.Error()})
+		return
+	}
+
+	err := r.svc.DeleteCARequestByID(ctx, services.GetByIDInput{
+		ID: params.ID,
+	})
+
+	if err != nil {
+		switch err {
+		case errs.ErrCANotFound:
+			ctx.JSON(404, gin.H{"err": err.Error()})
+		case errs.ErrValidateBadRequest:
+			ctx.JSON(400, gin.H{"err": err.Error()})
+		default:
+			ctx.JSON(500, gin.H{"err": err.Error()})
+		}
+
+		return
+	}
+
+	ctx.JSON(200, gin.H{})
+}
+
+func (r *caHttpRoutes) RequestCA(ctx *gin.Context) {
+	var requestBody resources.RequestCABody
+	if err := ctx.BindJSON(&requestBody); err != nil {
+		ctx.JSON(400, gin.H{"err": err.Error()})
+		return
+	}
+
+	caRequest, err := r.svc.RequestCACSR(ctx, services.RequestCAInput{
+		ID:          requestBody.ID,
+		ParentID:    requestBody.ParentID,
+		KeyMetadata: requestBody.KeyMetadata,
+		Subject:     requestBody.Subject,
+		EngineID:    requestBody.EngineID,
+		Metadata:    requestBody.Metadata,
+	})
+	if err != nil {
+		switch err {
+		case errs.ErrValidateBadRequest:
+			ctx.JSON(400, gin.H{"err": err.Error()})
+		case errs.ErrCAAlreadyExists:
+			ctx.JSON(409, gin.H{"err": err.Error()})
+		default:
+			ctx.JSON(500, gin.H{"err": err.Error()})
+		}
+		return
+	}
+	ctx.JSON(201, caRequest)
+}
+
 // @Summary Import CA
 // @Description Import CA
 // @Accept json
@@ -152,14 +241,14 @@ func (r *caHttpRoutes) ImportCA(ctx *gin.Context) {
 
 	var key any
 	if len(requestBody.CAPrivateKey) > 0 {
-		key, err = chelpers.ParsePrivateKey(decodedKey)
+		key, err = helpers.ParsePrivateKey(decodedKey)
 		if err != nil {
 			ctx.JSON(400, gin.H{"err": err.Error()})
 			return
 		}
 	}
 
-	var keyType cmodels.KeyType
+	var keyType models.KeyType
 	var rsaKey *rsa.PrivateKey
 	var ecKey *ecdsa.PrivateKey
 
@@ -180,6 +269,7 @@ func (r *caHttpRoutes) ImportCA(ctx *gin.Context) {
 		CAECKey:            ecKey,
 		EngineID:           requestBody.EngineID,
 		ParentID:           requestBody.ParentID,
+		CARequestID:        requestBody.CARequestID,
 	})
 	if err != nil {
 		switch err {
@@ -364,6 +454,82 @@ func (r *caHttpRoutes) GetAllCAs(ctx *gin.Context) {
 	})
 }
 
+func (r *caHttpRoutes) GetAllRequests(ctx *gin.Context) {
+	queryParams := FilterQuery(ctx.Request, resources.CARequestFiltrableFields)
+
+	reqs := []models.CACertificateRequest{}
+
+	nextBookmark, err := r.svc.GetCARequests(ctx, services.GetItemsInput[models.CACertificateRequest]{
+		QueryParameters: queryParams,
+		ExhaustiveRun:   false,
+		ApplyFunc: func(req models.CACertificateRequest) {
+			reqs = append(reqs, req)
+		},
+	})
+
+	if err != nil {
+		switch err {
+		default:
+			ctx.JSON(500, gin.H{"err": err.Error()})
+		}
+
+		return
+	}
+
+	ctx.JSON(200, resources.GetItemsResponse[models.CACertificateRequest]{
+		IterableList: resources.IterableList[models.CACertificateRequest]{
+			NextBookmark: nextBookmark,
+			List:         reqs,
+		},
+	})
+}
+
+func (r *caHttpRoutes) GetCARequests(ctx *gin.Context) {
+	queryParams := FilterQuery(ctx.Request, resources.CARequestFiltrableFields)
+
+	type uriParams struct {
+		ID string `uri:"id" binding:"required"`
+	}
+
+	var params uriParams
+	if err := ctx.ShouldBindUri(&params); err != nil {
+		ctx.JSON(400, gin.H{"err": err.Error()})
+		return
+	}
+
+	queryParams.Filters = append(queryParams.Filters, resources.FilterOption{
+		Field:           "issuer_meta_id",
+		FilterOperation: resources.StringEqual,
+		Value:           params.ID,
+	})
+
+	reqs := []models.CACertificateRequest{}
+
+	nextBookmark, err := r.svc.GetCARequests(ctx, services.GetItemsInput[models.CACertificateRequest]{
+		QueryParameters: queryParams,
+		ExhaustiveRun:   false,
+		ApplyFunc: func(req models.CACertificateRequest) {
+			reqs = append(reqs, req)
+		},
+	})
+
+	if err != nil {
+		switch err {
+		default:
+			ctx.JSON(500, gin.H{"err": err.Error()})
+		}
+
+		return
+	}
+
+	ctx.JSON(200, resources.GetItemsResponse[models.CACertificateRequest]{
+		IterableList: resources.IterableList[models.CACertificateRequest]{
+			NextBookmark: nextBookmark,
+			List:         reqs,
+		},
+	})
+}
+
 // @Summary Get CA By ID
 // @Description Get CA By ID
 // @Accept json
@@ -542,12 +708,12 @@ func (r *caHttpRoutes) GetCertificateBySerialNumber(ctx *gin.Context) {
 // @Failure 500
 // @Router /certificates [get]
 func (r *caHttpRoutes) GetCertificates(ctx *gin.Context) {
-	queryParams := FilterQuery(ctx.Request, cresources.CertificateFiltrableFields)
+	queryParams := FilterQuery(ctx.Request, resources.CertificateFiltrableFields)
 
 	certs := []models.Certificate{}
 
 	nextBookmark, err := r.svc.GetCertificates(ctx, services.GetCertificatesInput{
-		ListInput: cresources.ListInput[models.Certificate]{
+		ListInput: resources.ListInput[models.Certificate]{
 			QueryParameters: queryParams,
 			ExhaustiveRun:   false,
 			ApplyFunc: func(cert models.Certificate) {
@@ -580,14 +746,14 @@ func (r *caHttpRoutes) GetCertificatesByExpirationDate(ctx *gin.Context) {
 		return
 	}
 
-	queryParams := FilterQuery(ctx.Request, cresources.CertificateFiltrableFields)
+	queryParams := FilterQuery(ctx.Request, resources.CertificateFiltrableFields)
 
 	certs := []models.Certificate{}
 
 	nextBookmark, err := r.svc.GetCertificatesByExpirationDate(ctx, services.GetCertificatesByExpirationDateInput{
 		ExpiresAfter:  expirationQueryParams.ExpiresAfter,
 		ExpiresBefore: expirationQueryParams.ExpiresBefore,
-		ListInput: cresources.ListInput[models.Certificate]{
+		ListInput: resources.ListInput[models.Certificate]{
 			QueryParameters: queryParams,
 			ExhaustiveRun:   false,
 			ApplyFunc: func(cert models.Certificate) {
@@ -624,7 +790,7 @@ func (r *caHttpRoutes) GetCertificatesByExpirationDate(ctx *gin.Context) {
 // @Failure 500
 // @Router /cas/{id}/certificates [get]
 func (r *caHttpRoutes) GetCertificatesByCA(ctx *gin.Context) {
-	queryParams := FilterQuery(ctx.Request, cresources.CertificateFiltrableFields)
+	queryParams := FilterQuery(ctx.Request, resources.CertificateFiltrableFields)
 
 	type uriParams struct {
 		ID string `uri:"id" binding:"required"`
@@ -640,7 +806,7 @@ func (r *caHttpRoutes) GetCertificatesByCA(ctx *gin.Context) {
 
 	nextBookmark, err := r.svc.GetCertificatesByCA(ctx, services.GetCertificatesByCAInput{
 		CAID: params.ID,
-		ListInput: cresources.ListInput[models.Certificate]{
+		ListInput: resources.ListInput[models.Certificate]{
 			QueryParameters: queryParams,
 			ExhaustiveRun:   false,
 			ApplyFunc: func(cert models.Certificate) {
@@ -819,7 +985,7 @@ func (r *caHttpRoutes) SignatureVerify(ctx *gin.Context) {
 }
 
 func (r *caHttpRoutes) GetCertificatesByCAAndStatus(ctx *gin.Context) {
-	queryParams := FilterQuery(ctx.Request, cresources.CertificateFiltrableFields)
+	queryParams := FilterQuery(ctx.Request, resources.CertificateFiltrableFields)
 
 	type uriParams struct {
 		CAID   string `uri:"id" binding:"required"`
@@ -837,7 +1003,7 @@ func (r *caHttpRoutes) GetCertificatesByCAAndStatus(ctx *gin.Context) {
 	nextBookmark, err := r.svc.GetCertificatesByCaAndStatus(ctx, services.GetCertificatesByCaAndStatusInput{
 		CAID:   params.CAID,
 		Status: models.CertificateStatus(params.Status),
-		ListInput: cresources.ListInput[models.Certificate]{
+		ListInput: resources.ListInput[models.Certificate]{
 			QueryParameters: queryParams,
 			ExhaustiveRun:   false,
 			ApplyFunc: func(cert models.Certificate) {
@@ -870,7 +1036,7 @@ func (r *caHttpRoutes) GetCertificatesByCAAndStatus(ctx *gin.Context) {
 }
 
 func (r *caHttpRoutes) GetCertificatesByStatus(ctx *gin.Context) {
-	queryParams := FilterQuery(ctx.Request, cresources.CertificateFiltrableFields)
+	queryParams := FilterQuery(ctx.Request, resources.CertificateFiltrableFields)
 
 	type uriParams struct {
 		Status string `uri:"status" binding:"required"`
@@ -886,7 +1052,7 @@ func (r *caHttpRoutes) GetCertificatesByStatus(ctx *gin.Context) {
 
 	nextBookmark, err := r.svc.GetCertificatesByStatus(ctx, services.GetCertificatesByStatusInput{
 		Status: models.CertificateStatus(params.Status),
-		ListInput: cresources.ListInput[models.Certificate]{
+		ListInput: resources.ListInput[models.Certificate]{
 			QueryParameters: queryParams,
 			ExhaustiveRun:   false,
 			ApplyFunc: func(cert models.Certificate) {

--- a/backend/pkg/helpers/keystrength.go
+++ b/backend/pkg/helpers/keystrength.go
@@ -20,6 +20,11 @@ func KeyStrengthMetadataFromCertificate(cert *x509.Certificate) models.KeyStreng
 		keyBits = cert.PublicKey.(*ecdsa.PublicKey).Params().BitSize
 	}
 
+	return KeyStrengthBuilder(keyType, keyBits)
+
+}
+
+func KeyStrengthBuilder(keyType models.KeyType, keyBits int) models.KeyStrengthMetadata {
 	var keyStrength models.KeyStrength = models.KeyStrengthLow
 	switch keyType {
 	case models.KeyType(x509.RSA):

--- a/backend/pkg/middlewares/eventpub/ca.go
+++ b/backend/pkg/middlewares/eventpub/ca.go
@@ -6,7 +6,6 @@ import (
 
 	lservices "github.com/lamassuiot/lamassuiot/backend/v3/pkg/services"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
-	cmodels "github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/services"
 )
 
@@ -24,7 +23,7 @@ func NewCAEventBusPublisher(eventMWPub ICloudEventMiddlewarePublisher) lservices
 	}
 }
 
-func (mw CAEventPublisher) GetCryptoEngineProvider(ctx context.Context) ([]*cmodels.CryptoEngineProvider, error) {
+func (mw CAEventPublisher) GetCryptoEngineProvider(ctx context.Context) ([]*models.CryptoEngineProvider, error) {
 	return mw.Next.GetCryptoEngineProvider(ctx)
 }
 
@@ -42,6 +41,15 @@ func (mw CAEventPublisher) CreateCA(ctx context.Context, input services.CreateCA
 		}
 	}()
 	return mw.Next.CreateCA(ctx, input)
+}
+
+func (mw CAEventPublisher) RequestCACSR(ctx context.Context, input services.RequestCAInput) (output *models.CACertificateRequest, err error) {
+	defer func() {
+		if err == nil {
+			mw.eventMWPub.PublishCloudEvent(ctx, models.EventRequestCAKey, output)
+		}
+	}()
+	return mw.Next.RequestCACSR(ctx, input)
 }
 
 func (mw CAEventPublisher) ImportCA(ctx context.Context, input services.ImportCAInput) (output *models.CACertificate, err error) {
@@ -230,4 +238,16 @@ func (mw CAEventPublisher) UpdateCertificateMetadata(ctx context.Context, input 
 		}
 	}()
 	return mw.Next.UpdateCertificateMetadata(ctx, input)
+}
+
+func (mw CAEventPublisher) GetCARequestByID(ctx context.Context, input services.GetByIDInput) (*models.CACertificateRequest, error) {
+	return mw.Next.GetCARequestByID(ctx, input)
+}
+
+func (mw CAEventPublisher) DeleteCARequestByID(ctx context.Context, input services.GetByIDInput) error {
+	return mw.Next.DeleteCARequestByID(ctx, input)
+}
+
+func (mw CAEventPublisher) GetCARequests(ctx context.Context, input services.GetItemsInput[models.CACertificateRequest]) (string, error) {
+	return mw.Next.GetCARequests(ctx, input)
 }

--- a/backend/pkg/routes/ca.go
+++ b/backend/pkg/routes/ca.go
@@ -15,7 +15,6 @@ func NewCAHTTPLayer(parentRouterGroup *gin.RouterGroup, svc services.CAService) 
 	rv1.GET("/cas", routes.GetAllCAs)
 	rv1.POST("/cas", routes.CreateCA)
 	rv1.POST("/cas/import", routes.ImportCA)
-
 	rv1.GET("/cas/:id", routes.GetCAByID)
 	rv1.GET("/cas/cn/:cn", routes.GetCAsByCommonName)
 
@@ -29,6 +28,12 @@ func NewCAHTTPLayer(parentRouterGroup *gin.RouterGroup, svc services.CAService) 
 	rv1.GET("/cas/:id/certificates/:sn", routes.GetCertificateBySerialNumber)
 	rv1.PUT("/cas/:id/issuance-expiration", routes.UpdateCAIssuanceExpiration)
 	rv1.DELETE("/cas/:id", routes.DeleteCA)
+	rv1.GET("/cas/:id/requests", routes.GetCARequests)
+
+	rv1.POST("/cas/requests", routes.RequestCA)
+	rv1.GET("/cas/requests", routes.GetAllRequests)
+	rv1.GET("/cas/requests/:id", routes.GetCARequestByID)
+	rv1.DELETE("/cas/requests/:id", routes.DeleteCARequestByID)
 
 	rv1.GET("/certificates", routes.GetCertificates)
 	rv1.GET("/certificates/status/:status", routes.GetCertificatesByStatus)

--- a/backend/pkg/services/ca.go
+++ b/backend/pkg/services/ca.go
@@ -16,7 +16,7 @@ import (
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/engines/storage"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/errs"
 	chelpers "github.com/lamassuiot/lamassuiot/core/v3/pkg/helpers"
-	models "github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/resources"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/services"
 	"github.com/sirupsen/logrus"
@@ -34,24 +34,26 @@ type Engine struct {
 }
 
 type CAServiceBackend struct {
-	service               services.CAService
-	cryptoEngines         map[string]*cryptoengines.CryptoEngine
-	defaultCryptoEngine   *cryptoengines.CryptoEngine
-	defaultCryptoEngineID string
-	caStorage             storage.CACertificatesRepo
-	certStorage           storage.CertificatesRepo
-	cryptoMonitorConfig   cconfig.MonitoringJob
-	vaServerDomain        string
-	logger                *logrus.Entry
+	service                     services.CAService
+	cryptoEngines               map[string]*cryptoengines.CryptoEngine
+	defaultCryptoEngine         *cryptoengines.CryptoEngine
+	defaultCryptoEngineID       string
+	caStorage                   storage.CACertificatesRepo
+	certStorage                 storage.CertificatesRepo
+	caCertificateRequestStorage storage.CACertificateRequestRepo
+	cryptoMonitorConfig         cconfig.MonitoringJob
+	vaServerDomain              string
+	logger                      *logrus.Entry
 }
 
 type CAServiceBuilder struct {
-	Logger               *logrus.Entry
-	CryptoEngines        map[string]*Engine
-	CAStorage            storage.CACertificatesRepo
-	CertificateStorage   storage.CertificatesRepo
-	CryptoMonitoringConf cconfig.MonitoringJob
-	VAServerDomain       string
+	Logger                      *logrus.Entry
+	CryptoEngines               map[string]*Engine
+	CAStorage                   storage.CACertificatesRepo
+	CertificateStorage          storage.CertificatesRepo
+	CACertificateRequestStorage storage.CACertificateRequestRepo
+	CryptoMonitoringConf        cconfig.MonitoringJob
+	VAServerDomain              string
 }
 
 func NewCAService(builder CAServiceBuilder) (services.CAService, error) {
@@ -73,14 +75,15 @@ func NewCAService(builder CAServiceBuilder) (services.CAService, error) {
 	}
 
 	svc := CAServiceBackend{
-		cryptoEngines:         engines,
-		defaultCryptoEngine:   defaultCryptoEngine,
-		defaultCryptoEngineID: defaultCryptoEngineID,
-		caStorage:             builder.CAStorage,
-		certStorage:           builder.CertificateStorage,
-		cryptoMonitorConfig:   builder.CryptoMonitoringConf,
-		vaServerDomain:        builder.VAServerDomain,
-		logger:                builder.Logger,
+		cryptoEngines:               engines,
+		defaultCryptoEngine:         defaultCryptoEngine,
+		defaultCryptoEngineID:       defaultCryptoEngineID,
+		caStorage:                   builder.CAStorage,
+		certStorage:                 builder.CertificateStorage,
+		caCertificateRequestStorage: builder.CACertificateRequestStorage,
+		cryptoMonitorConfig:         builder.CryptoMonitoringConf,
+		vaServerDomain:              builder.VAServerDomain,
+		logger:                      builder.Logger,
 	}
 
 	svc.service = &svc
@@ -194,24 +197,58 @@ func (svc *CAServiceBackend) GetCryptoEngineProvider(ctx context.Context) ([]*mo
 	return info, nil
 }
 
-func (svc *CAServiceBackend) issueCA(ctx context.Context, input services.IssueCAInput) (*services.IssueCAOutput, error) {
-	lFunc := chelpers.ConfigureLogger(ctx, svc.logger)
-	var err error
-
+func (svc *CAServiceBackend) getX509CryptoEngineByID(_ context.Context, engineID string, logger *logrus.Entry) (x509engines.X509Engine, error) {
 	var x509Engine x509engines.X509Engine
-	if input.EngineID == "" {
-		x509Engine = x509engines.NewX509Engine(lFunc, svc.defaultCryptoEngine, svc.vaServerDomain)
-		lFunc.Infof("creating CA %s with default engine %s crypto engine", input.Subject.CommonName, x509Engine.GetEngineConfig().Provider)
+	if engineID == "" {
+		x509Engine = x509engines.NewX509Engine(logger, svc.defaultCryptoEngine, svc.vaServerDomain)
+		logger.Infof("selecting default crypto engine %s", x509Engine.GetEngineConfig().Provider)
 	} else {
-		if engine, ok := svc.cryptoEngines[input.EngineID]; ok {
-			x509Engine = x509engines.NewX509Engine(lFunc, engine, svc.vaServerDomain)
-			lFunc.Infof("creating CA %s with %s crypto engine", input.Subject.CommonName, x509Engine.GetEngineConfig().Provider)
+		if engine, ok := svc.cryptoEngines[engineID]; ok {
+			x509Engine = x509engines.NewX509Engine(logger, engine, svc.vaServerDomain)
 		} else {
-			errMsg := fmt.Sprintf("engine ID %s not configured", input.EngineID)
-			lFunc.Error(errMsg)
-			return nil, fmt.Errorf("%s", errMsg)
+			return x509Engine, errs.ErrCryptoEngineNotFound
 		}
 	}
+	return x509Engine, nil
+}
+
+func (svc *CAServiceBackend) issueCACSR(ctx context.Context, input services.IssueCACSRInput) (*services.IssueCACSROutput, error) {
+	lFunc := chelpers.ConfigureLogger(ctx, svc.logger)
+
+	x509Engine, err := svc.getX509CryptoEngineByID(ctx, input.EngineID, lFunc)
+	if err != nil {
+		errMsg := fmt.Sprintf("engine ID %s not configured", input.EngineID)
+		lFunc.Error(errMsg)
+		return nil, fmt.Errorf("%s", errMsg)
+	}
+
+	if input.ParentCA == nil {
+		return nil, fmt.Errorf("cannot issue a CA CSR for a root CA")
+	}
+
+	keyId, csr, err := x509Engine.CreateCertificateRequest(input.KeyMetadata, input.Subject)
+	if err != nil {
+		lFunc.Errorf("could not create CSR for CA %s: %s", input.Subject.CommonName, err)
+		return nil, err
+	}
+
+	return &services.IssueCACSROutput{
+		KeyID: keyId,
+		CSR:   csr,
+	}, nil
+
+}
+
+func (svc *CAServiceBackend) issueCA(ctx context.Context, input services.IssueCAInput) (*services.IssueCAOutput, error) {
+	lFunc := chelpers.ConfigureLogger(ctx, svc.logger)
+
+	x509Engine, err := svc.getX509CryptoEngineByID(ctx, input.EngineID, lFunc)
+	if err != nil {
+		errMsg := fmt.Sprintf("engine ID %s not configured", input.EngineID)
+		lFunc.Error(errMsg)
+		return nil, fmt.Errorf("%s", errMsg)
+	}
+	lFunc.Infof("creating CA %s with %s crypto engine", input.Subject.CommonName, x509Engine.GetEngineConfig().Provider)
 
 	var caCert *x509.Certificate
 	var keyID string
@@ -278,12 +315,11 @@ func (svc *CAServiceBackend) issueCA(ctx context.Context, input services.IssueCA
 //   - ErrValidateBadRequest
 //     The required variables of the data structure are not valid.
 func (svc *CAServiceBackend) ImportCA(ctx context.Context, input services.ImportCAInput) (*models.CACertificate, error) {
-	var err error
 
 	lFunc := chelpers.ConfigureLogger(ctx, svc.logger)
 
 	validate.RegisterStructValidation(importCAValidation, services.ImportCAInput{})
-	err = validate.Struct(input)
+	err := validate.Struct(input)
 	if err != nil {
 		lFunc.Errorf("ImportCA struct validation error: %s", err)
 		return nil, errs.ErrValidateBadRequest
@@ -292,10 +328,11 @@ func (svc *CAServiceBackend) ImportCA(ctx context.Context, input services.Import
 	}
 
 	var keyID string
-
-	caCert := input.CACertificate
 	var engineID string
-	if input.CAType != models.CertificateTypeExternal {
+	caCert := input.CACertificate
+	parentID := input.ParentID
+
+	if input.CAType == models.CertificateTypeImportedWithKey {
 		lFunc.Debugf("importing CA %s - %s  private key. CA type: %s", helpers.SerialNumberToString(input.CACertificate.SerialNumber), input.CACertificate.Subject.CommonName, input.CAType)
 		var engine cryptoengines.CryptoEngine
 		if input.EngineID == "" {
@@ -304,6 +341,10 @@ func (svc *CAServiceBackend) ImportCA(ctx context.Context, input services.Import
 			lFunc.Infof("importing CA %s - %s  with %s crypto engine", helpers.SerialNumberToString(input.CACertificate.SerialNumber), input.CACertificate.Subject.CommonName, engine.GetEngineConfig().Provider)
 		} else {
 			engine = *svc.cryptoEngines[input.EngineID]
+			if engine == nil {
+				lFunc.Errorf("engine ID %s not configured", input.EngineID)
+				return nil, fmt.Errorf("engine ID %s not configured", input.EngineID)
+			}
 			engineID = input.EngineID
 			lFunc.Infof("importing CA %s - %s with %s crypto engine", helpers.SerialNumberToString(input.CACertificate.SerialNumber), input.CACertificate.Subject.CommonName, engine.GetEngineConfig().Provider)
 		}
@@ -323,20 +364,80 @@ func (svc *CAServiceBackend) ImportCA(ctx context.Context, input services.Import
 		}
 	}
 
+	var caReq *models.CACertificateRequest
+	if input.CAType == models.CertificateTypeRequested {
+		lFunc.Debugf("importing CA %s - %s  from CSR. CA type: %s", helpers.SerialNumberToString(input.CACertificate.SerialNumber), input.CACertificate.Subject.CommonName, input.CAType)
+		if input.CARequestID == "" {
+			lFunc.Errorf("CA Request ID is required for requested CA")
+			return nil, fmt.Errorf("CA Request ID is required for requested CA")
+		}
+		var exists bool
+		exists, caReq, err = svc.caCertificateRequestStorage.SelectExistsByID(ctx, input.CARequestID)
+		if err != nil {
+			lFunc.Errorf("could not get CA Request %s: %s", input.CARequestID, err)
+			return nil, fmt.Errorf("could not get CA Request: %w", err)
+		}
+
+		if !exists {
+			lFunc.Errorf("CA Request %s not found", input.CARequestID)
+			return nil, fmt.Errorf("CA Request not found")
+		}
+
+		if caReq.Status != models.StatusRequestPending {
+			lFunc.Errorf("CA Request %s is not pending", input.CARequestID)
+			return nil, fmt.Errorf("CA Request is not pending")
+		}
+
+		caCSR := &caReq.CSR
+
+		if caCSR.PublicKeyAlgorithm != caCert.PublicKeyAlgorithm {
+			lFunc.Errorf("CA certificate and CSR are not compatible - Public Key Algorithm")
+			return nil, fmt.Errorf("%s", "CA certificate and CSR are not compatible - Public Key Algorithm")
+		}
+
+		if !chelpers.PkixNameEqual(caCSR.Subject, caCert.Subject) {
+			lFunc.Errorf("CA certificate and CSR are not compatible - Subject")
+			return nil, fmt.Errorf("%s", "CA certificate and CSR are not compatible - Subject")
+		}
+
+		if !caCert.IsCA {
+			lFunc.Errorf("CA certificate and CSR are not compatible - IsCA")
+			return nil, fmt.Errorf("%s", "CA certificate and CSR are not compatible - IsCA")
+		}
+
+		if !chelpers.EqualPublicKeys(caCSR.PublicKey, caCert.PublicKey) {
+			lFunc.Errorf("CA certificate and CSR are not compatible - Public Key")
+			return nil, fmt.Errorf("%s", "CA certificate and CSR are not compatible - Public Key")
+		}
+
+		engineID = caReq.EngineID
+		parentID = caReq.IssuerCAMetadata.ID
+		keyID = caReq.KeyId
+	}
+
 	caID := input.ID
 	if caID == "" {
 		caID = goid.NewV4UUID().String()
 	}
 
 	var parentCA *models.CACertificate
-	if input.ParentID != "" {
+	if parentID != "" {
 		parentCA, err = svc.service.GetCAByID(ctx, services.GetCAByIDInput{
-			CAID: input.ParentID,
+			CAID: parentID,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("parent CA not found: %w", err)
 		}
 
+		// Verify that the parent CA signed the certificate
+		parentCert := parentCA.Certificate.Certificate
+		p := x509.Certificate(*parentCert)
+		c := x509.Certificate(*caCert)
+		err = c.CheckSignatureFrom(&p)
+		if err != nil {
+			lFunc.Errorf("parent CA did not sign the certificate: %s", err)
+			return nil, fmt.Errorf("parent CA did not sign the certificate: %w", err)
+		}
 	}
 
 	issuerMeta := models.IssuerCAMetadata{
@@ -349,7 +450,7 @@ func (svc *CAServiceBackend) ImportCA(ctx context.Context, input services.Import
 	if parentCA != nil {
 		level = parentCA.Level + 1
 		issuerMeta = models.IssuerCAMetadata{
-			ID:    input.ParentID,
+			ID:    parentCA.ID,
 			SN:    parentCA.Certificate.SerialNumber,
 			Level: parentCA.Level,
 		}
@@ -380,7 +481,116 @@ func (svc *CAServiceBackend) ImportCA(ctx context.Context, input services.Import
 	}
 
 	lFunc.Debugf("insert CA %s in storage engine", caID)
-	return svc.caStorage.Insert(ctx, ca)
+	cert, err := svc.caStorage.Insert(ctx, ca)
+
+	if err == nil && input.CAType == models.CertificateTypeRequested {
+		caReq.Status = models.StatusRequestIssued
+		_, err = svc.caCertificateRequestStorage.Update(ctx, caReq)
+		if err != nil {
+			lFunc.Warnf("could not update CA Request %s: %s", input.CARequestID, err)
+		}
+	}
+
+	return cert, err
+}
+
+func (svc *CAServiceBackend) RequestCACSR(ctx context.Context, input services.RequestCAInput) (*models.CACertificateRequest, error) {
+	lFunc := chelpers.ConfigureLogger(ctx, svc.logger)
+	if input.Metadata == nil {
+		input.Metadata = map[string]any{}
+	}
+
+	var err error
+	validate.RegisterStructValidation(createCAValidation, services.CreateCAInput{})
+	err = validate.Struct(input)
+	if err != nil {
+		lFunc.Errorf("RequestCAInput struct validation error: %s", err)
+		return nil, errs.ErrValidateBadRequest
+	}
+
+	if input.ParentID == "" {
+		lFunc.Errorf("cannot request a CSR for a root CA")
+		return nil, fmt.Errorf("cannot request a CSR for a root CA")
+	}
+
+	lFunc.Debugf("requesting CSR for CA %s", input.Subject.CommonName)
+
+	exists, parentCA, err := svc.caStorage.SelectExistsByID(ctx, input.ParentID)
+	if err != nil {
+		lFunc.Errorf("could not check if parent CA %s exists: %s", input.ParentID, err)
+		return nil, err
+	}
+
+	if !exists {
+		lFunc.Errorf("parent CA %s does not exist", input.ParentID)
+		return nil, fmt.Errorf("parent CA %s does not exist", input.ParentID)
+	}
+
+	lFunc.Debugf("parent CA %s exists", input.ParentID)
+
+	if parentCA.Certificate.Type != models.CertificateTypeExternal {
+		lFunc.Errorf("cannot request a CSR for a managed CA")
+		return nil, fmt.Errorf("cannot request a CSR for a managed CA")
+	}
+
+	caID := input.ID
+	if caID == "" {
+		caID = goid.NewV4UUID().String()
+	}
+
+	exists, _, err = svc.caCertificateRequestStorage.SelectExistsByID(ctx, caID)
+	if err != nil {
+		lFunc.Errorf("could not check if CA %s exists: %s", caID, err)
+		return nil, err
+	}
+
+	if exists {
+		lFunc.Errorf("cannot create duplicate CA. CA with ID '%s' already exists:", caID)
+		return nil, errs.ErrCAAlreadyExists
+	}
+
+	engineID, err := svc.getAvailableCryptoEngineId(input.EngineID)
+	if err != nil {
+		lFunc.Errorf("could not get engine ID %s: %s", input.EngineID, err)
+	}
+
+	issuedCSR, err := svc.issueCACSR(ctx, services.IssueCACSRInput{
+		ParentCA:    parentCA,
+		KeyMetadata: input.KeyMetadata,
+		Subject:     input.Subject,
+		CAType:      models.CertificateTypeRequested,
+		EngineID:    engineID,
+		CAID:        input.ID,
+	})
+
+	if err != nil {
+		lFunc.Errorf("could not create CA %s CSR: %s", input.Subject.CommonName, err)
+		return nil, err
+	}
+
+	caLevel := parentCA.Level + 1
+	issuerCAMeta := models.IssuerCAMetadata{
+		SN:    parentCA.Certificate.SerialNumber,
+		ID:    parentCA.ID,
+		Level: parentCA.Level,
+	}
+
+	caCSRModel := models.CACertificateRequest{
+		ID:               caID,
+		Metadata:         input.Metadata,
+		CreationTS:       time.Now(),
+		Level:            caLevel,
+		KeyId:            issuedCSR.KeyID,
+		IssuerCAMetadata: issuerCAMeta,
+		Subject:          input.Subject,
+		Status:           models.StatusRequestPending,
+		EngineID:         engineID,
+		KeyMetadata:      helpers.KeyStrengthBuilder(input.KeyMetadata.Type, input.KeyMetadata.Bits),
+		CSR:              models.X509CertificateRequest(*issuedCSR.CSR),
+	}
+
+	lFunc.Debugf("insert CA Request %s in storage engine", caID)
+	return svc.caCertificateRequestStorage.Insert(ctx, &caCSRModel)
 }
 
 // Returned Error Codes:
@@ -470,12 +680,10 @@ func (svc *CAServiceBackend) CreateCA(ctx context.Context, input services.Create
 		lFunc.Errorf("could not create CA %s certificate: %s", input.Subject.CommonName, err)
 		return nil, err
 	}
-	var engineID string
-	if input.EngineID == "" {
-		engineID = svc.defaultCryptoEngineID
 
-	} else {
-		engineID = input.EngineID
+	engineID, err := svc.getAvailableCryptoEngineId(input.EngineID)
+	if err != nil {
+		lFunc.Errorf("could not get engine ID %s: %s", input.EngineID, err)
 	}
 
 	caCert := issuedCA.Certificate
@@ -527,6 +735,92 @@ func (svc *CAServiceBackend) CreateCA(ctx context.Context, input services.Create
 	return svc.caStorage.Insert(ctx, &ca)
 }
 
+func (svc *CAServiceBackend) getAvailableCryptoEngineId(engineId string) (string, error) {
+	availableEngineId := svc.defaultCryptoEngineID
+	if engineId != "" {
+		_, ok := svc.cryptoEngines[engineId]
+		if !ok {
+			return "", errs.ErrCryptoEngineNotFound
+		}
+		availableEngineId = engineId
+	}
+
+	return availableEngineId, nil
+}
+
+func (svc *CAServiceBackend) GetCARequests(ctx context.Context, input services.GetItemsInput[models.CACertificateRequest]) (string, error) {
+	lFunc := chelpers.ConfigureLogger(ctx, svc.logger)
+
+	nextBookmark, err := svc.caCertificateRequestStorage.SelectAll(ctx, storage.StorageListRequest[models.CACertificateRequest]{
+		ExhaustiveRun: input.ExhaustiveRun,
+		ApplyFunc:     input.ApplyFunc,
+		QueryParams:   input.QueryParameters,
+		ExtraOpts:     nil,
+	})
+	if err != nil {
+		lFunc.Errorf("something went wrong while reading all Requests from storage engine: %s", err)
+		return "", err
+	}
+
+	return nextBookmark, nil
+}
+
+func (svc *CAServiceBackend) GetCARequestByID(ctx context.Context, input services.GetByIDInput) (*models.CACertificateRequest, error) {
+	lFunc := chelpers.ConfigureLogger(ctx, svc.logger)
+
+	err := validate.Struct(input)
+	if err != nil {
+		lFunc.Errorf("GetByIDInput struct validation error: %s", err)
+		return nil, errs.ErrValidateBadRequest
+	}
+
+	lFunc.Debugf("checking if CA Request '%s' exists", input.ID)
+	exists, caReq, err := svc.caCertificateRequestStorage.SelectExistsByID(ctx, input.ID)
+	if err != nil {
+		lFunc.Errorf("something went wrong while checking if CA Request '%s' exists in storage engine: %s", input.ID, err)
+		return nil, err
+	}
+
+	if !exists {
+		lFunc.Errorf("CA Request %s can not be found in storage engine", input.ID)
+		return nil, errs.ErrCANotFound
+	}
+
+	return caReq, err
+}
+
+// DeleteCARequestByID deletes a CA Request by ID
+func (svc *CAServiceBackend) DeleteCARequestByID(ctx context.Context, input services.GetByIDInput) error {
+	lFunc := chelpers.ConfigureLogger(ctx, svc.logger)
+
+	err := validate.Struct(input)
+	if err != nil {
+		lFunc.Errorf("DeleteCAByIDInput struct validation error: %s", err)
+		return errs.ErrValidateBadRequest
+	}
+
+	lFunc.Debugf("checking if CA Request '%s' exists", input.ID)
+	exists, _, err := svc.caCertificateRequestStorage.SelectExistsByID(ctx, input.ID)
+	if err != nil {
+		lFunc.Errorf("something went wrong while checking if CA Request '%s' exists in storage engine: %s", input.ID, err)
+		return err
+	}
+
+	if !exists {
+		lFunc.Errorf("CA Request %s can not be found in storage engine", input.ID)
+		return errs.ErrCANotFound
+	}
+
+	lFunc.Debugf("deleting CA Request %s from storage engine", input.ID)
+	err = svc.caCertificateRequestStorage.Delete(ctx, input.ID)
+	if err != nil {
+		lFunc.Errorf("something went wrong while deleting CA Request '%s' from storage engine: %s", input.ID, err)
+		return err
+	}
+
+	return nil
+}
+
 // Returned Error Codes:
 //   - ErrCANotFound
 //     The specified CA can not be found in the Database
@@ -537,7 +831,7 @@ func (svc *CAServiceBackend) GetCAByID(ctx context.Context, input services.GetCA
 
 	err := validate.Struct(input)
 	if err != nil {
-		lFunc.Errorf("GetCAByIDInput struct validation error: %s", err)
+		lFunc.Errorf("GetByIDInput struct validation error: %s", err)
 		return nil, errs.ErrValidateBadRequest
 	}
 
@@ -1270,7 +1564,7 @@ func importCAValidation(sl validator.StructLevel) {
 	ca := sl.Current().Interface().(services.ImportCAInput)
 	caCert := ca.CACertificate
 
-	if ca.CAType != models.CertificateTypeExternal {
+	if ca.CAType == models.CertificateTypeImportedWithKey {
 		if !helpers.ValidateCAExpiration(ca.IssuanceExpiration, caCert.NotAfter) {
 			// lFunc.Errorf("issuance expiration is greater than the CA expiration")
 			sl.ReportError(ca.IssuanceExpiration, "IssuanceExpiration", "IssuanceExpiration", "IssuanceExpirationGreaterThanCAExpiration", "")

--- a/core/pkg/engines/storage/ca.go
+++ b/core/pkg/engines/storage/ca.go
@@ -43,6 +43,7 @@ type CACertificateRequestRepo interface {
 	Insert(ctx context.Context, caCertificateRequest *models.CACertificateRequest) (*models.CACertificateRequest, error)
 	SelectExistsByID(ctx context.Context, id string) (bool, *models.CACertificateRequest, error)
 	SelectAll(ctx context.Context, req StorageListRequest[models.CACertificateRequest]) (string, error)
+	SelectByFingerprint(ctx context.Context, fingerprint string, req StorageListRequest[models.CACertificateRequest]) (string, error)
 	Update(ctx context.Context, caCertificate *models.CACertificateRequest) (*models.CACertificateRequest, error)
 	Delete(ctx context.Context, caID string) error
 }

--- a/core/pkg/engines/storage/ca.go
+++ b/core/pkg/engines/storage/ca.go
@@ -38,3 +38,11 @@ type CACertificatesRepo interface {
 	Update(ctx context.Context, caCertificate *models.CACertificate) (*models.CACertificate, error)
 	Delete(ctx context.Context, caID string) error
 }
+
+type CACertificateRequestRepo interface {
+	Insert(ctx context.Context, caCertificateRequest *models.CACertificateRequest) (*models.CACertificateRequest, error)
+	SelectExistsByID(ctx context.Context, id string) (bool, *models.CACertificateRequest, error)
+	SelectAll(ctx context.Context, req StorageListRequest[models.CACertificateRequest]) (string, error)
+	Update(ctx context.Context, caCertificate *models.CACertificateRequest) (*models.CACertificateRequest, error)
+	Delete(ctx context.Context, caID string) error
+}

--- a/core/pkg/engines/storage/engine.go
+++ b/core/pkg/engines/storage/engine.go
@@ -6,18 +6,20 @@ import (
 )
 
 type CommonStorageEngine struct {
-	CA            CACertificatesRepo
-	Cert          CertificatesRepo
-	Device        DeviceManagerRepo
-	DMS           DMSRepo
-	Events        EventRepository
-	Subscriptions SubscriptionsRepository
+	CA                   CACertificatesRepo
+	CACertificateRequest CACertificateRequestRepo
+	Cert                 CertificatesRepo
+	Device               DeviceManagerRepo
+	DMS                  DMSRepo
+	Events               EventRepository
+	Subscriptions        SubscriptionsRepository
 }
 
 type StorageEngine interface {
 	GetProvider() config.StorageProvider
 	GetCAStorage() (CACertificatesRepo, error)
 	GetCertstorage() (CertificatesRepo, error)
+	GetCACertificateRequestStorage() (CACertificateRequestRepo, error)
 	GetDeviceStorage() (DeviceManagerRepo, error)
 	GetDMSStorage() (DMSRepo, error)
 	GetEnventsStorage() (EventRepository, error)

--- a/core/pkg/engines/storage/engine_test.go
+++ b/core/pkg/engines/storage/engine_test.go
@@ -22,6 +22,10 @@ func (m *MockStorageEngine) GetCertstorage() (CertificatesRepo, error) {
 	return nil, nil
 }
 
+func (m *MockStorageEngine) GetCACertificateRequestStorage() (CACertificateRequestRepo, error) {
+	return nil, nil
+}
+
 func (m *MockStorageEngine) GetDeviceStorage() (DeviceManagerRepo, error) {
 	return nil, nil
 }

--- a/core/pkg/helpers/cryptosubject.go
+++ b/core/pkg/helpers/cryptosubject.go
@@ -74,3 +74,31 @@ func PkixNameToSubject(pkixName pkix.Name) cmodels.Subject {
 func PkixNameToString(subject pkix.Name) string {
 	return fmt.Sprintf("C=%v/ST=%v/L=%v/O=%v/OU=%v/CN=%s", subject.Country, subject.Province, subject.Locality, subject.Organization, subject.OrganizationalUnit, subject.CommonName)
 }
+
+func PkixNameEqual(a, b pkix.Name) bool {
+	if a.CommonName != b.CommonName {
+		return false
+	}
+
+	if len(a.Country) != len(b.Country) || (len(a.Country) > 0 && a.Country[0] != b.Country[0]) {
+		return false
+	}
+
+	if len(a.Locality) != len(b.Locality) || (len(a.Locality) > 0 && a.Locality[0] != b.Locality[0]) {
+		return false
+	}
+
+	if len(a.Organization) != len(b.Organization) || (len(a.Organization) > 0 && a.Organization[0] != b.Organization[0]) {
+		return false
+	}
+
+	if len(a.OrganizationalUnit) != len(b.OrganizationalUnit) || (len(a.OrganizationalUnit) > 0 && a.OrganizationalUnit[0] != b.OrganizationalUnit[0]) {
+		return false
+	}
+
+	if len(a.Province) != len(b.Province) || (len(a.Province) > 0 && a.Province[0] != b.Province[0]) {
+		return false
+	}
+
+	return true
+}

--- a/core/pkg/helpers/cryptosubject_test.go
+++ b/core/pkg/helpers/cryptosubject_test.go
@@ -278,3 +278,187 @@ func TestPkixNameToString(t *testing.T) {
 		t.Errorf("Expected %v, but got %v", expected8, result8)
 	}
 }
+func TestPkixNameEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        pkix.Name
+		b        pkix.Name
+		expected bool
+	}{
+		{
+			name:     "both empty",
+			a:        pkix.Name{},
+			b:        pkix.Name{},
+			expected: true,
+		},
+		{
+			name: "different CommonName",
+			a: pkix.Name{
+				CommonName: "example.com",
+			},
+			b: pkix.Name{
+				CommonName: "example.org",
+			},
+			expected: false,
+		},
+		{
+			name: "same CommonName",
+			a: pkix.Name{
+				CommonName: "example.com",
+			},
+			b: pkix.Name{
+				CommonName: "example.com",
+			},
+			expected: true,
+		},
+		{
+			name: "different Country",
+			a: pkix.Name{
+				Country: []string{"US"},
+			},
+			b: pkix.Name{
+				Country: []string{"CA"},
+			},
+			expected: false,
+		},
+		{
+			name: "same Country",
+			a: pkix.Name{
+				Country: []string{"US"},
+			},
+			b: pkix.Name{
+				Country: []string{"US"},
+			},
+			expected: true,
+		},
+		{
+			name: "different Locality",
+			a: pkix.Name{
+				Locality: []string{"San Francisco"},
+			},
+			b: pkix.Name{
+				Locality: []string{"Los Angeles"},
+			},
+			expected: false,
+		},
+		{
+			name: "same Locality",
+			a: pkix.Name{
+				Locality: []string{"San Francisco"},
+			},
+			b: pkix.Name{
+				Locality: []string{"San Francisco"},
+			},
+			expected: true,
+		},
+		{
+			name: "different Organization",
+			a: pkix.Name{
+				Organization: []string{"Acme Corp"},
+			},
+			b: pkix.Name{
+				Organization: []string{"Globex Corp"},
+			},
+			expected: false,
+		},
+		{
+			name: "same Organization",
+			a: pkix.Name{
+				Organization: []string{"Acme Corp"},
+			},
+			b: pkix.Name{
+				Organization: []string{"Acme Corp"},
+			},
+			expected: true,
+		},
+		{
+			name: "different OrganizationalUnit",
+			a: pkix.Name{
+				OrganizationalUnit: []string{"IT"},
+			},
+			b: pkix.Name{
+				OrganizationalUnit: []string{"HR"},
+			},
+			expected: false,
+		},
+		{
+			name: "same OrganizationalUnit",
+			a: pkix.Name{
+				OrganizationalUnit: []string{"IT"},
+			},
+			b: pkix.Name{
+				OrganizationalUnit: []string{"IT"},
+			},
+			expected: true,
+		},
+		{
+			name: "different Province",
+			a: pkix.Name{
+				Province: []string{"California"},
+			},
+			b: pkix.Name{
+				Province: []string{"Nevada"},
+			},
+			expected: false,
+		},
+		{
+			name: "same Province",
+			a: pkix.Name{
+				Province: []string{"California"},
+			},
+			b: pkix.Name{
+				Province: []string{"California"},
+			},
+			expected: true,
+		},
+		{
+			name: "all fields same",
+			a: pkix.Name{
+				CommonName:         "example.com",
+				Country:            []string{"US"},
+				Locality:           []string{"San Francisco"},
+				Organization:       []string{"Acme Corp"},
+				OrganizationalUnit: []string{"IT"},
+				Province:           []string{"California"},
+			},
+			b: pkix.Name{
+				CommonName:         "example.com",
+				Country:            []string{"US"},
+				Locality:           []string{"San Francisco"},
+				Organization:       []string{"Acme Corp"},
+				OrganizationalUnit: []string{"IT"},
+				Province:           []string{"California"},
+			},
+			expected: true,
+		},
+		{
+			name: "all fields different",
+			a: pkix.Name{
+				CommonName:         "example.com",
+				Country:            []string{"US"},
+				Locality:           []string{"San Francisco"},
+				Organization:       []string{"Acme Corp"},
+				OrganizationalUnit: []string{"IT"},
+				Province:           []string{"California"},
+			},
+			b: pkix.Name{
+				CommonName:         "example.org",
+				Country:            []string{"CA"},
+				Locality:           []string{"Los Angeles"},
+				Organization:       []string{"Globex Corp"},
+				OrganizationalUnit: []string{"HR"},
+				Province:           []string{"Nevada"},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := PkixNameEqual(tt.a, tt.b)
+			if result != tt.expected {
+				t.Errorf("Expected %v, but got %v", tt.expected, result)
+			}
+		})
+	}
+}

--- a/core/pkg/helpers/cryptoutils.go
+++ b/core/pkg/helpers/cryptoutils.go
@@ -5,6 +5,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/sha512"
 	"crypto/tls"
 	"crypto/x509"
@@ -294,4 +295,23 @@ func EqualPublicKeys(pubKey1, pubKey2 any) bool {
 	}
 
 	return false
+}
+
+func ComputePublicKeyFingerprint[T *x509.Certificate | *x509.CertificateRequest](cert T) string {
+	switch v := any(cert).(type) {
+	case *x509.Certificate:
+		return PublicKeyFingerprint(v.PublicKey)
+	case *x509.CertificateRequest:
+		return PublicKeyFingerprint(v.PublicKey)
+	default:
+		return ""
+	}
+}
+
+func PublicKeyFingerprint(pubKey any) string {
+	pk, err := x509.MarshalPKIXPublicKey(pubKey)
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("%x", sha256.Sum256(pk))
 }

--- a/core/pkg/helpers/cryptoutils.go
+++ b/core/pkg/helpers/cryptoutils.go
@@ -276,3 +276,22 @@ func CalculateECDSAKeySizes(keyMin int, KeyMax int) []int {
 	}
 	return keySizes
 }
+
+func EqualPublicKeys(pubKey1, pubKey2 any) bool {
+	switch pubKey1.(type) {
+	case *rsa.PublicKey:
+		pk2, ok := pubKey2.(*rsa.PublicKey)
+		if !ok {
+			return false
+		}
+		return pubKey1.(*rsa.PublicKey).Equal(pk2)
+	case *ecdsa.PublicKey:
+		pk2, ok := pubKey2.(*ecdsa.PublicKey)
+		if !ok {
+			return false
+		}
+		return pubKey1.(*ecdsa.PublicKey).Equal(pk2)
+	}
+
+	return false
+}

--- a/core/pkg/helpers/cryptoutils_test.go
+++ b/core/pkg/helpers/cryptoutils_test.go
@@ -304,3 +304,51 @@ func TestCalculateECDSAKeySizes(t *testing.T) {
 		t.Errorf("Unexpected key sizes. Expected: %v, Got: %v", expectedKeySizes, keySizes)
 	}
 }
+func TestEqualPublicKeys(t *testing.T) {
+	// Test case 1: Equal RSA public keys
+	rsaKey1, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("Failed to generate RSA key: %v", err)
+	}
+	rsaKey2 := &rsaKey1.PublicKey
+
+	if !EqualPublicKeys(&rsaKey1.PublicKey, rsaKey2) {
+		t.Errorf("Expected RSA public keys to be equal, but they were not")
+	}
+
+	// Test case 2: Different RSA public keys
+	rsaKey3, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("Failed to generate RSA key: %v", err)
+	}
+
+	if EqualPublicKeys(&rsaKey1.PublicKey, &rsaKey3.PublicKey) {
+		t.Errorf("Expected RSA public keys to be different, but they were equal")
+	}
+
+	// Test case 3: Equal ECDSA public keys
+	ecdsaKey1, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("Failed to generate ECDSA key: %v", err)
+	}
+	ecdsaKey2 := &ecdsaKey1.PublicKey
+
+	if !EqualPublicKeys(&ecdsaKey1.PublicKey, ecdsaKey2) {
+		t.Errorf("Expected ECDSA public keys to be equal, but they were not")
+	}
+
+	// Test case 4: Different ECDSA public keys
+	ecdsaKey3, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("Failed to generate ECDSA key: %v", err)
+	}
+
+	if EqualPublicKeys(&ecdsaKey1.PublicKey, &ecdsaKey3.PublicKey) {
+		t.Errorf("Expected ECDSA public keys to be different, but they were equal")
+	}
+
+	// Test case 5: Different types of public keys
+	if EqualPublicKeys(&rsaKey1.PublicKey, &ecdsaKey1.PublicKey) {
+		t.Errorf("Expected public keys of different types to be different, but they were equal")
+	}
+}

--- a/core/pkg/helpers/readcerts.go
+++ b/core/pkg/helpers/readcerts.go
@@ -33,6 +33,11 @@ func ParseCertificate(cert string) (*x509.Certificate, error) {
 	return x509.ParseCertificate(certDERBlock.Bytes)
 }
 
+func ParseCertificateRequest(cert string) (*x509.CertificateRequest, error) {
+	certDERBlock, _ := pem.Decode([]byte(cert))
+	return x509.ParseCertificateRequest(certDERBlock.Bytes)
+}
+
 func ReadPrivateKeyFromFile(filePath string) (interface{}, error) {
 	keyFileBytes, err := os.ReadFile(filePath)
 	if err != nil {

--- a/core/pkg/models/ca.go
+++ b/core/pkg/models/ca.go
@@ -78,18 +78,16 @@ const (
 )
 
 type CACertificateRequest struct {
-	ID               string                   `json:"id"`
-	KeyId            string                   `json:"key_id"`
-	Metadata         map[string]interface{}   `json:"metadata" gorm:"serializer:json"`
-	IssuerCAMetadata IssuerCAMetadata         `json:"issuer_metadata" gorm:"embedded;embeddedPrefix:issuer_meta_"`
-	Subject          Subject                  `json:"subject" gorm:"embedded;embeddedPrefix:subject_"`
-	CreationTS       time.Time                `json:"creation_ts"`
-	Level            int                      `json:"level"`
-	EngineID         string                   `json:"engine_id"`
-	KeyMetadata      KeyStrengthMetadata      `json:"key_metadata" gorm:"embedded;embeddedPrefix:key_meta_"`
-	Status           CertificateRequestStatus `json:"status"`
-	Fingerprint      string                   `json:"fingerprint"`
-	CSR              X509CertificateRequest   `json:"csr"`
+	ID          string                   `json:"id"`
+	KeyId       string                   `json:"key_id"`
+	Metadata    map[string]interface{}   `json:"metadata" gorm:"serializer:json"`
+	Subject     Subject                  `json:"subject" gorm:"embedded;embeddedPrefix:subject_"`
+	CreationTS  time.Time                `json:"creation_ts"`
+	EngineID    string                   `json:"engine_id"`
+	KeyMetadata KeyStrengthMetadata      `json:"key_metadata" gorm:"embedded;embeddedPrefix:key_meta_"`
+	Status      CertificateRequestStatus `json:"status"`
+	Fingerprint string                   `json:"fingerprint"`
+	CSR         X509CertificateRequest   `json:"csr"`
 }
 
 type CAStats struct {

--- a/core/pkg/models/ca.go
+++ b/core/pkg/models/ca.go
@@ -8,6 +8,7 @@ type CertificateType string
 
 const (
 	CertificateTypeManaged         CertificateType = "MANAGED"
+	CertificateTypeRequested       CertificateType = "REQUESTED"
 	CertificateTypeImportedWithKey CertificateType = "IMPORTED"
 	CertificateTypeExternal        CertificateType = "EXTERNAL"
 )
@@ -22,9 +23,10 @@ var (
 type CertificateStatus string
 
 const (
-	StatusActive  CertificateStatus = "ACTIVE"
-	StatusExpired CertificateStatus = "EXPIRED"
-	StatusRevoked CertificateStatus = "REVOKED"
+	StatusActive   CertificateStatus = "ACTIVE"
+	StatusExpired  CertificateStatus = "EXPIRED"
+	StatusRevoked  CertificateStatus = "REVOKED"
+	StatusInactive CertificateStatus = "INACTIVE"
 )
 
 type Certificate struct {
@@ -65,6 +67,28 @@ type CACertificate struct {
 	Validity                Validity               `json:"validity" gorm:"embedded;embeddedPrefix:validity_"`
 	CreationTS              time.Time              `json:"creation_ts"`
 	Level                   int                    `json:"level"`
+}
+
+type CertificateRequestStatus string
+
+const (
+	StatusRequestIssued  CertificateRequestStatus = "ISSUED"
+	StatusRequestRevoked CertificateRequestStatus = "REVOKED"
+	StatusRequestPending CertificateRequestStatus = "PENDING"
+)
+
+type CACertificateRequest struct {
+	ID               string                   `json:"id"`
+	KeyId            string                   `json:"key_id"`
+	Metadata         map[string]interface{}   `json:"metadata" gorm:"serializer:json"`
+	IssuerCAMetadata IssuerCAMetadata         `json:"issuer_metadata" gorm:"embedded;embeddedPrefix:issuer_meta_"`
+	Subject          Subject                  `json:"subject" gorm:"embedded;embeddedPrefix:subject_"`
+	CreationTS       time.Time                `json:"creation_ts"`
+	Level            int                      `json:"level"`
+	EngineID         string                   `json:"engine_id"`
+	KeyMetadata      KeyStrengthMetadata      `json:"key_metadata" gorm:"embedded;embeddedPrefix:key_meta_"`
+	Status           CertificateRequestStatus `json:"status"`
+	CSR              X509CertificateRequest   `json:"csr"`
 }
 
 type CAStats struct {

--- a/core/pkg/models/ca.go
+++ b/core/pkg/models/ca.go
@@ -88,6 +88,7 @@ type CACertificateRequest struct {
 	EngineID         string                   `json:"engine_id"`
 	KeyMetadata      KeyStrengthMetadata      `json:"key_metadata" gorm:"embedded;embeddedPrefix:key_meta_"`
 	Status           CertificateRequestStatus `json:"status"`
+	Fingerprint      string                   `json:"fingerprint"`
 	CSR              X509CertificateRequest   `json:"csr"`
 }
 

--- a/core/pkg/models/events.go
+++ b/core/pkg/models/events.go
@@ -22,6 +22,7 @@ type EventType string
 
 const (
 	EventCreateCAKey                   EventType = "ca.create"
+	EventRequestCAKey                  EventType = "ca.request"
 	EventImportCAKey                   EventType = "ca.import"
 	EventImportCACertificateKey        EventType = "ca.certificate.import"
 	EventUpdateCAStatusKey             EventType = "ca.status.update"

--- a/core/pkg/models/webhook-call.go
+++ b/core/pkg/models/webhook-call.go
@@ -31,6 +31,6 @@ type WebhookCallHttpClientApiKey struct {
 }
 
 type WebhookCallHttpClientMutualTLS struct {
-	Cert string `json:"cert`
+	Cert string `json:"cert"`
 	Key  string `json:"key"`
 }

--- a/core/pkg/models/x509certificate.go
+++ b/core/pkg/models/x509certificate.go
@@ -62,6 +62,17 @@ func (c *X509Certificate) UnmarshalJSON(data []byte) error {
 // --------------------------------------------
 type X509CertificateRequest x509.CertificateRequest
 
+func (c *X509CertificateRequest) String() string {
+	res, err := c.MarshalJSON()
+	if err != nil {
+		return ""
+	}
+
+	certString := strings.ReplaceAll(string(res), "\"", "")
+
+	return string(certString)
+}
+
 func (c *X509CertificateRequest) MarshalJSON() ([]byte, error) {
 	data := []byte{}
 
@@ -120,5 +131,31 @@ func (c *X509Certificate) Scan(value interface{}) error {
 
 // Value return json value, implement driver.Valuer interface
 func (c X509Certificate) Value() (driver.Value, error) {
+	return c.String(), nil
+}
+
+// --------------------------------------------
+func (X509CertificateRequest) GormDataType() string {
+	return "text"
+}
+
+func (c *X509CertificateRequest) Scan(value interface{}) error {
+	crtString, ok := value.(string)
+	if !ok {
+		return errors.New(fmt.Sprint("Failed to unmarshal JSONB value:", value))
+	}
+
+	crtBytes := []byte(fmt.Sprintf("\"%s\"", crtString))
+
+	err := json.Unmarshal(crtBytes, &c)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Value return json value, implement driver.Valuer interface
+func (c X509CertificateRequest) Value() (driver.Value, error) {
 	return c.String(), nil
 }

--- a/core/pkg/resources/careq.go
+++ b/core/pkg/resources/careq.go
@@ -42,7 +42,6 @@ type CreateCABody struct {
 
 type RequestCABody struct {
 	ID          string             `json:"id"`
-	ParentID    string             `json:"parent_id"`
 	Subject     models.Subject     `json:"subject"`
 	KeyMetadata models.KeyMetadata `json:"key_metadata"`
 	EngineID    string             `json:"engine_id"`

--- a/core/pkg/resources/careq.go
+++ b/core/pkg/resources/careq.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
-	cmodels "github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
 )
 
 var CAFiltrableFields = map[string]FilterFieldType{
@@ -21,21 +20,40 @@ var CAFiltrableFields = map[string]FilterFieldType{
 	"subject.common_name":  StringFilterFieldType,
 }
 
+var CARequestFiltrableFields = map[string]FilterFieldType{
+	"id":                  StringFilterFieldType,
+	"level":               NumberFilterFieldType,
+	"status":              EnumFilterFieldType,
+	"engine_id":           StringFilterFieldType,
+	"subject_common_name": StringFilterFieldType,
+	"issuer_metadata_id":  StringFilterFieldType,
+}
+
 type CreateCABody struct {
-	ID                 string              `json:"id"`
-	ParentID           string              `json:"parent_id"`
-	Subject            cmodels.Subject     `json:"subject"`
-	KeyMetadata        cmodels.KeyMetadata `json:"key_metadata"`
-	CAExpiration       models.Validity     `json:"ca_expiration"`
-	IssuanceExpiration models.Validity     `json:"issuance_expiration"`
-	EngineID           string              `json:"engine_id"`
-	Metadata           map[string]any      `json:"metadata"`
+	ID                 string             `json:"id"`
+	ParentID           string             `json:"parent_id"`
+	Subject            models.Subject     `json:"subject"`
+	KeyMetadata        models.KeyMetadata `json:"key_metadata"`
+	CAExpiration       models.Validity    `json:"ca_expiration"`
+	IssuanceExpiration models.Validity    `json:"issuance_expiration"`
+	EngineID           string             `json:"engine_id"`
+	Metadata           map[string]any     `json:"metadata"`
+}
+
+type RequestCABody struct {
+	ID          string             `json:"id"`
+	ParentID    string             `json:"parent_id"`
+	Subject     models.Subject     `json:"subject"`
+	KeyMetadata models.KeyMetadata `json:"key_metadata"`
+	EngineID    string             `json:"engine_id"`
+	Metadata    map[string]any     `json:"metadata"`
 }
 
 type ImportCABody struct {
 	ID                 string                    `json:"id"`
 	EngineID           string                    `json:"engine_id"`
 	ParentID           string                    `json:"parent_id"`
+	CARequestID        string                    `json:"ca_request_id"`
 	CAPrivateKey       string                    `json:"private_key"` //b64 from PEM
 	CACertificate      *models.X509Certificate   `json:"ca"`
 	CAChain            []*models.X509Certificate `json:"ca_chain"`
@@ -53,7 +71,7 @@ type UpdateCAIssuanceExpirationBody struct {
 type SignCertificateBody struct {
 	SignVerbatim bool                           `json:"sign_verbatim"`
 	CertRequest  *models.X509CertificateRequest `json:"csr"`
-	Subject      *cmodels.Subject               `json:"subject"`
+	Subject      *models.Subject                `json:"subject"`
 }
 
 type SignatureSignBody struct {

--- a/core/pkg/resources/caresp.go
+++ b/core/pkg/resources/caresp.go
@@ -6,6 +6,10 @@ type GetCAsResponse struct {
 	IterableList[models.CACertificate]
 }
 
+type GetItemsResponse[T any] struct {
+	IterableList[T]
+}
+
 type GetCertsResponse struct {
 	IterableList[models.Certificate]
 }

--- a/core/pkg/services/ca.go
+++ b/core/pkg/services/ca.go
@@ -63,12 +63,11 @@ type SignInput struct {
 }
 
 type IssueCACSRInput struct {
-	ParentCA    *models.CACertificate
+	CAID        string                 `validate:"required"`
 	KeyMetadata models.KeyMetadata     `validate:"required"`
 	Subject     models.Subject         `validate:"required"`
 	CAType      models.CertificateType `validate:"required"`
 	EngineID    string
-	CAID        string `validate:"required"`
 }
 
 type IssueCAInput struct {

--- a/core/pkg/services/ca.go
+++ b/core/pkg/services/ca.go
@@ -117,7 +117,6 @@ type CreateCAInput struct {
 
 type RequestCAInput struct {
 	ID          string
-	ParentID    string
 	KeyMetadata models.KeyMetadata `validate:"required"`
 	Subject     models.Subject     `validate:"required"`
 	EngineID    string

--- a/core/pkg/services/mock/caservice_mock.go
+++ b/core/pkg/services/mock/caservice_mock.go
@@ -4,13 +4,17 @@ import (
 	"context"
 
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
-	cmodels "github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/services"
 	"github.com/stretchr/testify/mock"
 )
 
 type MockCAService struct {
 	mock.Mock
+}
+
+func (m *MockCAService) GetCARequests(ctx context.Context, input services.GetItemsInput[models.CACertificateRequest]) (string, error) {
+	args := m.Called(ctx, input)
+	return args.String(0), args.Error(1)
 }
 
 func (m *MockCAService) UpdateCertificateStatus(ctx context.Context, input services.UpdateCertificateStatusInput) (*models.Certificate, error) {
@@ -37,15 +41,21 @@ func (m *MockCAService) GetStatsByCAID(ctx context.Context, input services.GetSt
 	return args.Get(0).(map[models.CertificateStatus]int), args.Error(1)
 }
 
-func (m *MockCAService) GetCryptoEngineProvider(ctx context.Context) ([]*cmodels.CryptoEngineProvider, error) {
+func (m *MockCAService) GetCryptoEngineProvider(ctx context.Context) ([]*models.CryptoEngineProvider, error) {
 	args := m.Called(ctx)
-	return args.Get(0).([]*cmodels.CryptoEngineProvider), args.Error(1)
+	return args.Get(0).([]*models.CryptoEngineProvider), args.Error(1)
 }
 
 func (m *MockCAService) CreateCA(ctx context.Context, input services.CreateCAInput) (*models.CACertificate, error) {
 	args := m.Called(ctx, input)
 	return args.Get(0).(*models.CACertificate), args.Error(1)
 }
+
+func (m *MockCAService) RequestCACSR(ctx context.Context, input services.RequestCAInput) (*models.CACertificateRequest, error) {
+	args := m.Called(ctx, input)
+	return args.Get(0).(*models.CACertificateRequest), args.Error(1)
+}
+
 func (m *MockCAService) ImportCA(ctx context.Context, input services.ImportCAInput) (*models.CACertificate, error) {
 	args := m.Called(ctx, input)
 	return args.Get(0).(*models.CACertificate), args.Error(1)
@@ -128,4 +138,14 @@ func (m *MockCAService) GetCertificatesByCaAndStatus(ctx context.Context, input 
 func (m *MockCAService) GetCertificatesByStatus(ctx context.Context, input services.GetCertificatesByStatusInput) (string, error) {
 	args := m.Called(ctx, input)
 	return args.String(0), args.Error(1)
+}
+
+func (m *MockCAService) GetCARequestByID(ctx context.Context, input services.GetByIDInput) (*models.CACertificateRequest, error) {
+	args := m.Called(ctx, input)
+	return args.Get(0).(*models.CACertificateRequest), args.Error(1)
+}
+
+func (m *MockCAService) DeleteCARequestByID(ctx context.Context, input services.GetByIDInput) error {
+	args := m.Called(ctx, input)
+	return args.Error(0)
 }

--- a/engines/storage/postgres/careqstore.go
+++ b/engines/storage/postgres/careqstore.go
@@ -1,0 +1,49 @@
+package postgres
+
+import (
+	"context"
+
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/engines/storage"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
+	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+)
+
+const caRequestDBName = "ca_certificate_requests"
+
+type PostgresCACertificateRequestStore struct {
+	db      *gorm.DB
+	querier *postgresDBQuerier[models.CACertificateRequest]
+}
+
+func NewCACertRequestPostgresRepository(log *logrus.Entry, db *gorm.DB) (storage.CACertificateRequestRepo, error) {
+	querier, err := TableQuery(log, db, caRequestDBName, "id", models.CACertificateRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	return &PostgresCACertificateRequestStore{
+		db:      db,
+		querier: querier,
+	}, nil
+}
+
+func (db *PostgresCACertificateRequestStore) Insert(ctx context.Context, caCertificateRequest *models.CACertificateRequest) (*models.CACertificateRequest, error) {
+	return db.querier.Insert(ctx, caCertificateRequest, caCertificateRequest.ID)
+}
+
+func (db *PostgresCACertificateRequestStore) SelectExistsByID(ctx context.Context, id string) (bool, *models.CACertificateRequest, error) {
+	return db.querier.SelectExists(ctx, id, nil)
+}
+
+func (db *PostgresCACertificateRequestStore) Update(ctx context.Context, caCertificate *models.CACertificateRequest) (*models.CACertificateRequest, error) {
+	return db.querier.Update(ctx, caCertificate, caCertificate.ID)
+}
+
+func (db *PostgresCACertificateRequestStore) Delete(ctx context.Context, reqID string) error {
+	return db.querier.Delete(ctx, reqID)
+}
+
+func (db *PostgresCACertificateRequestStore) SelectAll(ctx context.Context, req storage.StorageListRequest[models.CACertificateRequest]) (string, error) {
+	return db.querier.SelectAll(ctx, req.QueryParams, []gormExtraOps{}, req.ExhaustiveRun, req.ApplyFunc)
+}

--- a/engines/storage/postgres/careqstore.go
+++ b/engines/storage/postgres/careqstore.go
@@ -47,3 +47,9 @@ func (db *PostgresCACertificateRequestStore) Delete(ctx context.Context, reqID s
 func (db *PostgresCACertificateRequestStore) SelectAll(ctx context.Context, req storage.StorageListRequest[models.CACertificateRequest]) (string, error) {
 	return db.querier.SelectAll(ctx, req.QueryParams, []gormExtraOps{}, req.ExhaustiveRun, req.ApplyFunc)
 }
+
+func (db *PostgresCACertificateRequestStore) SelectByFingerprint(ctx context.Context, fingerprint string, req storage.StorageListRequest[models.CACertificateRequest]) (string, error) {
+	return db.querier.SelectAll(ctx, req.QueryParams, []gormExtraOps{
+		{query: "fingerprint = ?", additionalWhere: []any{fingerprint}},
+	}, req.ExhaustiveRun, req.ApplyFunc)
+}

--- a/engines/storage/postgres/engine.go
+++ b/engines/storage/postgres/engine.go
@@ -76,6 +76,14 @@ func (s *PostgresStorageEngine) initialiceCACertStorage() error {
 			return err
 		}
 	}
+
+	if s.CACertificateRequest == nil {
+		s.CACertificateRequest, err = NewCACertRequestPostgresRepository(s.logger, psqlCli)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -88,6 +96,16 @@ func (s *PostgresStorageEngine) GetCertstorage() (storage.CertificatesRepo, erro
 	}
 
 	return s.Cert, nil
+}
+
+func (s *PostgresStorageEngine) GetCACertificateRequestStorage() (storage.CACertificateRequestRepo, error) {
+	if s.CACertificateRequest == nil {
+		err := s.initialiceCACertStorage()
+		if err != nil {
+			return nil, fmt.Errorf("could not initialize postgres CA request client: %s", err)
+		}
+	}
+	return s.CACertificateRequest, nil
 }
 
 func (s *PostgresStorageEngine) GetDeviceStorage() (storage.DeviceManagerRepo, error) {

--- a/engines/storage/postgres/migrations/ca/20250105155900_create_requests_table.sql
+++ b/engines/storage/postgres/migrations/ca/20250105155900_create_requests_table.sql
@@ -1,0 +1,35 @@
+-- +goose Up
+-- +goose StatementBegin
+-- public.ca_certificates definition
+
+-- this is the schema used by LAMASSU 3.2
+
+CREATE TABLE ca_certificate_requests (
+	id text NOT NULL,
+    key_id text NOT NULL,
+    engine_id text NULL,
+	metadata text NULL,
+	issuer_meta_serial_number text NULL,
+	issuer_meta_id text NULL,
+	issuer_meta_level int8 NULL,
+    subject_common_name text NULL,
+	subject_organization text NULL,
+	subject_organization_unit text NULL,
+	subject_country text NULL,
+	subject_state text NULL,
+	subject_locality text NULL,
+    creation_ts timestamptz NULL,
+	"level" int8 NULL,
+    key_meta_type text NULL,
+	key_meta_bits int8 NULL,
+	key_meta_strength text NULL,
+	status text NULL,
+	csr text NULL,
+	CONSTRAINT certificate_requests_pkey PRIMARY KEY (id)
+);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE ca_certificate_requests;
+-- +goose StatementEnd

--- a/engines/storage/postgres/migrations/ca/20250105155900_create_requests_table.sql
+++ b/engines/storage/postgres/migrations/ca/20250105155900_create_requests_table.sql
@@ -24,6 +24,7 @@ CREATE TABLE ca_certificate_requests (
 	key_meta_bits int8 NULL,
 	key_meta_strength text NULL,
 	status text NULL,
+	fingerprint text NULL,
 	csr text NULL,
 	CONSTRAINT certificate_requests_pkey PRIMARY KEY (id)
 );

--- a/engines/storage/postgres/migrations_test/ca_test.go
+++ b/engines/storage/postgres/migrations_test/ca_test.go
@@ -2,11 +2,14 @@ package migrationstest
 
 import (
 	"context"
+	"crypto/x509"
+	"encoding/base64"
 	"testing"
 	"time"
 
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/config"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/helpers"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
 	"github.com/lamassuiot/lamassuiot/engines/storage/postgres/v3"
 
 	"github.com/sirupsen/logrus"
@@ -139,6 +142,67 @@ func MigrationTest_CA_20241223183344_unified_ca_models(t *testing.T, logger *log
 	assert.Equal(t, 1, ctrCerts)
 }
 
+func MigrationTest_CA_20250105155900_create_requests_table(t *testing.T, logger *logrus.Entry, con *gorm.DB) {
+	ApplyMigration(t, logger, con, CADBName)
+
+	reqRepo, err := postgres.NewCACertRequestPostgresRepository(logger, con)
+	if err != nil {
+		t.Fatalf("could not create certificate repository: %s", err)
+	}
+
+	csrStr := "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0KTUlJQ1hUQ0NBVVVDQVFBd0dERVdNQlFHQTFVRUF4TU5UWGxTWlhGMVpYTjBaV1JEUVRDQ0FTSXdEUVlKS29aSQpodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCQUx4VmcxT2RrUjVScjAyMUJWQzB1SzdMMDhjUG9MTDlCd1lxCmNjaGJxOWtIYTZQS0NmZldRZ2ZhaHNSMy9oT2U4cXdmRFhjZnFXMS9rWnRHRnVjQkMwNVpnNG9ZaXVockwvb2EKa05DWGIvNlZRdjk3b2VqcXBFOHdwbzc3UlArN0RQYU51TXA5UGlrclRuYmVWdVhLTnBPUTcvZlpWQmpuMGxqcApSa3BMN1gwdE9QU1FRNzEyeHY3elhoVCtJL2hCODJ2ZkRWRFRmRzdOaHlycW1nSEsvWXFNUGVEcUIvNjQvb29xCm43anJabjFWbVpQRzVXcUkrVTltYmtHUGpQbjUxTGdheTE0NGFPajE2aW9Uak56Z05BRnhoRUVlcVB1bXRmSWcKS2kxTnZXMTI0dWJSOGpNandoMmF2RDYxYVhOTHlQaERiUm9VdG9OU29VQzlyS3pxRTRFQ0F3RUFBYUFBTUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQkFRQmJZUlZVZk44TG9nNisySlNPTTBSNTVINHZ3OGxPOWRNeFZOc01ibG5VCnBTR0FoM3k0WHFDTm0zTllORUJ4TFQ4eDdON0xlSWJZZTJiUGZXbWduc0crb0dKelBaeU5hUmNMd1d1N3R0VlMKbml2Y2t4Ums4MGV0ZGkxcUlyM2JBVmRjcHZkWWJ5N2FySjl1Z2ZUNlQ4N3p5Rk1Ka2RvZWV4b2J0dlJ6dnZEMQp3WW1aVzQwRE1HbHBlMllIZFd3dXBaejFTSENtODBmdGxUV3M5aG1jUW1GU2hOVHViRzllQjgxL3pTdXVLbTl0Cnl2ekM5MFd6LysvSjFicW1XejZwcU1xSXJkVGVNeFRST0hibG1WMWFIdWtzT2FESFljNStPVkV3YUQ0clF3ZEoKS3MxeGFWT2lIcjIvVDBadUYrdzJHNGFNQ1k3TUp0QW16QmVsbTAvVHJwUmUKLS0tLS1FTkQgQ0VSVElGSUNBVEUgUkVRVUVTVC0tLS0tCg=="
+	crtBytes, err := base64.StdEncoding.DecodeString(csrStr)
+	if err != nil {
+		t.Fatalf("could not decode certificate: %s", err)
+	}
+
+	csr, err := helpers.ParseCertificateRequest(string(crtBytes))
+	if err != nil {
+		t.Fatalf("could not parse certificate: %s", err)
+	}
+
+	_, err = reqRepo.Insert(context.Background(), &models.CACertificateRequest{
+		ID:       "1111-2222-3333-4444",
+		KeyId:    "1111-2222-3333-4444",
+		EngineID: "filesystem-1",
+		Status:   models.StatusRequestPending,
+		IssuerCAMetadata: models.IssuerCAMetadata{
+			SN:    "ef-6d-47-f4-e5-bd-c8-e3-81-67-74-60-12-c1-0f-47",
+			ID:    "1111-2222-3333-4444",
+			Level: 0,
+		},
+		Subject: models.Subject{
+			CommonName:       "test",
+			Organization:     "test",
+			OrganizationUnit: "test",
+			Country:          "test",
+			Locality:         "test",
+			State:            "test",
+		},
+		KeyMetadata: models.KeyStrengthMetadata{
+			Type:     models.KeyType(x509.RSA),
+			Bits:     4096,
+			Strength: models.KeyStrengthHigh,
+		},
+		CSR:        models.X509CertificateRequest(*csr),
+		Metadata:   map[string]interface{}{},
+		CreationTS: time.Date(2024, time.November, 25, 9, 45, 48, 0, time.UTC),
+	})
+
+	if err != nil {
+		t.Fatalf("could not insert certificate request: %s", err)
+	}
+
+	exists, _, err := reqRepo.SelectExistsByID(context.Background(), "1111-2222-3333-4444")
+	if err != nil {
+		t.Fatalf("could not check if certificate request exists: %s", err)
+	}
+
+	if !exists {
+		t.Fatalf("certificate request does not exist")
+	}
+}
+
 func MigrationTest_CA_20250107164937_add_is_ca(t *testing.T, logger *logrus.Entry, con *gorm.DB) {
 	//Add 2 CAs (1 Root and SubCA)
 	con.Exec(`INSERT INTO certificates
@@ -228,6 +292,11 @@ func TestMigrations(t *testing.T) {
 	MigrationTest_CA_20241223183344_unified_ca_models(t, logger, con)
 	if t.Failed() {
 		t.Fatalf("failed while running migration v20241223183344_unified_ca_models")
+	}
+
+	MigrationTest_CA_20250105155900_create_requests_table(t, logger, con)
+	if t.Failed() {
+		t.Fatalf("failed while running migration v20250105155900_create_requests_table")
 	}
 
 	CleanAllTables(t, logger, con)

--- a/engines/storage/postgres/migrations_test/ca_test.go
+++ b/engines/storage/postgres/migrations_test/ca_test.go
@@ -166,11 +166,6 @@ func MigrationTest_CA_20250105155900_create_requests_table(t *testing.T, logger 
 		KeyId:    "1111-2222-3333-4444",
 		EngineID: "filesystem-1",
 		Status:   models.StatusRequestPending,
-		IssuerCAMetadata: models.IssuerCAMetadata{
-			SN:    "ef-6d-47-f4-e5-bd-c8-e3-81-67-74-60-12-c1-0f-47",
-			ID:    "1111-2222-3333-4444",
-			Level: 0,
-		},
 		Subject: models.Subject{
 			CommonName:       "test",
 			Organization:     "test",

--- a/engines/storage/postgres/subsystem/subsystem.go
+++ b/engines/storage/postgres/subsystem/subsystem.go
@@ -52,6 +52,12 @@ func (p *PostgresSubsystem) Run() (*subsystems.SubsystemBackend, error) {
 				if err != nil {
 					return fmt.Errorf("could not run reinitialize Certificates tables: %s", err)
 				}
+
+				_, err = postgres.NewCACertRequestPostgresRepository(logger, postgresEngine.DB[dbName])
+				if err != nil {
+					return fmt.Errorf("could not run reinitialize CA Certificate Request tables: %s", err)
+				}
+
 			case "devicemanager":
 				_, err := postgres.NewDeviceManagerRepository(logger, postgresEngine.DB[dbName])
 				if err != nil {

--- a/sdk/ca.go
+++ b/sdk/ca.go
@@ -114,7 +114,6 @@ func (cli *httpCAClient) RequestCACSR(ctx context.Context, input services.Reques
 		Subject:     input.Subject,
 		KeyMetadata: input.KeyMetadata,
 		EngineID:    input.EngineID,
-		ParentID:    input.ParentID,
 		Metadata:    input.Metadata,
 	}, map[int][]error{
 		400: {

--- a/sdk/ca.go
+++ b/sdk/ca.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/errs"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
-	cmodels "github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/resources"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/services"
 )
@@ -30,8 +29,13 @@ func NewHttpCAClient(client *http.Client, url string) services.CAService {
 	}
 }
 
-func (cli *httpCAClient) GetCryptoEngineProvider(ctx context.Context) ([]*cmodels.CryptoEngineProvider, error) {
-	engine, err := Get[[]*cmodels.CryptoEngineProvider](ctx, cli.httpClient, cli.baseUrl+"/v1/engines", nil, map[int][]error{})
+func (cli *httpCAClient) GetCARequests(ctx context.Context, input services.GetItemsInput[models.CACertificateRequest]) (string, error) {
+	url := cli.baseUrl + "/v1/cas/requests"
+	return IterGet[models.CACertificateRequest, *resources.GetItemsResponse[models.CACertificateRequest]](ctx, cli.httpClient, url, input.ExhaustiveRun, input.QueryParameters, input.ApplyFunc, map[int][]error{})
+}
+
+func (cli *httpCAClient) GetCryptoEngineProvider(ctx context.Context) ([]*models.CryptoEngineProvider, error) {
+	engine, err := Get[[]*models.CryptoEngineProvider](ctx, cli.httpClient, cli.baseUrl+"/v1/engines", nil, map[int][]error{})
 	if err != nil {
 		return nil, err
 	}
@@ -104,15 +108,42 @@ func (cli *httpCAClient) CreateCA(ctx context.Context, input services.CreateCAIn
 	return response, nil
 }
 
+func (cli *httpCAClient) RequestCACSR(ctx context.Context, input services.RequestCAInput) (*models.CACertificateRequest, error) {
+	response, err := Post[*models.CACertificateRequest](ctx, cli.httpClient, cli.baseUrl+"/v1/cas/request", resources.CreateCABody{
+		ID:          input.ID,
+		Subject:     input.Subject,
+		KeyMetadata: input.KeyMetadata,
+		EngineID:    input.EngineID,
+		ParentID:    input.ParentID,
+		Metadata:    input.Metadata,
+	}, map[int][]error{
+		400: {
+			errs.ErrCAIncompatibleValidity,
+			errs.ErrCAIssuanceExpiration,
+		},
+		409: {
+			errs.ErrCAAlreadyExists,
+		},
+		500: {
+			errs.ErrCAIncompatibleValidity,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
 func (cli *httpCAClient) ImportCA(ctx context.Context, input services.ImportCAInput) (*models.CACertificate, error) {
 	var privKey string
-	if input.KeyType == cmodels.KeyType(x509.RSA) {
+	if input.KeyType == models.KeyType(x509.RSA) {
 		rsaBytes := x509.MarshalPKCS1PrivateKey(input.CARSAKey)
 		privKey = base64.StdEncoding.EncodeToString(pem.EncodeToMemory(&pem.Block{
 			Type:  "RSA PRIVATE KEY",
 			Bytes: rsaBytes,
 		}))
-	} else if input.KeyType == cmodels.KeyType(x509.ECDSA) {
+	} else if input.KeyType == models.KeyType(x509.ECDSA) {
 		ecBytes, err := x509.MarshalECPrivateKey(input.CAECKey)
 		if err != nil {
 			return nil, err
@@ -178,7 +209,7 @@ func (cli *httpCAClient) UpdateCAStatus(ctx context.Context, input services.Upda
 		NewStatus:        input.Status,
 		RevocationReason: input.RevocationReason,
 	}, map[int][]error{
-		400: []error{
+		400: {
 			errs.ErrCertificateStatusTransitionNotAllowed,
 		},
 	})
@@ -332,4 +363,22 @@ func (cli *httpCAClient) UpdateCertificateMetadata(ctx context.Context, input se
 		return nil, err
 	}
 	return response, nil
+}
+
+func (cli *httpCAClient) GetCARequestByID(ctx context.Context, input services.GetByIDInput) (*models.CACertificateRequest, error) {
+	response, err := Get[models.CACertificateRequest](ctx, cli.httpClient, cli.baseUrl+"/v1/cas/requests/"+input.ID, nil, map[int][]error{})
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+func (cli *httpCAClient) DeleteCARequestByID(ctx context.Context, input services.GetByIDInput) error {
+	err := Delete(ctx, cli.httpClient, cli.baseUrl+"/v1/cas/requests/"+input.ID, map[int][]error{})
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/sdk/utils.go
+++ b/sdk/utils.go
@@ -14,7 +14,6 @@ import (
 	chelpers "github.com/lamassuiot/lamassuiot/core/v3/pkg/helpers"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/resources"
-	cresources "github.com/lamassuiot/lamassuiot/core/v3/pkg/resources"
 	hhelpers "github.com/lamassuiot/lamassuiot/shared/http/v3/pkg/helpers"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
@@ -118,7 +117,7 @@ func BuildHTTPClient(cfg config.HTTPClient, logger *logrus.Entry) (*http.Client,
 			RevocationURL string `json:"revocation_endpoint"`
 		}
 
-		wellKnown, err := Get[ODICDiscoveryJSON](ctx, authHttpCli, cfg.AuthJWTOptions.OIDCWellKnownURL, &cresources.QueryParameters{}, map[int][]error{})
+		wellKnown, err := Get[ODICDiscoveryJSON](ctx, authHttpCli, cfg.AuthJWTOptions.OIDCWellKnownURL, &resources.QueryParameters{}, map[int][]error{})
 		if err != nil {
 			return nil, err
 		}
@@ -126,7 +125,7 @@ func BuildHTTPClient(cfg config.HTTPClient, logger *logrus.Entry) (*http.Client,
 		clientConfig := clientcredentials.Config{
 			ClientID:     cfg.AuthJWTOptions.ClientID,
 			ClientSecret: string(cfg.AuthJWTOptions.ClientSecret),
-			TokenURL:     fmt.Sprintf(wellKnown.TokenURL),
+			TokenURL:     wellKnown.TokenURL,
 		}
 
 		authHttpCli.Transport = &http.Transport{
@@ -190,7 +189,7 @@ func requestWithBody[T any](ctx context.Context, client *http.Client, method str
 	return ParseJSON[T](body)
 }
 
-func Get[T any](ctx context.Context, client *http.Client, url string, queryParams *cresources.QueryParameters, knownErrors map[int][]error) (T, error) {
+func Get[T any](ctx context.Context, client *http.Client, url string, queryParams *resources.QueryParameters, knownErrors map[int][]error) (T, error) {
 	var m T
 	r, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
@@ -254,10 +253,10 @@ func Delete(ctx context.Context, client *http.Client, url string, knownErrors ma
 	return nil
 }
 
-func IterGet[E any, T resources.Iterator[E]](ctx context.Context, client *http.Client, url string, exhaustiveRun bool, queryParams *cresources.QueryParameters, applyFunc func(E), knownErrors map[int][]error) (string, error) {
+func IterGet[E any, T resources.Iterator[E]](ctx context.Context, client *http.Client, url string, exhaustiveRun bool, queryParams *resources.QueryParameters, applyFunc func(E), knownErrors map[int][]error) (string, error) {
 	continueIter := true
 	if queryParams == nil {
-		queryParams = &cresources.QueryParameters{}
+		queryParams = &resources.QueryParameters{}
 	}
 
 	if exhaustiveRun {
@@ -277,9 +276,9 @@ func IterGet[E any, T resources.Iterator[E]](ctx context.Context, client *http.C
 		queryParams.NextBookmark = response.GetNextBookmark()
 
 		for _, item := range response.GetList() {
-			if &item != nil {
-				applyFunc(item)
-			}
+
+			applyFunc(item)
+
 		}
 	}
 


### PR DESCRIPTION
## Overview

This PR adds functionality to initialize a Certificate Authority (CA) using a Certificate Signing Request (CSR) that has been signed by an external PKI. This enhancement enables integration scenarios where the CA certificate needs to be obtained from an existing external PKI infrastructure.

The process consists of three main steps:

1. **External CA Import**: 
   - Import the certificate of the external CA that will sign the new managed CA
   - This establishes trust and enables validation of the signed certificate

2. **CSR Generation**:
   - New endpoint `POST /ca/request` creates the key pair that will support the new CA
   - Generates a CSR using these keys
   - Returns a request ID for tracking the CSR and associating it with the generated keys

3. **CA Initialization**:
   - Enhanced CA import service to handle certificates that are responses to previously generated CSRs
   - Requires both:
     * The request ID from the CSR generation step
     * The externally signed certificate
   - Validates the certificate against the imported external CA

After completion, the initialized CA becomes fully operational within Lamassu IoT and can be used like any other managed CA, while maintaining a cryptographic trust relationship with the external PKI.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation

- [X] REQUIRES updating the documentation
- [ ] DOES NOT require updating the documentation

## Helm Chart

Note that image bumping (updating a pod/container image tag) DOES NOT require updating the helm chart, since this is related to the Release lifecycle

- [ ] REQUIRES updating the helm chart
- [X] DOES NOT require updating the helm chart 

## UI

- [X] REQUIRES updating the UI with new fuctionalities
- [ ] DOES NOT require updating UI with new fuctionalities

### Sections to update

CAs management sections
