### PR TITLE
fix: EST: add content length in cacerts download with PEM support

### DIFF
--- a/backend/pkg/controllers/est.go
+++ b/backend/pkg/controllers/est.go
@@ -67,6 +67,7 @@ func (r *estHttpRoutes) GetCACerts(ctx *gin.Context) {
 		}
 
 		ctx.Writer.Header().Set("Content-Type", "application/x-pem-file")
+		ctx.Writer.Header().Set("Content-Length", strconv.Itoa(len(casPEM)))
 		ctx.Writer.Write([]byte(strings.Join(casPEM, "\n")))
 		return
 	}

--- a/backend/pkg/controllers/est.go
+++ b/backend/pkg/controllers/est.go
@@ -66,9 +66,10 @@ func (r *estHttpRoutes) GetCACerts(ctx *gin.Context) {
 			casPEM = append(casPEM, chelpers.CertificateToPEM(cert))
 		}
 
+		content := []byte(strings.Join(casPEM, "\n"))
 		ctx.Writer.Header().Set("Content-Type", "application/x-pem-file")
-		ctx.Writer.Header().Set("Content-Length", strconv.Itoa(len(casPEM)))
-		ctx.Writer.Write([]byte(strings.Join(casPEM, "\n")))
+		ctx.Writer.Header().Set("Content-Length", strconv.Itoa(len(content)))
+		ctx.Writer.Write(content)
 		return
 	}
 


### PR DESCRIPTION
This pull request includes a minor update to the `backend/pkg/controllers/est.go` file. The change adds a `Content-Length` header to the HTTP response in the `GetCACerts` function to specify the length of the PEM file content.

* [`backend/pkg/controllers/est.go`](diffhunk://#diff-4eeba5bff7bbe5ca14b7f70ae2f60fef8d109c8d20cf684ecb51badcbf42ffb9R70): Added `Content-Length` header to the HTTP response in the `GetCACerts` function.