### PR TITLE
feat: ca - Add multiple URLs to CRL and OCSP fields in certificates as well as accesing over http instead of https

### DIFF
--- a/backend/pkg/assemblers/ca.go
+++ b/backend/pkg/assemblers/ca.go
@@ -71,7 +71,7 @@ func AssembleCAService(conf config.CAConfig) (*services.CAService, *jobs.JobSche
 		CertificateStorage:          certStorage,
 		CACertificateRequestStorage: caCertRequestStorage,
 		CryptoMonitoringConf:        conf.CryptoMonitoring,
-		VAServerDomain:              conf.VAServerDomain,
+		VAServerDomains:             conf.VAServerDomains,
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not create CA service: %v", err)

--- a/backend/pkg/assemblers/service-assembler_test.go
+++ b/backend/pkg/assemblers/service-assembler_test.go
@@ -350,7 +350,7 @@ func BuildVATestServer(caTestServer *CATestServer) (*VATestServer, error) {
 			Level: cconfig.Info,
 		},
 		Server: cconfig.HttpServer{
-			LogLevel:           cconfig.Info,
+			LogLevel:           cconfig.Debug,
 			HealthCheckLogging: false,
 			Protocol:           cconfig.HTTP,
 		},

--- a/backend/pkg/assemblers/service-assembler_test.go
+++ b/backend/pkg/assemblers/service-assembler_test.go
@@ -215,7 +215,7 @@ func BuildCATestServer(storageEngine *TestStorageEngineConfig, cryptoEngines *Te
 			Enabled:   monitor,
 			Frequency: "* * * * * *", //this CRON-like expression will scan certificate each second.
 		},
-		VAServerDomain: "dev.lamassu.test",
+		VAServerDomains: []string{"dev.lamassu.test"},
 	}, models.APIServiceInfo{
 		Version:   "test",
 		BuildSHA:  "-",

--- a/backend/pkg/assemblers/va_test.go
+++ b/backend/pkg/assemblers/va_test.go
@@ -57,7 +57,7 @@ func TestBaseCRL(t *testing.T) {
 				return crts, nil
 			},
 			resultCheck: func(crts []*models.Certificate, issuer *models.CACertificate, crl *x509.RevocationList, err error) {
-				if len(crl.RevokedCertificateEntries) != len(crts) {
+				if len(crl.RevokedCertificateEntries) != 10 {
 					t.Fatalf("crl should have %d entries, got %d", len(crts), len(crl.RevokedCertificateEntries))
 				}
 			},

--- a/backend/pkg/assemblers/va_test.go
+++ b/backend/pkg/assemblers/va_test.go
@@ -117,7 +117,7 @@ func TestBaseCRL(t *testing.T) {
 				t.Fatalf("could not run 'before' function:  %s", err)
 			}
 
-			crl, err := external_clients.GetCRLResponse(fmt.Sprintf("%s/crl/%s", serverTest.VA.HttpServerURL, DefaultCAID), (*x509.Certificate)(issuerCA.Certificate.Certificate), nil, true)
+			crl, err := external_clients.GetCRLResponse(fmt.Sprintf("%s/crl/%s", serverTest.VA.HttpServerURL, string(issuerCA.Certificate.Certificate.AuthorityKeyId)), (*x509.Certificate)(issuerCA.Certificate.Certificate), nil, true)
 			if err != nil {
 				t.Fatalf("could not get CRL: %s", err)
 			}
@@ -152,7 +152,7 @@ func TestCRLNumber(t *testing.T) {
 	iters := 15
 	var prevCrl *x509.RevocationList
 	for i := range iters {
-		crl, err := external_clients.GetCRLResponse(fmt.Sprintf("%s/crl/%s", serverTest.VA.HttpServerURL, DefaultCAID), (*x509.Certificate)(ca.Certificate.Certificate), nil, true)
+		crl, err := external_clients.GetCRLResponse(fmt.Sprintf("%s/crl/%s", serverTest.VA.HttpServerURL, string(ca.Certificate.Certificate.AuthorityKeyId)), (*x509.Certificate)(ca.Certificate.Certificate), nil, true)
 		if err != nil {
 			t.Fatalf("could not get CRL: %s", err)
 		}

--- a/backend/pkg/config/ca.go
+++ b/backend/pkg/config/ca.go
@@ -11,7 +11,7 @@ type CAConfig struct {
 	Storage            cconfig.PluggableStorageEngine `mapstructure:"storage"`
 	CryptoEngineConfig CryptoEngines                  `mapstructure:"crypto_engines"`
 	CryptoMonitoring   cconfig.MonitoringJob          `mapstructure:"crypto_monitoring"`
-	VAServerDomain     string                         `mapstructure:"va_server_domain"`
+	VAServerDomains    []string                       `mapstructure:"va_server_domains"`
 }
 
 type CryptoEngines struct {

--- a/backend/pkg/controllers/va.go
+++ b/backend/pkg/controllers/va.go
@@ -110,7 +110,7 @@ func (r *vaHttpRoutes) Verify(ctx *gin.Context) {
 
 func (r *vaHttpRoutes) CRL(ctx *gin.Context) {
 	type uriParams struct {
-		ID string `uri:"id" binding:"required"`
+		AuthorityKeyId string `uri:"aki" binding:"required"`
 	}
 
 	var params uriParams
@@ -120,7 +120,7 @@ func (r *vaHttpRoutes) CRL(ctx *gin.Context) {
 	}
 
 	crl, err := r.crl.GetCRL(ctx, services.GetCRLInput{
-		CAID: params.ID,
+		AuthorityKeyId: params.AuthorityKeyId,
 	})
 	if err != nil {
 		r.logger.Errorf("something went wrong while getting crl list: %s", err)

--- a/backend/pkg/routes/va.go
+++ b/backend/pkg/routes/va.go
@@ -12,5 +12,5 @@ func NewValidationRoutes(logger *logrus.Entry, httpGrp *gin.RouterGroup, ocsp se
 
 	httpGrp.GET("/ocsp/:ocsp_request", vaRoutes.Verify)
 	httpGrp.POST("/ocsp", vaRoutes.Verify)
-	httpGrp.GET("/crl/:id", vaRoutes.CRL)
+	httpGrp.GET("/crl/:aki", vaRoutes.CRL)
 }

--- a/backend/pkg/services/ca.go
+++ b/backend/pkg/services/ca.go
@@ -43,7 +43,7 @@ type CAServiceBackend struct {
 	certStorage                 storage.CertificatesRepo
 	caCertificateRequestStorage storage.CACertificateRequestRepo
 	cryptoMonitorConfig         cconfig.MonitoringJob
-	vaServerDomain              string
+	vaServerDomains             []string
 	logger                      *logrus.Entry
 }
 
@@ -54,7 +54,7 @@ type CAServiceBuilder struct {
 	CertificateStorage          storage.CertificatesRepo
 	CACertificateRequestStorage storage.CACertificateRequestRepo
 	CryptoMonitoringConf        cconfig.MonitoringJob
-	VAServerDomain              string
+	VAServerDomains             []string
 }
 
 func NewCAService(builder CAServiceBuilder) (services.CAService, error) {
@@ -126,7 +126,7 @@ func NewCAService(builder CAServiceBuilder) (services.CAService, error) {
 		certStorage:                 builder.CertificateStorage,
 		caCertificateRequestStorage: builder.CACertificateRequestStorage,
 		cryptoMonitorConfig:         builder.CryptoMonitoringConf,
-		vaServerDomain:              builder.VAServerDomain,
+		vaServerDomains:             builder.VAServerDomains,
 		logger:                      builder.Logger,
 	}
 
@@ -691,7 +691,7 @@ func (svc *CAServiceBackend) getCryptoEngine(engineId string) (string, x509engin
 		availableEngineId = engineId
 	}
 
-	return availableEngineId, x509engines.NewX509Engine(svc.logger, svc.cryptoEngines[availableEngineId], svc.vaServerDomain), nil
+	return availableEngineId, x509engines.NewX509Engine(svc.logger, svc.cryptoEngines[availableEngineId], svc.vaServerDomains), nil
 }
 
 func (svc *CAServiceBackend) GetCARequests(ctx context.Context, input services.GetItemsInput[models.CACertificateRequest]) (string, error) {
@@ -1118,7 +1118,7 @@ func (svc *CAServiceBackend) SignCertificate(ctx context.Context, input services
 	}
 
 	engine := svc.cryptoEngines[ca.Certificate.EngineID]
-	x509Engine := x509engines.NewX509Engine(lFunc, engine, svc.vaServerDomain)
+	x509Engine := x509engines.NewX509Engine(lFunc, engine, svc.vaServerDomains)
 
 	caCert := (*x509.Certificate)(ca.Certificate.Certificate)
 	csr := (*x509.CertificateRequest)(input.CertRequest)
@@ -1253,7 +1253,7 @@ func (svc *CAServiceBackend) SignatureSign(ctx context.Context, input services.S
 	}
 
 	engine := svc.cryptoEngines[ca.Certificate.EngineID]
-	x509Engine := x509engines.NewX509Engine(lFunc, engine, svc.vaServerDomain)
+	x509Engine := x509engines.NewX509Engine(lFunc, engine, svc.vaServerDomains)
 	lFunc.Debugf("sign signature with %s CA and %s crypto engine", input.CAID, x509Engine.GetEngineConfig().Provider)
 	signature, err := x509Engine.Sign(ctx, (*x509.Certificate)(ca.Certificate.Certificate), input.Message, input.MessageType, input.SigningAlgorithm)
 	if err != nil {
@@ -1283,7 +1283,7 @@ func (svc *CAServiceBackend) SignatureVerify(ctx context.Context, input services
 		return false, errs.ErrCANotFound
 	}
 	engine := svc.cryptoEngines[ca.Certificate.EngineID]
-	x509Engine := x509engines.NewX509Engine(lFunc, engine, svc.vaServerDomain)
+	x509Engine := x509engines.NewX509Engine(lFunc, engine, svc.vaServerDomains)
 	lFunc.Debugf("verify signature with %s CA and %s crypto engine", input.CAID, x509Engine.GetEngineConfig().Provider)
 	return x509Engine.Verify(ctx, (*x509.Certificate)(ca.Certificate.Certificate), input.Signature, input.Message, input.MessageType, input.SigningAlgorithm)
 }

--- a/backend/pkg/services/crl.go
+++ b/backend/pkg/services/crl.go
@@ -46,10 +46,32 @@ func (svc crlServiceImpl) GetCRL(ctx context.Context, input services.GetCRLInput
 		return nil, errs.ErrValidateBadRequest
 	}
 
+	var crlCA *models.CACertificate
+	_, err = svc.caSDK.GetCAs(ctx, services.GetCAsInput{
+		QueryParameters: &resources.QueryParameters{
+			Filters: []resources.FilterOption{},
+		},
+		ExhaustiveRun: true,
+		ApplyFunc: func(ca models.CACertificate) {
+			if slices.Equal(ca.Certificate.Certificate.AuthorityKeyId, []byte(input.AuthorityKeyId)) {
+				crlCA = &ca
+			}
+		},
+	})
+	if err != nil {
+		lFunc.Errorf("something went wrong while reading CA %s: %s", input.AuthorityKeyId, err)
+		return nil, err
+	}
+
+	if crlCA == nil {
+		lFunc.Errorf("CA %s not found", input.AuthorityKeyId)
+		return nil, fmt.Errorf("CA %s not found", input.AuthorityKeyId)
+	}
+
 	certList := []x509.RevocationListEntry{}
-	lFunc.Debugf("reading CA %s certificates", input.CAID)
+	lFunc.Debugf("reading CA %s certificates", crlCA.ID)
 	_, err = svc.caSDK.GetCertificatesByCaAndStatus(ctx, services.GetCertificatesByCaAndStatusInput{
-		CAID:   input.CAID,
+		CAID:   crlCA.ID,
 		Status: models.StatusRevoked,
 		ListInput: resources.ListInput[models.Certificate]{
 			ExhaustiveRun: true,
@@ -67,19 +89,14 @@ func (svc crlServiceImpl) GetCRL(ctx context.Context, input services.GetCRLInput
 		},
 	})
 	if err != nil {
-		lFunc.Errorf("something went wrong while reading CA %s certificates: %s", input.CAID, err)
+		lFunc.Errorf("something went wrong while reading CA %s certificates: %s", crlCA.ID, err)
 		return nil, err
 	}
 
-	ca, err := svc.caSDK.GetCAByID(ctx, services.GetCAByIDInput(input))
-	if err != nil {
-		return nil, err
-	}
+	caSigner := NewCASigner(ctx, crlCA, svc.caSDK)
+	caCert := (*x509.Certificate)(crlCA.Certificate.Certificate)
 
-	caSigner := NewCASigner(ctx, ca, svc.caSDK)
-	caCert := (*x509.Certificate)(ca.Certificate.Certificate)
-
-	lFunc.Debugf("creating revocation list. CA %s", input.CAID)
+	lFunc.Debugf("creating revocation list. CA %s", crlCA.ID)
 	now := time.Now()
 	crl, err := x509.CreateRevocationList(rand.Reader, &x509.RevocationList{
 		RevokedCertificateEntries: certList,

--- a/backend/pkg/services/crl.go
+++ b/backend/pkg/services/crl.go
@@ -5,7 +5,9 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"fmt"
 	"math/big"
+	"slices"
 	"time"
 
 	"github.com/go-playground/validator/v10"

--- a/backend/pkg/x509engines/x509engine_test.go
+++ b/backend/pkg/x509engines/x509engine_test.go
@@ -47,7 +47,7 @@ func setup(t *testing.T) (string, cryptoengines.CryptoEngine, X509Engine) {
 
 	engine, _ := builder(log, conf)
 
-	x509Engine := NewX509Engine(log, &engine, "ocsp.lamassu.io")
+	x509Engine := NewX509Engine(log, &engine, []string{"ocsp.lamassu.io", "va.lamassu.io"})
 
 	return tempDir, engine, x509Engine
 }
@@ -162,8 +162,12 @@ func checkCACertificate(cert *x509.Certificate, ca *x509.Certificate, tcSubject 
 		return fmt.Errorf("unexpected result, got: %t, want: %t", cert.IsCA, true)
 	}
 
-	if cert.OCSPServer[0] != "https://ocsp.lamassu.io/ocsp" {
-		return fmt.Errorf("unexpected result, got: %s, want: %s", cert.OCSPServer, "https://ocsp.lamassuiot.com/ocsp")
+	if cert.OCSPServer[0] != "http://ocsp.lamassu.io/ocsp" {
+		return fmt.Errorf("unexpected result, got: %s, want: %s", cert.OCSPServer[0], "http://ocsp.lamassuiot.com/ocsp")
+	}
+
+	if cert.OCSPServer[1] != "http://va.lamassu.io/ocsp" {
+		return fmt.Errorf("unexpected result, got: %s, want: %s", cert.OCSPServer[1], "http://va.lamassuiot.com/ocsp")
 	}
 
 	v2CrlID, err := software.NewSoftwareCryptoEngine(logrus.NewEntry(logrus.StandardLogger())).EncodePKIXPublicKeyDigest(ca.PublicKey)
@@ -171,8 +175,12 @@ func checkCACertificate(cert *x509.Certificate, ca *x509.Certificate, tcSubject 
 		return fmt.Errorf("unexpected error: %s", err)
 	}
 
-	if cert.CRLDistributionPoints[0] != "https://ocsp.lamassu.io/crl/"+v2CrlID {
-		return fmt.Errorf("unexpected result, got: %s, want: %s", cert.CRLDistributionPoints, "https://crl.lamassuiot.com/crl/"+v2CrlID)
+	if cert.CRLDistributionPoints[0] != "http://ocsp.lamassu.io/crl/"+v2CrlID {
+		return fmt.Errorf("unexpected result, got: %s, want: %s", cert.CRLDistributionPoints[0], "http://crl.lamassuiot.com/crl/"+v2CrlID)
+	}
+
+	if cert.CRLDistributionPoints[1] != "http://va.lamassu.io/crl/"+v2CrlID {
+		return fmt.Errorf("unexpected result, got: %s, want: %s", cert.CRLDistributionPoints[1], "http://va.lamassuiot.com/crl/"+v2CrlID)
 	}
 
 	return nil

--- a/core/pkg/resources/careq.go
+++ b/core/pkg/resources/careq.go
@@ -18,6 +18,7 @@ var CAFiltrableFields = map[string]FilterFieldType{
 	"revocation_timestamp": DateFilterFieldType,
 	"revocation_reason":    EnumFilterFieldType,
 	"subject.common_name":  StringFilterFieldType,
+	"key_id":               StringFilterFieldType,
 }
 
 var CARequestFiltrableFields = map[string]FilterFieldType{

--- a/core/pkg/services/crl.go
+++ b/core/pkg/services/crl.go
@@ -7,5 +7,5 @@ type CRLService interface {
 }
 
 type GetCRLInput struct {
-	CAID string `validate:"required"`
+	AuthorityKeyId string `validate:"required"`
 }

--- a/monolithic/cmd/development/main.go
+++ b/monolithic/cmd/development/main.go
@@ -343,7 +343,8 @@ func main() {
 		SubscriberEventBus: eventBus,
 		PublisherEventBus:  eventBus,
 		Domain:             "dev.lamassu.test",
-		GatewayPort:        8443,
+		GatewayPortHttps:   8443,
+		GatewayPortHttp:    8080,
 		AssemblyMode:       pkg.Http,
 		CryptoEngines:      cryptoEnginesConfig.CryptoEngines,
 		CryptoMonitoring: cconfig.MonitoringJob{
@@ -364,7 +365,7 @@ func main() {
 		},
 	}
 
-	_, err = pkg.RunMonolithicLamassuPKI(conf)
+	_, _, err = pkg.RunMonolithicLamassuPKI(conf)
 	if err != nil {
 		fmt.Println("could not start monolithic PKI. Shuting down: ", err)
 		panic(err)
@@ -380,7 +381,7 @@ func main() {
 	}
 
 	time.Sleep(3 * time.Second)
-	caCli := sdk.NewHttpCAClient(http.DefaultClient, fmt.Sprintf("https://127.0.0.1:%d/api/ca", conf.GatewayPort))
+	caCli := sdk.NewHttpCAClient(http.DefaultClient, fmt.Sprintf("https://127.0.0.1:%d/api/ca", conf.GatewayPortHttps))
 	engines, err := caCli.GetCryptoEngineProvider(context.Background())
 	if err != nil {
 		panic(err)

--- a/monolithic/pkg/assembler.go
+++ b/monolithic/pkg/assembler.go
@@ -64,7 +64,9 @@ func RunMonolithicLamassuPKI(conf MonolithicConfig) (int, error) {
 				CryptoEngines: conf.CryptoEngines,
 			},
 			CryptoMonitoring: conf.CryptoMonitoring,
-			VAServerDomain:   fmt.Sprintf("%s/api/va", conf.Domain),
+			VAServerDomains: []string{
+				fmt.Sprintf("%s/api/va", conf.Domain),
+			},
 		}, apiInfo)
 		if err != nil {
 			return -1, fmt.Errorf("could not assemble CA Service: %s", err)

--- a/monolithic/pkg/assembler.go
+++ b/monolithic/pkg/assembler.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/gin-gonic/gin"
@@ -277,6 +278,7 @@ func RunMonolithicLamassuPKI(conf MonolithicConfig) (int, int, error) {
 				TLSConfig: &tls.Config{
 					ClientAuth: tls.RequestClientCert,
 				},
+				ReadHeaderTimeout: time.Second * 10,
 			}
 
 			log.Fatal(serverHttps.ServeTLS(listenerHttps, "proxy.crt", "proxy.key"))
@@ -284,8 +286,9 @@ func RunMonolithicLamassuPKI(conf MonolithicConfig) (int, int, error) {
 
 		go func() {
 			serverHttp := http.Server{
-				Handler: engine,
-				Addr:    fmt.Sprintf(":%d", conf.GatewayPortHttp),
+				Handler:           engine,
+				Addr:              fmt.Sprintf(":%d", conf.GatewayPortHttp),
+				ReadHeaderTimeout: time.Second * 10,
 			}
 
 			log.Fatal(serverHttp.Serve(listenerHttp))

--- a/monolithic/pkg/config.go
+++ b/monolithic/pkg/config.go
@@ -24,7 +24,8 @@ type MonolithicConfig struct {
 	CryptoMonitoring   cconfig.MonitoringJob          `mapstructure:"crypto_monitoring"`
 	Domain             string                         `mapstructure:"domain"`
 	AssemblyMode       LamassuMonolithicAssembleMode  `mapstructure:"assembly_mode"`
-	GatewayPort        int                            `mapstructure:"gateway_port"`
+	GatewayPortHttps   int                            `mapstructure:"gateway_port_https"`
+	GatewayPortHttp    int                            `mapstructure:"gateway_port_http"`
 	AWSIoTManager      MonolithicAWSIoTManagerConfig  `mapstructure:"aws_iot_manager"`
 }
 

--- a/sdk/utils.go
+++ b/sdk/utils.go
@@ -276,9 +276,7 @@ func IterGet[E any, T resources.Iterator[E]](ctx context.Context, client *http.C
 		queryParams.NextBookmark = response.GetNextBookmark()
 
 		for _, item := range response.GetList() {
-
 			applyFunc(item)
-
 		}
 	}
 

--- a/shared/aws/docker-emulator.go
+++ b/shared/aws/docker-emulator.go
@@ -16,7 +16,7 @@ import (
 func RunAWSEmulationLocalStackDocker() (func() error, func() error, *AWSSDKConfig, error) {
 	containerCleanup, container, dockerHost, err := dockerrunner.RunDocker(dockertest.RunOptions{
 		Repository: "localstack/localstack", // image
-		Tag:        "latest",                // version
+		Tag:        "3.8",                   // version
 	}, func(hc *docker.HostConfig) {})
 	if err != nil {
 		return nil, nil, nil, err


### PR DESCRIPTION
This pull request focuses on updating the CA service configuration to support multiple VA server domains instead of a single domain. The changes span across multiple files, including configuration, service assembly, and X509 engine handling.

Key changes include:

### Configuration Updates:
* Updated `CAConfig` to replace `VAServerDomain` with `VAServerDomains`, changing its type from `string` to `[]string`.

### Service Assembly:
* Modified `AssembleCAService` and `BuildCATestServer` functions to use `VAServerDomains` instead of `VAServerDomain`. [[1]](diffhunk://#diff-b87f82107570fc7f691218a78e530d765a3d9469c0206a3acbf3fd9316ee690dL74-R74) [[2]](diffhunk://#diff-18ebc66899d0b8ab6716293d7873e75f775fddd50b13fcf5c7b6ceb07a1c0046L218-R218)

### Service Backend:
* Updated `CAServiceBackend` and `CAServiceBuilder` to use `VAServerDomains` instead of `VAServerDomain`. [[1]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L46-R46) [[2]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L57-R57) [[3]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L129-R129)
* Adjusted methods in `CAServiceBackend` to pass `VAServerDomains` to the X509 engine. [[1]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L694-R694) [[2]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L1121-R1121) [[3]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L1256-R1256) [[4]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L1286-R1286)

### X509 Engine:
* Updated `X509Engine` to handle multiple VA domains, including modifying the constructor and methods to append multiple OCSP and CRL distribution points. [[1]](diffhunk://#diff-b15b5b5ded5a4617a741af57622e3381f5d261365c58005926628a4cd8953756L36-R43) [[2]](diffhunk://#diff-b15b5b5ded5a4617a741af57622e3381f5d261365c58005926628a4cd8953756L116-R117) [[3]](diffhunk://#diff-b15b5b5ded5a4617a741af57622e3381f5d261365c58005926628a4cd8953756R126-R130) [[4]](diffhunk://#diff-b15b5b5ded5a4617a741af57622e3381f5d261365c58005926628a4cd8953756L178-R185)

### Tests:
* Adjusted tests to reflect the changes in handling multiple VA domains, ensuring the correct OCSP and CRL distribution points are set. [[1]](diffhunk://#diff-215f32d72265a21acc3eb5d226f13c27ec59d258e2d8c079385e07298c444c3fL50-R50) [[2]](diffhunk://#diff-215f32d72265a21acc3eb5d226f13c27ec59d258e2d8c079385e07298c444c3fL165-R183)