### PR TITLE
chore: show codecov flag for backend module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Lamassu IoT
 ===================
-[![codecov](https://codecov.io/gh/lamassuiot/lamassuiot/graph/badge.svg?token=GBZQ1CNYHZ)](https://codecov.io/gh/lamassuiot/lamassuiot)
+[![codecov](https://codecov.io/gh/lamassuiot/lamassuiot/graph/badge.svg?token=GBZQ1CNYHZ&flag=backend)](https://codecov.io/gh/lamassuiot/lamassuiot)
 
 <img src="https://www.lamassu.io/assets/brand/lamassu-brand.png" alt="Lamassu App" title="Lamassu" />
 


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change updates the Codecov badge URL show coverture for backend module.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3): Updated the Codecov badge URL to restrict to the `backend` flag.