### PR TITLE
Fix: CA - fixed x509 key serialization

### DIFF
--- a/backend/pkg/assemblers/dms-manager_test.go
+++ b/backend/pkg/assemblers/dms-manager_test.go
@@ -35,11 +35,11 @@ import (
 )
 
 func StartDMSManagerServiceTestServer(t *testing.T, withEventBus bool) (*DMSManagerTestServer, *TestServer, error) {
-
 	builder := TestServiceBuilder{}.WithDatabase("ca", "devicemanager", "dmsmanager").WithService(CA, DEVICE_MANAGER, DMS_MANAGER)
 	if withEventBus {
 		builder = builder.WithEventBus()
 	}
+
 	testServer, err := builder.Build(t)
 	if err != nil {
 		return nil, nil, err

--- a/backend/pkg/assemblers/service-assembler_test.go
+++ b/backend/pkg/assemblers/service-assembler_test.go
@@ -253,7 +253,7 @@ func BuildDeviceManagerServiceTestServer(storageEngine *TestStorageEngineConfig,
 		PublisherEventBus:  eventBus.config,
 		SubscriberEventBus: eventBus.config,
 		Storage:            storageEngine.config,
-	}, caTestServer.Service, models.APIServiceInfo{
+	}, caTestServer.HttpCASDK, models.APIServiceInfo{
 		Version:   "test",
 		BuildSHA:  "-",
 		BuildTime: "-",
@@ -314,7 +314,7 @@ func BuildDMSManagerServiceTestServer(storageEngine *TestStorageEngineConfig, ev
 		Storage:                   storageEngine.config,
 		DownstreamCertificateFile: downstreamCertPath,
 	},
-		caTestServer.Service,
+		caTestServer.HttpCASDK,
 		deviceManagerTestServer.Service,
 		models.APIServiceInfo{
 			Version:   "test",

--- a/backend/pkg/x509engines/x509engine.go
+++ b/backend/pkg/x509engines/x509engine.go
@@ -208,12 +208,7 @@ func (engine X509Engine) SignCertificateRequest(ctx context.Context, csr *x509.C
 	}
 
 	// Define certificate key usage
-	var keyUsage x509.KeyUsage
-	for _, usage := range profile.KeyUsage {
-		keyUsage |= x509.KeyUsage(usage)
-	}
-
-	certificateTemplate.KeyUsage = keyUsage
+	certificateTemplate.KeyUsage = x509.KeyUsage(profile.KeyUsage)
 
 	// Define certificate extended key usage
 	var extKeyUsage []x509.ExtKeyUsage
@@ -286,14 +281,11 @@ func (engine X509Engine) GetCertificateSigner(ctx context.Context, caCertificate
 
 func (engine X509Engine) GetDefaultCAIssuanceProfile(ctx context.Context, validity cmodels.Validity) cmodels.IssuanceProfile {
 	return cmodels.IssuanceProfile{
-		Validity:        validity,
-		SignAsCA:        true,
-		HonorExtensions: true,
-		HonorSubject:    true,
-		KeyUsage: []cmodels.X509KeyUsage{
-			cmodels.X509KeyUsage(x509.KeyUsageCertSign),
-			cmodels.X509KeyUsage(x509.KeyUsageCRLSign),
-		},
+		Validity:          validity,
+		SignAsCA:          true,
+		HonorExtensions:   true,
+		HonorSubject:      true,
+		KeyUsage:          models.X509KeyUsage(x509.KeyUsageCertSign | x509.KeyUsageCRLSign),
 		ExtendedKeyUsages: []cmodels.X509ExtKeyUsage{},
 	}
 }

--- a/backend/pkg/x509engines/x509engine_test.go
+++ b/backend/pkg/x509engines/x509engine_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/config"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/engines/cryptoengines"
 	chelpers "github.com/lamassuiot/lamassuiot/core/v3/pkg/helpers"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
 	cmodels "github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
 	"github.com/lamassuiot/lamassuiot/engines/crypto/filesystem/v3"
 	"github.com/lamassuiot/lamassuiot/engines/crypto/software/v3"
@@ -615,9 +616,7 @@ func TestSignCertificateRequest(t *testing.T) {
 		},
 		SignAsCA:     false,
 		HonorSubject: true,
-		KeyUsage: []cmodels.X509KeyUsage{
-			cmodels.X509KeyUsage(x509.KeyUsageKeyAgreement),
-		},
+		KeyUsage:     models.X509KeyUsage(x509.KeyUsageKeyAgreement),
 		ExtendedKeyUsages: []cmodels.X509ExtKeyUsage{
 			cmodels.X509ExtKeyUsage(x509.ExtKeyUsageClientAuth),
 		},
@@ -753,12 +752,8 @@ func TestSignCertificateRequest(t *testing.T) {
 					Type: cmodels.Time,
 					Time: expirationTime,
 				},
-				SignAsCA: false,
-				KeyUsage: []cmodels.X509KeyUsage{
-					cmodels.X509KeyUsage(x509.KeyUsageDigitalSignature),
-					cmodels.X509KeyUsage(x509.KeyUsageDataEncipherment),
-					cmodels.X509KeyUsage(x509.KeyUsageContentCommitment),
-				},
+				SignAsCA:        false,
+				KeyUsage:        models.X509KeyUsage(x509.KeyUsageDigitalSignature | x509.KeyUsageDataEncipherment | x509.KeyUsageContentCommitment),
 				HonorSubject:    true,
 				HonorExtensions: true,
 			},
@@ -809,7 +804,6 @@ func TestSignCertificateRequest(t *testing.T) {
 				},
 				HonorSubject:    true,
 				HonorExtensions: true,
-				KeyUsage:        []cmodels.X509KeyUsage{},
 			},
 			subject: csrSubject,
 			keyType: cmodels.KeyType(x509.ECDSA),

--- a/core/pkg/models/ca.go
+++ b/core/pkg/models/ca.go
@@ -132,7 +132,7 @@ type IssuanceProfile struct {
 	Validity Validity `json:"validity" gorm:"embedded;embeddedPrefix:validity_"`
 	SignAsCA bool     `json:"sign_as_ca"`
 
-	KeyUsage          []X509KeyUsage    `json:"key_usage"`
+	KeyUsage          X509KeyUsage      `json:"key_usage"`
 	ExtendedKeyUsages []X509ExtKeyUsage `json:"extended_key_usage"`
 
 	HonorSubject bool    `json:"honor_subject"`

--- a/core/pkg/models/x509_keyusage.go
+++ b/core/pkg/models/x509_keyusage.go
@@ -9,7 +9,7 @@ import (
 
 type X509KeyUsage x509.KeyUsage
 
-func (p X509KeyUsage) MarshalText() ([]byte, error) {
+func (p X509KeyUsage) MarshalJSON() ([]byte, error) {
 	usages := []string{}
 	if p&X509KeyUsage(x509.KeyUsageDigitalSignature) != 0 {
 		usages = append(usages, "DigitalSignature")
@@ -96,77 +96,54 @@ func (c *X509KeyUsage) UnmarshalJSON(data []byte) error {
 		}
 	}
 
+	*c = X509KeyUsage(usages)
 	return nil
 }
 
 type X509ExtKeyUsage x509.ExtKeyUsage
 
-func (p X509ExtKeyUsage) MarshalText() ([]byte, error) {
-	str := ""
-	switch p {
-	case X509ExtKeyUsage(x509.ExtKeyUsageAny):
-		str = "Any"
-	case X509ExtKeyUsage(x509.ExtKeyUsageServerAuth):
-		str = "ServerAuth"
-	case X509ExtKeyUsage(x509.ExtKeyUsageClientAuth):
-		str = "ClientAuth"
-	case X509ExtKeyUsage(x509.ExtKeyUsageCodeSigning):
-		str = "CodeSigning"
-	case X509ExtKeyUsage(x509.ExtKeyUsageEmailProtection):
-		str = "EmailProtection"
-	case X509ExtKeyUsage(x509.ExtKeyUsageIPSECEndSystem):
-		str = "IPSECEndSystem"
-	case X509ExtKeyUsage(x509.ExtKeyUsageIPSECTunnel):
-		str = "IPSECTunnel"
-	case X509ExtKeyUsage(x509.ExtKeyUsageIPSECUser):
-		str = "IPSECUser"
-	case X509ExtKeyUsage(x509.ExtKeyUsageTimeStamping):
-		str = "TimeStamping"
-	case X509ExtKeyUsage(x509.ExtKeyUsageOCSPSigning):
-		str = "OCSPSigning"
-	}
-
-	return json.Marshal(str)
+var X509ExtKeyUsageMap = map[x509.ExtKeyUsage]string{
+	x509.ExtKeyUsageAny:                            "Any",
+	x509.ExtKeyUsageServerAuth:                     "ServerAuth",
+	x509.ExtKeyUsageClientAuth:                     "ClientAuth",
+	x509.ExtKeyUsageCodeSigning:                    "CodeSigning",
+	x509.ExtKeyUsageEmailProtection:                "EmailProtection",
+	x509.ExtKeyUsageIPSECEndSystem:                 "IPSECEndSystem",
+	x509.ExtKeyUsageIPSECTunnel:                    "IPSECTunnel",
+	x509.ExtKeyUsageIPSECUser:                      "IPSECUser",
+	x509.ExtKeyUsageTimeStamping:                   "TimeStamping",
+	x509.ExtKeyUsageOCSPSigning:                    "OCSPSigning",
+	x509.ExtKeyUsageMicrosoftServerGatedCrypto:     "MicrosoftServerGatedCrypto",
+	x509.ExtKeyUsageNetscapeServerGatedCrypto:      "NetscapeServerGatedCrypto",
+	x509.ExtKeyUsageMicrosoftCommercialCodeSigning: "MicrosoftCommercialCodeSigning",
 }
 
-func (c *X509ExtKeyUsage) UnmarshalJSON(data []byte) error {
-	var usage X509ExtKeyUsage
+func (p X509ExtKeyUsage) MarshalText() ([]byte, error) {
+	if value, ok := X509ExtKeyUsageMap[x509.ExtKeyUsage(p)]; ok {
+		return []byte(value), nil
+	}
 
-	var singleUsage string
-	err := json.Unmarshal(data, &singleUsage)
-	if err != nil {
-		if err != nil {
-			return fmt.Errorf("invalid format")
+	return nil, fmt.Errorf("unsupported ext key usage")
+}
+
+func (p *X509ExtKeyUsage) UnmarshalText(text []byte) (err error) {
+	pw := string(text)
+
+	for k, v := range X509ExtKeyUsageMap {
+		if strings.EqualFold(strings.ToLower(v), strings.ToLower(pw)) {
+			*p = X509ExtKeyUsage(k)
+			return nil
 		}
-
 	}
 
-	switch singleUsage {
-	case "Any":
-		usage = X509ExtKeyUsage(x509.ExtKeyUsageAny)
-	case "ServerAuth":
-		usage = X509ExtKeyUsage(x509.ExtKeyUsageServerAuth)
-	case "ClientAuth":
-		usage = X509ExtKeyUsage(x509.ExtKeyUsageClientAuth)
-	case "CodeSigning":
-		usage = X509ExtKeyUsage(x509.ExtKeyUsageCodeSigning)
-	case "EmailProtection":
-		usage = X509ExtKeyUsage(x509.ExtKeyUsageEmailProtection)
-	case "IPSECEndSystem":
-		usage = X509ExtKeyUsage(x509.ExtKeyUsageIPSECEndSystem)
-	case "IPSECTunnel":
-		usage = X509ExtKeyUsage(x509.ExtKeyUsageIPSECTunnel)
-	case "IPSECUser":
-		usage = X509ExtKeyUsage(x509.ExtKeyUsageIPSECUser)
-	case "TimeStamping":
-		usage = X509ExtKeyUsage(x509.ExtKeyUsageTimeStamping)
-	case "OCSPSigning":
-		usage = X509ExtKeyUsage(x509.ExtKeyUsageOCSPSigning)
-	default:
-		return fmt.Errorf("unknown extended key usage: %s", singleUsage)
+	return fmt.Errorf("unsupported ext key usage")
+}
+
+func (c X509ExtKeyUsage) String() string {
+	r, err := c.MarshalText()
+	if err != nil {
+		return "-"
 	}
 
-	c = &usage
-
-	return nil
+	return string(r)
 }

--- a/core/pkg/models/x509_keyusage_test.go
+++ b/core/pkg/models/x509_keyusage_test.go
@@ -1,0 +1,308 @@
+package models
+
+import (
+	"crypto/x509"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestKeyUsageMarshal(t *testing.T) {
+	var testcases = []struct {
+		name           string
+		keyUsage       X509KeyUsage
+		expectedString string
+	}{
+		{
+			name:           "OK/Usage1",
+			keyUsage:       X509KeyUsage(x509.KeyUsageDigitalSignature),
+			expectedString: `["DigitalSignature"]`,
+		},
+		{
+			name:           "OK/Usage256",
+			keyUsage:       X509KeyUsage(x509.KeyUsageDecipherOnly),
+			expectedString: `["DecipherOnly"]`,
+		},
+		{
+			name:           "OK/UsageNoneOrInvalid",
+			keyUsage:       X509KeyUsage(0),
+			expectedString: `[]`,
+		},
+		{
+			name: "OK/AllUsages",
+			keyUsage: X509KeyUsage(x509.KeyUsageDigitalSignature |
+				x509.KeyUsageContentCommitment |
+				x509.KeyUsageKeyEncipherment |
+				x509.KeyUsageDataEncipherment |
+				x509.KeyUsageKeyAgreement |
+				x509.KeyUsageCertSign |
+				x509.KeyUsageCRLSign |
+				x509.KeyUsageEncipherOnly |
+				x509.KeyUsageDecipherOnly,
+			),
+			expectedString: `["DigitalSignature","ContentCommitment","KeyEncipherment","DataEncipherment","KeyAgreement","CertSign","CRLSign","EncipherOnly","DecipherOnly"]`,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			keyUsageB, err := tc.keyUsage.MarshalJSON()
+			if err != nil {
+				t.Fatalf("got error while marshaling key usage: %s", err)
+			}
+
+			if string(keyUsageB) != tc.expectedString {
+				t.Fatalf("unexpected string. Expected '%s'. Got '%s'", tc.expectedString, string(keyUsageB))
+			}
+		})
+	}
+}
+
+func TestKeyUsageUnmarshal(t *testing.T) {
+	var testcases = []struct {
+		name             string
+		keyUsage         string
+		expectedKeyUsage X509KeyUsage
+		expectedErr      error
+	}{
+		{
+			name:             "OK/Usage1",
+			keyUsage:         `["DigitalSignature"]`,
+			expectedKeyUsage: X509KeyUsage(x509.KeyUsageDigitalSignature),
+			expectedErr:      nil,
+		},
+		{
+			name:             "OK/Usage256",
+			keyUsage:         `["DecipherOnly"]`,
+			expectedKeyUsage: X509KeyUsage(x509.KeyUsageDigitalSignature),
+			expectedErr:      nil,
+		},
+		{
+			name:     "OK/AllUsages",
+			keyUsage: `["DigitalSignature","ContentCommitment","KeyEncipherment","DataEncipherment","KeyAgreement","CertSign","CRLSign","EncipherOnly","DecipherOnly"]`,
+			expectedKeyUsage: X509KeyUsage(x509.KeyUsageDigitalSignature |
+				x509.KeyUsageContentCommitment |
+				x509.KeyUsageKeyEncipherment |
+				x509.KeyUsageDataEncipherment |
+				x509.KeyUsageKeyAgreement |
+				x509.KeyUsageCertSign |
+				x509.KeyUsageCRLSign |
+				x509.KeyUsageEncipherOnly |
+				x509.KeyUsageDecipherOnly,
+			),
+			expectedErr: nil,
+		},
+		{
+			name:     "OK/2Usages",
+			keyUsage: `["ContentCommitment","KeyAgreement","CertSign"]`,
+			expectedKeyUsage: X509KeyUsage(x509.KeyUsageContentCommitment |
+				x509.KeyUsageKeyAgreement |
+				x509.KeyUsageCertSign,
+			),
+			expectedErr: nil,
+		},
+		{
+			name:             "OK/Usage256",
+			keyUsage:         `"KeyEncipherment"`,
+			expectedKeyUsage: X509KeyUsage(x509.KeyUsageEncipherOnly),
+			expectedErr:      nil,
+		},
+		{
+			name:             "Err/Usage256",
+			keyUsage:         `aaa`,
+			expectedKeyUsage: X509KeyUsage(0),
+			expectedErr:      fmt.Errorf("invalid format"),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			var keyUsage X509KeyUsage
+			err := keyUsage.UnmarshalJSON([]byte(tc.keyUsage))
+			if err != nil {
+				if tc.expectedErr != nil {
+					if !strings.Contains(err.Error(), tc.expectedErr.Error()) {
+						t.Fatalf("got unexpected while unmarshaling key usage. Expected %s. Got %s", tc.expectedErr, err)
+					}
+				} else {
+					t.Fatalf("got unexpected while unmarshaling key usage. Got %s", err)
+				}
+			} else {
+				if tc.expectedErr != nil {
+					t.Fatalf("expected error %s but got none", err)
+				}
+			}
+		})
+	}
+
+}
+func TestExtendedKeyUsageMarshal(t *testing.T) {
+	var testcases = []struct {
+		name           string
+		keyUsage       X509ExtKeyUsage
+		expectedString string
+	}{
+		{
+			name:           "OK/Any",
+			keyUsage:       X509ExtKeyUsage(x509.ExtKeyUsageAny),
+			expectedString: "Any",
+		},
+		{
+			name:           "OK/ServerAuth",
+			keyUsage:       X509ExtKeyUsage(x509.ExtKeyUsageServerAuth),
+			expectedString: "ServerAuth",
+		},
+		{
+			name:           "OK/ClientAuth",
+			keyUsage:       X509ExtKeyUsage(x509.ExtKeyUsageClientAuth),
+			expectedString: "ClientAuth",
+		},
+		{
+			name:           "OK/CodeSigning",
+			keyUsage:       X509ExtKeyUsage(x509.ExtKeyUsageCodeSigning),
+			expectedString: "CodeSigning",
+		},
+		{
+			name:           "OK/EmailProtection",
+			keyUsage:       X509ExtKeyUsage(x509.ExtKeyUsageEmailProtection),
+			expectedString: "EmailProtection",
+		},
+		{
+			name:           "OK/IPSECEndSystem",
+			keyUsage:       X509ExtKeyUsage(x509.ExtKeyUsageIPSECEndSystem),
+			expectedString: "IPSECEndSystem",
+		},
+		{
+			name:           "OK/IPSECTunnel",
+			keyUsage:       X509ExtKeyUsage(x509.ExtKeyUsageIPSECTunnel),
+			expectedString: "IPSECTunnel",
+		},
+		{
+			name:           "OK/IPSECUser",
+			keyUsage:       X509ExtKeyUsage(x509.ExtKeyUsageIPSECUser),
+			expectedString: "IPSECUser",
+		},
+		{
+			name:           "OK/OCSPSigning",
+			keyUsage:       X509ExtKeyUsage(x509.ExtKeyUsageOCSPSigning),
+			expectedString: "OCSPSigning",
+		},
+		{
+			name:           "OK/TimeStamping",
+			keyUsage:       X509ExtKeyUsage(x509.ExtKeyUsageTimeStamping),
+			expectedString: "TimeStamping",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			keyUsageB, err := tc.keyUsage.MarshalText()
+			if err != nil {
+				t.Fatalf("got error while marshaling key usage: %s", err)
+			}
+
+			if string(keyUsageB) != tc.expectedString {
+				t.Fatalf("unexpected string. Expected '%s'. Got '%s'", tc.expectedString, string(keyUsageB))
+			}
+		})
+	}
+}
+
+func TestExtendedKeyUsageUnmarshal(t *testing.T) {
+	var testcases = []struct {
+		name             string
+		keyUsage         string
+		expectedKeyUsage X509ExtKeyUsage
+		expectedErr      error
+	}{
+		{
+			name:             "OK/Any",
+			keyUsage:         "Any",
+			expectedKeyUsage: X509ExtKeyUsage(x509.ExtKeyUsageAny),
+			expectedErr:      nil,
+		},
+		{
+			name:             "OK/ServerAuth",
+			keyUsage:         "ServerAuth",
+			expectedKeyUsage: X509ExtKeyUsage(x509.ExtKeyUsageServerAuth),
+			expectedErr:      nil,
+		},
+		{
+			name:             "OK/ClientAuth",
+			keyUsage:         "ClientAuth",
+			expectedKeyUsage: X509ExtKeyUsage(x509.ExtKeyUsageClientAuth),
+			expectedErr:      nil,
+		},
+		{
+			name:             "OK/CodeSigning",
+			keyUsage:         "CodeSigning",
+			expectedKeyUsage: X509ExtKeyUsage(x509.ExtKeyUsageClientAuth),
+			expectedErr:      nil,
+		},
+		{
+			name:             "OK/EmailProtection",
+			keyUsage:         "EmailProtection",
+			expectedKeyUsage: X509ExtKeyUsage(x509.ExtKeyUsageEmailProtection),
+			expectedErr:      nil,
+		},
+		{
+			name:             "OK/IPSECEndSystem",
+			keyUsage:         "IPSECEndSystem",
+			expectedKeyUsage: X509ExtKeyUsage(x509.ExtKeyUsageIPSECEndSystem),
+			expectedErr:      nil,
+		},
+		{
+			name:             "OK/IPSECTunnel",
+			keyUsage:         "IPSECTunnel",
+			expectedKeyUsage: X509ExtKeyUsage(x509.ExtKeyUsageIPSECTunnel),
+			expectedErr:      nil,
+		},
+		{
+			name:             "OK/IPSECUser",
+			keyUsage:         "IPSECUser",
+			expectedKeyUsage: X509ExtKeyUsage(x509.ExtKeyUsageIPSECUser),
+			expectedErr:      nil,
+		},
+		{
+			name:             "OK/OCSPSigning",
+			keyUsage:         "OCSPSigning",
+			expectedKeyUsage: X509ExtKeyUsage(x509.ExtKeyUsageOCSPSigning),
+			expectedErr:      nil,
+		},
+		{
+			name:             "OK/TimeStamping",
+			keyUsage:         "TimeStamping",
+			expectedKeyUsage: X509ExtKeyUsage(x509.ExtKeyUsageTimeStamping),
+			expectedErr:      nil,
+		},
+		{
+			name:             "Err/InvalidFormat",
+			keyUsage:         "aaa",
+			expectedKeyUsage: X509ExtKeyUsage(0),
+			expectedErr:      fmt.Errorf("unsupported ext key usage"),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			var keyUsage X509ExtKeyUsage
+			err := keyUsage.UnmarshalText([]byte(tc.keyUsage))
+			if err != nil {
+				if tc.expectedErr != nil {
+					if !strings.Contains(err.Error(), tc.expectedErr.Error()) {
+						t.Fatalf("got unexpected while unmarshaling key usage. Expected %s. Got %s", tc.expectedErr, err)
+					}
+				} else {
+					t.Fatalf("got unexpected while unmarshaling key usage. Got %s", err)
+				}
+			} else {
+				if tc.expectedErr != nil {
+					t.Fatalf("expected error %s but got none", err)
+				}
+			}
+		})
+	}
+
+}

--- a/engines/storage/postgres/migrations_test/utils.go
+++ b/engines/storage/postgres/migrations_test/utils.go
@@ -74,7 +74,7 @@ func ApplyMigration(t *testing.T, logger *logrus.Entry, con *gorm.DB, dbName str
 	applied := false
 	for _, s := range src {
 		if strings.Contains(s.Path, migrationName) {
-			logger.Infof("APPLYING MIGRATION %s: %d", s.Path, s.Version)
+			logger.Infof("APPLYING MIGRATION %s - %d", s.Path, s.Version)
 			_, err := m.Goose.ApplyVersion(context.Background(), s.Version, true)
 			if err != nil {
 				t.Fatalf("could not apply migration: %s", err)


### PR DESCRIPTION
This pull request includes multiple changes to improve the handling of key usage and extended key usage in certificate issuance, as well as adding new test cases for these functionalities. The most important changes include modifying the `X509KeyUsage` and `X509ExtKeyUsage` structures and their associated methods, updating the `IssuanceProfile` struct, and adding comprehensive test cases.

### Key Usage and Extended Key Usage Handling:

* [`core/pkg/models/ca.go`](diffhunk://#diff-d7c84197a128bb02fdb2f86c24923f368dc245f5d1bd13a0ee997930651ee7bbL135-R135): Changed `KeyUsage` from a slice to a single `X509KeyUsage` type in the `IssuanceProfile` struct.
* [`core/pkg/models/x509_keyusage.go`](diffhunk://#diff-04a9c7c83f177ea0630c33deb14692b8fd7b4f1167b8fc3ba0261572d2a9f665L12-R12): Modified the `X509KeyUsage` and `X509ExtKeyUsage` structures to improve JSON marshalling and unmarshalling, and added a map for `X509ExtKeyUsage` values. [[1]](diffhunk://#diff-04a9c7c83f177ea0630c33deb14692b8fd7b4f1167b8fc3ba0261572d2a9f665L12-R12) [[2]](diffhunk://#diff-04a9c7c83f177ea0630c33deb14692b8fd7b4f1167b8fc3ba0261572d2a9f665R99-R148)
* [`backend/pkg/x509engines/x509engine.go`](diffhunk://#diff-b15b5b5ded5a4617a741af57622e3381f5d261365c58005926628a4cd8953756L211-R211): Updated the `SignCertificateRequest` method to handle the new `X509KeyUsage` format. [[1]](diffhunk://#diff-b15b5b5ded5a4617a741af57622e3381f5d261365c58005926628a4cd8953756L211-R211) [[2]](diffhunk://#diff-b15b5b5ded5a4617a741af57622e3381f5d261365c58005926628a4cd8953756L293-R288)

### Test Cases:

* [`backend/pkg/assemblers/ca_test.go`](diffhunk://#diff-9ea5abd3d84e44a0f09b39eab353b4f3dbb36eb90cfa68c4299f37d17ef828b0R942-R1000): Added a new test case for signing certificates with specific key usages.
* [`core/pkg/models/x509_keyusage_test.go`](diffhunk://#diff-1b5c9b14b47e695b159b62d6c7219bc58668b9c25282022781b25bb18d0173b3R1-R308): Added comprehensive test cases for marshalling and unmarshalling `X509KeyUsage` and `X509ExtKeyUsage`.

### Other Changes:

* Updated imports in various test files to include necessary packages. [[1]](diffhunk://#diff-9ea5abd3d84e44a0f09b39eab353b4f3dbb36eb90cfa68c4299f37d17ef828b0R15) [[2]](diffhunk://#diff-61a3adc2177581870f1d6f16b5039fab2c29893d4928c7f7ac30e837a403ad0cL38-R42) [[3]](diffhunk://#diff-215f32d72265a21acc3eb5d226f13c27ec59d258e2d8c079385e07298c444c3fR22)
* Minor logging improvement in migration tests.