### PR TITLE
chore: modularize engine registration with build tags to favour custom builds

### DIFF
--- a/backend/pkg/cryptoengines/builder/builder.go
+++ b/backend/pkg/cryptoengines/builder/builder.go
@@ -7,13 +7,7 @@ import (
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/engines/cryptoengines"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/lamassuiot/lamassuiot/engines/crypto/aws/v3"
-	aws_subsystem "github.com/lamassuiot/lamassuiot/engines/crypto/aws/v3/subsystem"
 	"github.com/lamassuiot/lamassuiot/engines/crypto/filesystem/v3"
-	"github.com/lamassuiot/lamassuiot/engines/crypto/pkcs11/v3"
-	pkcs11_subsystem "github.com/lamassuiot/lamassuiot/engines/crypto/pkcs11/v3/subsystem"
-	"github.com/lamassuiot/lamassuiot/engines/crypto/vaultkv2/v3"
-	vault_subsystem "github.com/lamassuiot/lamassuiot/engines/crypto/vaultkv2/v3/subsystem"
 )
 
 func BuildCryptoEngine(logger *log.Entry, conf cconfig.CryptoEngineConfig) (cryptoengines.CryptoEngine, error) {
@@ -26,16 +20,6 @@ func BuildCryptoEngine(logger *log.Entry, conf cconfig.CryptoEngineConfig) (cryp
 }
 
 func init() {
-	log.Info("Registering crypto engines")
+	log.Info("Registering default crypto engine")
 	filesystem.Register()
-
-	aws.RegisterAWSKMS()
-	aws.RegisterAWSSecrets()
-	aws_subsystem.Register()
-
-	vaultkv2.Register()
-	vault_subsystem.Register()
-
-	pkcs11.Register()
-	pkcs11_subsystem.Register()
 }

--- a/backend/pkg/cryptoengines/builder/registrar_aws.go
+++ b/backend/pkg/cryptoengines/builder/registrar_aws.go
@@ -1,0 +1,16 @@
+//go:build !noaws
+
+package builder
+
+import (
+	"github.com/lamassuiot/lamassuiot/engines/crypto/aws/v3"
+	aws_subsystem "github.com/lamassuiot/lamassuiot/engines/crypto/aws/v3/subsystem"
+	log "github.com/sirupsen/logrus"
+)
+
+func init() {
+	log.Info("Registering  AWS crypto engines")
+	aws.RegisterAWSKMS()
+	aws.RegisterAWSSecrets()
+	aws_subsystem.Register()
+}

--- a/backend/pkg/cryptoengines/builder/registrar_pkcs11.go
+++ b/backend/pkg/cryptoengines/builder/registrar_pkcs11.go
@@ -1,0 +1,15 @@
+//go:build !nopkcs11
+
+package builder
+
+import (
+	"github.com/lamassuiot/lamassuiot/engines/crypto/pkcs11/v3"
+	pkcs11_subsystem "github.com/lamassuiot/lamassuiot/engines/crypto/pkcs11/v3/subsystem"
+	log "github.com/sirupsen/logrus"
+)
+
+func init() {
+	log.Info("Registering VaultKV crypto engines")
+	pkcs11.Register()
+	pkcs11_subsystem.Register()
+}

--- a/backend/pkg/cryptoengines/builder/registrar_vault.go
+++ b/backend/pkg/cryptoengines/builder/registrar_vault.go
@@ -1,0 +1,15 @@
+//go:build !novault
+
+package builder
+
+import (
+	"github.com/lamassuiot/lamassuiot/engines/crypto/vaultkv2/v3"
+	vault_subsystem "github.com/lamassuiot/lamassuiot/engines/crypto/vaultkv2/v3/subsystem"
+	log "github.com/sirupsen/logrus"
+)
+
+func init() {
+	log.Info("Registering VaultKV crypto engines")
+	vaultkv2.Register()
+	vault_subsystem.Register()
+}

--- a/backend/pkg/eventbus/builder/builder.go
+++ b/backend/pkg/eventbus/builder/builder.go
@@ -2,18 +2,9 @@ package builder
 
 import (
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/engines/eventbus"
-	"github.com/lamassuiot/lamassuiot/engines/eventbus/amqp/v3"
-	ampq_subsystem "github.com/lamassuiot/lamassuiot/engines/eventbus/amqp/v3/subsystem"
-	"github.com/lamassuiot/lamassuiot/engines/eventbus/aws/v3"
 	"github.com/sirupsen/logrus"
 )
 
 func BuildEventBusEngine(provider string, config interface{}, serviceId string, logger *logrus.Entry) (eventbus.EventBusEngine, error) {
 	return eventbus.GetEventBusEngine(provider, config, serviceId, logger)
-}
-
-func init() {
-	amqp.Register()
-	ampq_subsystem.Register()
-	aws.Register()
 }

--- a/backend/pkg/eventbus/builder/registrar_amqp.go
+++ b/backend/pkg/eventbus/builder/registrar_amqp.go
@@ -1,0 +1,13 @@
+//go:build !noamqp
+
+package builder
+
+import (
+	"github.com/lamassuiot/lamassuiot/engines/eventbus/amqp/v3"
+	ampq_subsystem "github.com/lamassuiot/lamassuiot/engines/eventbus/amqp/v3/subsystem"
+)
+
+func init() {
+	amqp.Register()
+	ampq_subsystem.Register()
+}

--- a/backend/pkg/eventbus/builder/registrar_aws.go
+++ b/backend/pkg/eventbus/builder/registrar_aws.go
@@ -1,0 +1,9 @@
+//go:build !noaws
+
+package builder
+
+import "github.com/lamassuiot/lamassuiot/engines/eventbus/aws/v3"
+
+func init() {
+	aws.Register()
+}

--- a/monolithic/pkg/assembler.go
+++ b/monolithic/pkg/assembler.go
@@ -16,7 +16,6 @@ import (
 	"github.com/google/uuid"
 	lamassu "github.com/lamassuiot/lamassuiot/backend/v3/pkg/assemblers"
 	"github.com/lamassuiot/lamassuiot/backend/v3/pkg/config"
-	awsiotconnector "github.com/lamassuiot/lamassuiot/connectors/awsiot/v3/pkg"
 	cconfig "github.com/lamassuiot/lamassuiot/core/v3/pkg/config"
 	chelpers "github.com/lamassuiot/lamassuiot/core/v3/pkg/helpers"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
@@ -203,14 +202,7 @@ func RunMonolithicLamassuPKI(conf MonolithicConfig) (int, int, error) {
 		}
 
 		if conf.AWSIoTManager.Enabled {
-			_, err = awsiotconnector.AssembleAWSIoTManagerService(awsiotconnector.ConnectorServiceConfig{
-				Logs: cconfig.Logging{
-					Level: conf.Logs.Level,
-				},
-				SubscriberEventBus: conf.SubscriberEventBus,
-				ConnectorID:        conf.AWSIoTManager.ConnectorID,
-				AWSSDKConfig:       conf.AWSIoTManager.AWSSDKConfig,
-			}, caSDKBuilder("AWS IoT Connector", awsiotconnector.AWSIoTSource(conf.AWSIoTManager.ConnectorID)), dmsMngrSDKBuilder("AWS IoT Connector", awsiotconnector.AWSIoTSource(conf.AWSIoTManager.ConnectorID)), deviceMngrSDKBuilder("AWS IoT Connector", awsiotconnector.AWSIoTSource(conf.AWSIoTManager.ConnectorID)))
+			err = AssembleAWSIoT(conf, caSDKBuilder, dmsMngrSDKBuilder, deviceMngrSDKBuilder)
 			if err != nil {
 				return -1, -1, fmt.Errorf("could not assemble AWS IoT Manager: %s", err)
 			}

--- a/monolithic/pkg/assembler_awsiot.go
+++ b/monolithic/pkg/assembler_awsiot.go
@@ -1,0 +1,24 @@
+//go:build !noaws
+// +build !noaws
+
+package pkg
+
+import (
+	awsiotconnector "github.com/lamassuiot/lamassuiot/connectors/awsiot/v3/pkg"
+	cconfig "github.com/lamassuiot/lamassuiot/core/v3/pkg/config"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/services"
+)
+
+func AssembleAWSIoT(conf MonolithicConfig, caSDKBuilder func(serviceID string, src string) services.CAService, dmsMngrSDKBuilder func(serviceID string, src string) services.DMSManagerService, deviceMngrSDKBuilder func(serviceID string, src string) services.DeviceManagerService) error {
+	_, err := awsiotconnector.AssembleAWSIoTManagerService(awsiotconnector.ConnectorServiceConfig{
+		Logs: cconfig.Logging{
+			Level: conf.Logs.Level,
+		},
+		SubscriberEventBus: conf.SubscriberEventBus,
+		ConnectorID:        conf.AWSIoTManager.ConnectorID,
+		AWSSDKConfig:       conf.AWSIoTManager.AWSSDKConfig,
+	}, caSDKBuilder("AWS IoT Connector", awsiotconnector.AWSIoTSource(conf.AWSIoTManager.ConnectorID)),
+		dmsMngrSDKBuilder("AWS IoT Connector", awsiotconnector.AWSIoTSource(conf.AWSIoTManager.ConnectorID)),
+		deviceMngrSDKBuilder("AWS IoT Connector", awsiotconnector.AWSIoTSource(conf.AWSIoTManager.ConnectorID)))
+	return err
+}

--- a/monolithic/pkg/assembler_noaws.go
+++ b/monolithic/pkg/assembler_noaws.go
@@ -1,0 +1,14 @@
+//go:build noaws
+// +build noaws
+
+package pkg
+
+import (
+	"fmt"
+
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/services"
+)
+
+func AssembleAWSIoT(conf MonolithicConfig, caSDKBuilder func(serviceID string, src string) services.CAService, dmsMngrSDKBuilder func(serviceID string, src string) services.DMSManagerService, deviceMngrSDKBuilder func(serviceID string, src string) services.DeviceManagerService) error {
+	return fmt.Errorf("AWS IoT is not supported in this build")
+}


### PR DESCRIPTION
This pull request refactors the registration of various crypto and event bus engines by moving their initialization into separate files, conditional on build tags. This enhances modularity and allows for more flexible builds.

The following tags are defined in this PR:
- noaws
- nopcks11
- novault
- noamqp

The build can be customized by setting the build tags in the build command:
`go build -tags novault,noamqp <path-to-go-file>`

### Refactoring for modularity:

* [`backend/pkg/cryptoengines/builder/builder.go`](diffhunk://#diff-db3009e094ce474605a57d2f27dc69a6fb00923ce1959ce4daad8edba871a1c5L10-L16): Removed the registration of AWS, PKCS11, and VaultKV crypto engines from the main builder file. [[1]](diffhunk://#diff-db3009e094ce474605a57d2f27dc69a6fb00923ce1959ce4daad8edba871a1c5L10-L16) [[2]](diffhunk://#diff-db3009e094ce474605a57d2f27dc69a6fb00923ce1959ce4daad8edba871a1c5L29-L40)
* [`backend/pkg/eventbus/builder/builder.go`](diffhunk://#diff-a1833ec85c5689a4801105eafbfd55fefef5c8f6752420a6fbc2b7f51ff61d2bL5-L19): Removed the registration of AMQP and AWS event bus engines from the main builder file.

### Conditional engine registration:

* [`backend/pkg/cryptoengines/builder/registrar_aws.go`](diffhunk://#diff-c9c8e85b8649196fc41a66ab55caff6b3d2bccd47c995d5b4bc5d28e6cbb0c42R1-R16): Added new file to register AWS crypto engines when the `!noaws` build tag is set.
* [`backend/pkg/cryptoengines/builder/registrar_pkcs11.go`](diffhunk://#diff-2a438fe2ffb586963c635116a6cef84002bcb33f0604c0ec2ec8bccc6854ec3eR1-R15): Added new file to register PKCS11 crypto engines when the `!nopkcs11` build tag is set.
* [`backend/pkg/cryptoengines/builder/registrar_vault.go`](diffhunk://#diff-8d596743d9792b0e4a66ffa6c2b4e43e0a1592697d2f1b1076e5c1aebb7fb466R1-R15): Added new file to register VaultKV crypto engines when the `!novault` build tag is set.
* [`backend/pkg/eventbus/builder/registrar_amqp.go`](diffhunk://#diff-2a804755b0ba1cce9dc49f776849fddb8329b317b5171c63f54e9e0b960f2141R1-R13): Added new file to register AMQP event bus engines when the `!noamqp` build tag is set.
* [`backend/pkg/eventbus/builder/registrar_aws.go`](diffhunk://#diff-b9ef93292d084757d2075ce76fd61e6b87da8f0cc1465dc3e97ffa3ce6f61a20R1-R9): Added new file to register AWS event bus engines when the `!noaws` build tag is set.

### AWS IoT manager refactoring:

* [`monolithic/pkg/assembler.go`](diffhunk://#diff-1fd28d344eca02197a07bd2e0673671df38e8981ca118c71aa029c08d93ac244L19): Refactored the AWS IoT manager assembly into a separate function `AssembleAWSIoT`. [[1]](diffhunk://#diff-1fd28d344eca02197a07bd2e0673671df38e8981ca118c71aa029c08d93ac244L19) [[2]](diffhunk://#diff-1fd28d344eca02197a07bd2e0673671df38e8981ca118c71aa029c08d93ac244L206-R205)
* [`monolithic/pkg/assembler_awsiot.go`](diffhunk://#diff-14214d6c162d314e2ecb7adbfa287f80f6286d711ade4253ffee5b30841e2d85R1-R24): Added new file to define the `AssembleAWSIoT` function when the `!noaws` build tag is set.
* [`monolithic/pkg/assembler_noaws.go`](diffhunk://#diff-44dc856d6136bcbb87ad59adc6e5436afe73b9a4a95bf7bfac120b873e155f23R1-R14): Added new file to handle the case where AWS IoT is not supported in the build.