### PR TITLE
chore: rename ci-test worflow

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -1,4 +1,4 @@
-name: CI Launch Tests
+name: GO Unit Testing
  
 on:
   pull_request:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/ci-test.yaml` file. The change updates the name of the CI workflow from "CI Launch Tests" to "GO Unit Testing".