### PR TITLE
fix: AWS Connector: use issuer metadata to refer caid

### DIFF
--- a/connectors/awsiot/pkg/service.go
+++ b/connectors/awsiot/pkg/service.go
@@ -331,12 +331,11 @@ func (svc *AWSCloudConnectorServiceBackend) RegisterAndAttachThing(ctx context.C
 		}
 	}
 
-	aki := input.BindedIdentity.Certificate.Certificate.AuthorityKeyId
 	ca, err := svc.CaSDK.GetCAByID(context.Background(), services.GetCAByIDInput{
-		CAID: string(aki),
+		CAID: input.BindedIdentity.Certificate.IssuerCAMetadata.ID,
 	})
 	if err != nil {
-		lFunc.Errorf("could not get CA using AKI %s for device %s: Skipping: %s", string(aki), input.DeviceID, err)
+		lFunc.Errorf("could not get CA %s for device %s: Skipping: %s", input.BindedIdentity.Certificate.IssuerCAMetadata.ID, input.DeviceID, err)
 		return err
 	}
 


### PR DESCRIPTION
# Pull Request Template

## Description

This pull request includes a change to the `RegisterAndAttachThing` function in the `AWSCloudConnectorServiceBackend` class within the `connectors/awsiot/pkg/service.go` file. The change updates how the CA ID is retrieved and logged for a device.

Key change:

* Modified the `RegisterAndAttachThing` function to use `IssuerCAMetadata.ID` instead of `AuthorityKeyId` for retrieving the CA ID and updating the error logging accordingly.
Fixes # (issue)

