### PR TITLE
Job Refactor proposal

### DIFF
--- a/backend/pkg/jobs/va-crl-job_test.go
+++ b/backend/pkg/jobs/va-crl-job_test.go
@@ -1,6 +1,7 @@
 package jobs
 
 import (
+	"context"
 	"crypto/x509"
 	"math/big"
 	"testing"
@@ -12,22 +13,22 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-func TestCreatePeriodicCRL(t *testing.T) {
+func TestCreatePeriodicCRLExpired(t *testing.T) {
 	mockService := new(svcmock.MockVAService)
 
 	log := helpers.SetupLogger("debug", "VA", "CRL Monitor")
 
 	// Create a new CryptoMonitor instance with the mock service
-	job := NewVACrlMonitorJob(mockService, "@every 10s", log)
+	job := NewVACrlMonitorJob(log, mockService, time.Duration(time.Second*1))
 
 	now := time.Now()
 	vaRoles := []*models.VARole{
 		{
 			CAID: "123456",
 			LatestCRL: models.LatestCRLMeta{
-				Version:    models.BigInt{big.NewInt(1)},
+				Version:    models.BigInt{Int: big.NewInt(1)},
 				ValidFrom:  now.Add(-time.Second * 5),
-				ValidUntil: now.Add(time.Second * 5),
+				ValidUntil: now.Add(-time.Second * 1),
 			},
 			CRLOptions: models.VACRLRole{
 				Validity:           models.TimeDuration(10 * time.Second),
@@ -42,7 +43,42 @@ func TestCreatePeriodicCRL(t *testing.T) {
 	mockService.On("CalculateCRL", mock.Anything, mock.Anything).Return(&newCRL, nil)
 	mockService.On("GetVARoles", mock.Anything, mock.Anything).Return(&vaRoles, nil)
 
-	job.Run()
+	job.processVARoles(context.TODO(), log)
 
 	mockService.AssertCalled(t, "CalculateCRL", mock.Anything, mock.Anything)
+}
+
+func TestCreatePeriodicCRLValid(t *testing.T) {
+	mockService := new(svcmock.MockVAService)
+
+	log := helpers.SetupLogger("debug", "VA", "CRL Monitor")
+
+	// Create a new CryptoMonitor instance with the mock service
+	job := NewVACrlMonitorJob(log, mockService, time.Duration(time.Second*1))
+
+	now := time.Now()
+	vaRoles := []*models.VARole{
+		{
+			CAID: "123456",
+			LatestCRL: models.LatestCRLMeta{
+				Version:    models.BigInt{Int: big.NewInt(1)},
+				ValidFrom:  now.Add(-time.Second * 5),
+				ValidUntil: now.Add(time.Second * 10000),
+			},
+			CRLOptions: models.VACRLRole{
+				Validity:           models.TimeDuration(10 * time.Second),
+				KeyIDSigner:        "123456",
+				RegenerateOnRevoke: false,
+			},
+		},
+	}
+
+	newCRL := x509.RevocationList{}
+
+	mockService.On("CalculateCRL", mock.Anything, mock.Anything).Return(&newCRL, nil)
+	mockService.On("GetVARoles", mock.Anything, mock.Anything).Return(&vaRoles, nil)
+
+	job.processVARoles(context.TODO(), log)
+
+	mockService.AssertNotCalled(t, "CalculateCRL", mock.Anything, mock.Anything)
 }

--- a/backend/pkg/services/crl.go
+++ b/backend/pkg/services/crl.go
@@ -120,7 +120,7 @@ func (svc CRLServiceBackend) InitCRLRole(ctx context.Context, caID string) (*mod
 			RegenerateOnRevoke: true,
 		},
 		LatestCRL: models.LatestCRLMeta{
-			Version:   models.BigInt{big.NewInt(0)},
+			Version:   models.BigInt{Int: big.NewInt(0)},
 			ValidFrom: time.Now(),
 		},
 	})


### PR DESCRIPTION
This pull request includes several changes to improve the VA CRL monitoring functionality by introducing a scheduler period and refactoring the CRL job logic. The most important changes include adding a new function to calculate the scheduler period, updating the CRL job to use this period, and enhancing test coverage.

### Scheduler Period and CRL Job Refactoring:

* [`backend/pkg/assemblers/va.go`](diffhunk://#diff-8fe0cfe52a16a3428bd5e2d7acc13d21907c0208a6c3195e4942df5de462af8cL110-R133): Added a new function `getSchedulerPeriod` to parse the scheduler period from a cron expression. Updated the `AssembleVAService` function to use this scheduler period when creating the `VACrlMonitorJob`.
* [`backend/pkg/jobs/va-crl-job.go`](diffhunk://#diff-ca8ef19256eae3de61b69e6d1c1a8fa4e55cfa358847dd6e7c90f738c04c1ec8L11-L74): Refactored the `VACrlMonitor` struct to use `blindPeriod` instead of `frequency`. Updated the `NewVACrlMonitorJob` constructor and `Run` method to accommodate this change.

### Test Enhancements:

* [`backend/pkg/jobs/va-crl-job_test.go`](diffhunk://#diff-605633df542a097a647b142d18de759db14456f3a69c00dba7656c0e3ed1b39dR4): Added a new test `TestCreatePeriodicCRLValid` to verify the behavior when the CRL is still valid. Updated the existing test `TestCreatePeriodicCRLExpired` to reflect the changes in the CRL job logic. [[1]](diffhunk://#diff-605633df542a097a647b142d18de759db14456f3a69c00dba7656c0e3ed1b39dR4) [[2]](diffhunk://#diff-605633df542a097a647b142d18de759db14456f3a69c00dba7656c0e3ed1b39dL15-R31) [[3]](diffhunk://#diff-605633df542a097a647b142d18de759db14456f3a69c00dba7656c0e3ed1b39dL45-R84)

### Dependency Updates:

* [`backend/pkg/assemblers/va.go`](diffhunk://#diff-8fe0cfe52a16a3428bd5e2d7acc13d21907c0208a6c3195e4942df5de462af8cR5): Added imports for `time` and `github.com/robfig/cron/v3` to support the new scheduler functionality. [[1]](diffhunk://#diff-8fe0cfe52a16a3428bd5e2d7acc13d21907c0208a6c3195e4942df5de462af8cR5) [[2]](diffhunk://#diff-8fe0cfe52a16a3428bd5e2d7acc13d21907c0208a6c3195e4942df5de462af8cR20)

### Minor Fixes:

* [`backend/pkg/services/crl.go`](diffhunk://#diff-36e99b98f94ea1fcc02c595dd54ceba4b61b76aa865f369d6aa3a78fc1170056L123-R123): Fixed the initialization of `models.BigInt` to use the `Int` field.