### PR TITLE
fix: aws evenbus - ensure sns topic exists before subscribing to sns

### DIFF
--- a/shared/aws/docker-emulator.go
+++ b/shared/aws/docker-emulator.go
@@ -16,7 +16,7 @@ import (
 func RunAWSEmulationLocalStackDocker() (func() error, func() error, *AWSSDKConfig, error) {
 	containerCleanup, container, dockerHost, err := dockerrunner.RunDocker(dockertest.RunOptions{
 		Repository: "localstack/localstack", // image
-		Tag:        "latest",                // version
+		Tag:        "4.1",                   // version
 	}, func(hc *docker.HostConfig) {})
 	if err != nil {
 		return nil, nil, nil, err


### PR DESCRIPTION
This pull request includes changes to ensure the SNS topic exists before creating the subscription and updates the Docker image version for AWS emulation. The most important changes are:

Improvements to AWS SQS Subscription:

* [`engines/eventbus/aws/aws-sqs-sns.go`](diffhunk://#diff-0574c7c2e9da722b58d5bd2281d129b7bf899f61299bbfde83768ee3ce382584R40-R51): Added code to ensure that the SNS topic exists before creating the subscription by creating a new SNS publisher and calling `CreateTopic`.

Updates to Docker Configuration:

* [`shared/aws/docker-emulator.go`](diffhunk://#diff-0fcd2b3102f3fa87835e22ab437634b90c955eac5562a111aa1e8fcce3d4ffb1L19-R19): Updated the Docker image version for AWS emulation from "latest" to "4.1".