### PR TITLE
Improved ImportCA to update level based on DSN and KID

### DIFF
--- a/backend/pkg/assemblers/ca_test.go
+++ b/backend/pkg/assemblers/ca_test.go
@@ -2513,6 +2513,7 @@ func TestImportCA(t *testing.T) {
 			KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsage(x509.ExtKeyUsageOCSPSigning),
 			ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 			BasicConstraintsValid: true,
+			IsCA:                  true,
 		}
 
 		derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, pubKey, key)
@@ -2884,6 +2885,308 @@ func TestImportCA(t *testing.T) {
 		// 				return nil
 		// 			},
 		// 		},
+		{
+			name:   "OK/ImportingHierarchyBottomUp",
+			before: func(svc services.CAService) error { return nil },
+			run: func(caSDK services.CAService) (*models.CACertificate, error) {
+				ca0Crt := `
+-----BEGIN CERTIFICATE-----
+MIIDqzCCApOgAwIBAgIUY/29239q5Iz5/m2NGnFiQZCDeoswDQYJKoZIhvcNAQEL
+BQAwXTELMAkGA1UEBhMCVVMxFTATBgNVBAgMDEV4YW1wbGVTdGF0ZTEUMBIGA1UE
+BwwLRXhhbXBsZUNpdHkxDzANBgNVBAoMBlJvb3RDQTEQMA4GA1UEAwwHUm9vdCBD
+QTAeFw0yNTAyMjUxMzU0MDBaFw0zNTAyMjMxMzU0MDBaMF0xCzAJBgNVBAYTAlVT
+MRUwEwYDVQQIDAxFeGFtcGxlU3RhdGUxFDASBgNVBAcMC0V4YW1wbGVDaXR5MQ8w
+DQYDVQQKDAZSb290Q0ExEDAOBgNVBAMMB1Jvb3QgQ0EwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQDJgxeplksYYGm7ilnJYQMu2bUbv+rxgGCpfZlDlzRk
+3HBjt3Q0Xa8r1rBS1LI3iktBgUWiqBElqhYAX0d459Mko3J7dPAf+0mcPzYgGd8X
+5MoztHc+fpzht+Natpvm/ocp8lFoEt68SDGiG24sdhmbSTJPsU50JneO7LHK8YPL
+h5VL+4pu9dHrXgH6d7CK8bP25nCE90B4gpFKy2Oc9vIvAiZ0m31441ipOJqujsvm
+MsPAR/rsOBGVRqkvQ933BR3PwBm4nbMWPtbsg/OL5WgzoYs2wiRmaj3YvZoAAHzy
+c/2ntEh33hemHgKkI++mwDLxzDg+jhsod/gWPt9hTOljAgMBAAGjYzBhMA8GA1Ud
+EwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEGMB0GA1UdDgQWBBTkWLVA/xb37hGL
+/S1UTgJqJfmm/jAfBgNVHSMEGDAWgBTkWLVA/xb37hGL/S1UTgJqJfmm/jANBgkq
+hkiG9w0BAQsFAAOCAQEARBs3V/jUheZffb/9zfpo26e3e+whlXIcL6VjA94HWKXh
+FzdAbQfvQUQCfT/tRJzUE3MZoi6g0vtZmi3if3KA9Mb+zSmrfjgEtymGKAyaKzR6
+LSjt7RHRAXVjjnkNAmGZiVfi9rsslHr3WeVGwwNZGQQpZBN5Atcd7YSRWk9wuH+N
+ReLpV/Neg/wBMAxLgCBuvIfDQkSOsUwSmLMLzuRYqOMAyVR8bUiu9bxHOHaUQ6TI
+DruLxGHV4uOAx2SqBNr7XWKJyOZxMkmm0YnZWnIX6+uTHeGTdxgWuHLlkrUGVmaW
+Spj4CeR8GjWfp66G75tjuT5qpgFJ2yhnaDJ/JqNTrQ==
+-----END CERTIFICATE-----
+`
+
+				ca1Crt := `
+-----BEGIN CERTIFICATE-----
+MIIDlDCCAnygAwIBAgIUN2XNhvC/xcgbfxD4FU5ONYFM2HkwDQYJKoZIhvcNAQEL
+BQAwXTELMAkGA1UEBhMCVVMxFTATBgNVBAgMDEV4YW1wbGVTdGF0ZTEUMBIGA1UE
+BwwLRXhhbXBsZUNpdHkxDzANBgNVBAoMBlJvb3RDQTEQMA4GA1UEAwwHUm9vdCBD
+QTAeFw0yNTAyMjUxMzU0MThaFw0zNTAyMjMxMzU0MThaMEYxCzAJBgNVBAYTAlVT
+MRUwEwYDVQQIDAxFeGFtcGxlU3RhdGUxDzANBgNVBAoMBlJvb3RDQTEPMA0GA1UE
+AwwGU3ViIENBMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2Hk/uF/U
+RMtp3zx2bimRYoHAq1rz9H2/QwKgtE4dNI5GMHIHxeeIfOlbxxOhr1PaMKSoxIv1
+3Sj1arpIhQEFset42tYOEKgTO0x5KQHQRnsX9F5uuc5Drj6E4U1qAv0kqBS/7chm
+jszpsZ2+Q19j+v3G3CMkkpOOYZaTAo0ZPEtRBaNG3xX2X4jGbviM1aCx6v2cC3K8
+rfauh74xOyKjWM0MOVndKctUAs5oUrFcNC6spp8kjBMWpXcCtcY+YNnHH5aD7/LB
+jGZJlZNDNKCCtR0GNtwlqPvbCzTbuvPvjVF6hWPhB0dWXP5jE1nsNARLgYnuE2WM
+hAlyqOvmgehfUQIDAQABo2MwYTAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQE
+AwIBBjAdBgNVHQ4EFgQUHuuPIC/kUYP60ysHiL19v51r1KEwHwYDVR0jBBgwFoAU
+5Fi1QP8W9+4Ri/0tVE4CaiX5pv4wDQYJKoZIhvcNAQELBQADggEBAIu1lAZteU+n
++6l/wuEoev+Ad8D3TvHDEjxyHnYtE4Mf+HLk2SguYvXJJRFFc9usG3FmmB0hTPmx
+KDrMk9QObgHsZHcNagwhB6Urn+EKrj/YUnIJE2TrX/blFYoMBPaxbWrwrmFAjKsl
+8uuJoNY64G6sOMzHBpeELhdZU/xgDsrNk+dGyVtYAjmfksQLOSgF14XZnXL9+wPc
+jSm4n8W5YQ0zsKAZ5TmB0VpTCkvVS/gGDHoZfdO38CSry4z8nM3W4zdkmvo76G8U
+2fvC11FSXxzRVQrbxfaOMEcdzT0u1wcsQQzM4+v0Njt3vVy+gRljm+Gmt0Dc9/Lb
+O3v2AfmhPiU=
+-----END CERTIFICATE-----
+`
+
+				ca2Crt := `-----BEGIN CERTIFICATE-----
+MIIDgTCCAmmgAwIBAgIUWb++79DZH43iqHeBItwkJYT5e+QwDQYJKoZIhvcNAQEL
+BQAwRjELMAkGA1UEBhMCVVMxFTATBgNVBAgMDEV4YW1wbGVTdGF0ZTEPMA0GA1UE
+CgwGUm9vdENBMQ8wDQYDVQQDDAZTdWIgQ0EwHhcNMjUwMjI1MTM1NTQ1WhcNMzUw
+MjIzMTM1NTQ1WjBKMQswCQYDVQQGEwJVUzEVMBMGA1UECAwMRXhhbXBsZVN0YXRl
+MQ8wDQYDVQQKDAZSb290Q0ExEzARBgNVBAMMClN1Yi1TdWIgQ0EwggEiMA0GCSqG
+SIb3DQEBAQUAA4IBDwAwggEKAoIBAQDhUi8oRQBDLAxKp74qGy3RbvgzaJxyxVSr
+U+N+l+iHJZ/N4K+papFnZGSc6TycJVW06msyvSdod/gaB3n6SfsOPjAFBGaDNFAz
+YHrIaQKPU/+uEQWMHekEqQmT3vdlgtl6vuBh3qjBKLUwCTwWdRhHckIgTgq7rMKW
+WT5Jsp5J0QSREIi5o99MILex+4p2OsAXC91a37snQ0HvzOsKoWilZvx/dpBCHWa8
+h8UlTo7bbttVCI2NbKXUMH3LNJBvO0gyysMhkEXIynNoZN3j0bxOHnm494wBN8bQ
+EEAb3ah9VEkN1EHXmoTwujQNL0YD9Us1Fv59Ff44EOW9uQn4nbK/AgMBAAGjYzBh
+MA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEGMB0GA1UdDgQWBBQNQvWi
+KOPK/XL5S7LAcEdBqkCxcjAfBgNVHSMEGDAWgBQe648gL+RRg/rTKweIvX2/nWvU
+oTANBgkqhkiG9w0BAQsFAAOCAQEAPjWq7neRIDnRO7DITs9YV97QW9TGfTWyIzhX
+f+SEi4q/OOuKz9lHFkL/aCQHcilmIn2dcBlQNJKW2w41fd7mB6AyM3b0qDvPAQkw
+xaLER5ox4EsIUJwpCjADCLIEEFQh1cjthiBI0tVuIAbUKoq08E+YdFutkMrnZuPs
+VnGK/wULw7ATS4jC+6wCfDQTCNuGWA7Fec/uznu4yyD5YNvBkSxk0fSn7B3uEe7c
+JzepKLZK9pKiq8PTzPOc/zGCRLF7qdquaeJkpRGI8a3pl3sUA521eYWjh6f+kkjf
+V4Ahz5up3arkTIU2XR40ge9x2+hlxmD+KF8aHMdB/89YXgp0MA==
+-----END CERTIFICATE-----
+`
+
+				cert0, err := chelpers.ParseCertificate(ca0Crt)
+				if err != nil {
+					t.Fatalf("could not parse root cert: %s", err)
+				}
+
+				cert1, err := chelpers.ParseCertificate(ca1Crt)
+				if err != nil {
+					t.Fatalf("could not parse ca-lvl-1 cert: %s", err)
+				}
+
+				cert2, err := chelpers.ParseCertificate(ca2Crt)
+				if err != nil {
+					t.Fatalf("could not parse ca-lvl-2 cert: %s", err)
+				}
+
+				duration, _ := models.ParseDuration("100d")
+
+				importedCALvl2, err := caSDK.ImportCA(context.Background(), services.ImportCAInput{
+					CAType: models.CertificateTypeExternal,
+					IssuanceExpiration: models.Validity{
+						Type:     models.Duration,
+						Duration: (models.TimeDuration)(duration),
+					},
+					CACertificate: (*models.X509Certificate)(cert2),
+				})
+				if err != nil {
+					t.Fatalf("could not import ca-lvl-2 CA: %s", err)
+				}
+
+				_, err = caSDK.ImportCA(context.Background(), services.ImportCAInput{
+					CAType: models.CertificateTypeExternal,
+					IssuanceExpiration: models.Validity{
+						Type:     models.Duration,
+						Duration: (models.TimeDuration)(duration),
+					},
+					CACertificate: (*models.X509Certificate)(cert1),
+				})
+				if err != nil {
+					t.Fatalf("could not import ca-lvl-1 CA: %s", err)
+				}
+
+				_, err = caSDK.ImportCA(context.Background(), services.ImportCAInput{
+					CAType: models.CertificateTypeExternal,
+					IssuanceExpiration: models.Validity{
+						Type:     models.Duration,
+						Duration: (models.TimeDuration)(duration),
+					},
+					CACertificate: (*models.X509Certificate)(cert0),
+				})
+				if err != nil {
+					t.Fatalf("could not import root CA: %s", err)
+				}
+
+				importedCALvl2Updated, err := caSDK.GetCAByID(context.Background(), services.GetCAByIDInput{CAID: importedCALvl2.ID})
+				if err != nil {
+					t.Fatalf("could not retrieve ca-lvl-2 CA: %s", err)
+				}
+
+				return importedCALvl2Updated, err
+			},
+			resultCheck: func(ca *models.CACertificate, err error) error {
+				if err != nil {
+					return fmt.Errorf("got unexpected error: %s", err)
+				}
+
+				if ca.Level != 2 {
+					return fmt.Errorf("CA should be at level 2. Got %d", ca.Level)
+				}
+
+				if ca.Certificate.IssuerCAMetadata.Level != 1 {
+					return fmt.Errorf("CA parent should be at level 1. Got %d", ca.Certificate.IssuerCAMetadata.Level)
+				}
+
+				return nil
+			},
+		},
+		{
+			name:   "OK/ImportingHierarchyTopDown",
+			before: func(svc services.CAService) error { return nil },
+			run: func(caSDK services.CAService) (*models.CACertificate, error) {
+				ca0Crt := `
+-----BEGIN CERTIFICATE-----
+MIIDqzCCApOgAwIBAgIUY/29239q5Iz5/m2NGnFiQZCDeoswDQYJKoZIhvcNAQEL
+BQAwXTELMAkGA1UEBhMCVVMxFTATBgNVBAgMDEV4YW1wbGVTdGF0ZTEUMBIGA1UE
+BwwLRXhhbXBsZUNpdHkxDzANBgNVBAoMBlJvb3RDQTEQMA4GA1UEAwwHUm9vdCBD
+QTAeFw0yNTAyMjUxMzU0MDBaFw0zNTAyMjMxMzU0MDBaMF0xCzAJBgNVBAYTAlVT
+MRUwEwYDVQQIDAxFeGFtcGxlU3RhdGUxFDASBgNVBAcMC0V4YW1wbGVDaXR5MQ8w
+DQYDVQQKDAZSb290Q0ExEDAOBgNVBAMMB1Jvb3QgQ0EwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQDJgxeplksYYGm7ilnJYQMu2bUbv+rxgGCpfZlDlzRk
+3HBjt3Q0Xa8r1rBS1LI3iktBgUWiqBElqhYAX0d459Mko3J7dPAf+0mcPzYgGd8X
+5MoztHc+fpzht+Natpvm/ocp8lFoEt68SDGiG24sdhmbSTJPsU50JneO7LHK8YPL
+h5VL+4pu9dHrXgH6d7CK8bP25nCE90B4gpFKy2Oc9vIvAiZ0m31441ipOJqujsvm
+MsPAR/rsOBGVRqkvQ933BR3PwBm4nbMWPtbsg/OL5WgzoYs2wiRmaj3YvZoAAHzy
+c/2ntEh33hemHgKkI++mwDLxzDg+jhsod/gWPt9hTOljAgMBAAGjYzBhMA8GA1Ud
+EwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEGMB0GA1UdDgQWBBTkWLVA/xb37hGL
+/S1UTgJqJfmm/jAfBgNVHSMEGDAWgBTkWLVA/xb37hGL/S1UTgJqJfmm/jANBgkq
+hkiG9w0BAQsFAAOCAQEARBs3V/jUheZffb/9zfpo26e3e+whlXIcL6VjA94HWKXh
+FzdAbQfvQUQCfT/tRJzUE3MZoi6g0vtZmi3if3KA9Mb+zSmrfjgEtymGKAyaKzR6
+LSjt7RHRAXVjjnkNAmGZiVfi9rsslHr3WeVGwwNZGQQpZBN5Atcd7YSRWk9wuH+N
+ReLpV/Neg/wBMAxLgCBuvIfDQkSOsUwSmLMLzuRYqOMAyVR8bUiu9bxHOHaUQ6TI
+DruLxGHV4uOAx2SqBNr7XWKJyOZxMkmm0YnZWnIX6+uTHeGTdxgWuHLlkrUGVmaW
+Spj4CeR8GjWfp66G75tjuT5qpgFJ2yhnaDJ/JqNTrQ==
+-----END CERTIFICATE-----
+`
+
+				ca1Crt := `
+-----BEGIN CERTIFICATE-----
+MIIDlDCCAnygAwIBAgIUN2XNhvC/xcgbfxD4FU5ONYFM2HkwDQYJKoZIhvcNAQEL
+BQAwXTELMAkGA1UEBhMCVVMxFTATBgNVBAgMDEV4YW1wbGVTdGF0ZTEUMBIGA1UE
+BwwLRXhhbXBsZUNpdHkxDzANBgNVBAoMBlJvb3RDQTEQMA4GA1UEAwwHUm9vdCBD
+QTAeFw0yNTAyMjUxMzU0MThaFw0zNTAyMjMxMzU0MThaMEYxCzAJBgNVBAYTAlVT
+MRUwEwYDVQQIDAxFeGFtcGxlU3RhdGUxDzANBgNVBAoMBlJvb3RDQTEPMA0GA1UE
+AwwGU3ViIENBMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2Hk/uF/U
+RMtp3zx2bimRYoHAq1rz9H2/QwKgtE4dNI5GMHIHxeeIfOlbxxOhr1PaMKSoxIv1
+3Sj1arpIhQEFset42tYOEKgTO0x5KQHQRnsX9F5uuc5Drj6E4U1qAv0kqBS/7chm
+jszpsZ2+Q19j+v3G3CMkkpOOYZaTAo0ZPEtRBaNG3xX2X4jGbviM1aCx6v2cC3K8
+rfauh74xOyKjWM0MOVndKctUAs5oUrFcNC6spp8kjBMWpXcCtcY+YNnHH5aD7/LB
+jGZJlZNDNKCCtR0GNtwlqPvbCzTbuvPvjVF6hWPhB0dWXP5jE1nsNARLgYnuE2WM
+hAlyqOvmgehfUQIDAQABo2MwYTAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQE
+AwIBBjAdBgNVHQ4EFgQUHuuPIC/kUYP60ysHiL19v51r1KEwHwYDVR0jBBgwFoAU
+5Fi1QP8W9+4Ri/0tVE4CaiX5pv4wDQYJKoZIhvcNAQELBQADggEBAIu1lAZteU+n
++6l/wuEoev+Ad8D3TvHDEjxyHnYtE4Mf+HLk2SguYvXJJRFFc9usG3FmmB0hTPmx
+KDrMk9QObgHsZHcNagwhB6Urn+EKrj/YUnIJE2TrX/blFYoMBPaxbWrwrmFAjKsl
+8uuJoNY64G6sOMzHBpeELhdZU/xgDsrNk+dGyVtYAjmfksQLOSgF14XZnXL9+wPc
+jSm4n8W5YQ0zsKAZ5TmB0VpTCkvVS/gGDHoZfdO38CSry4z8nM3W4zdkmvo76G8U
+2fvC11FSXxzRVQrbxfaOMEcdzT0u1wcsQQzM4+v0Njt3vVy+gRljm+Gmt0Dc9/Lb
+O3v2AfmhPiU=
+-----END CERTIFICATE-----
+`
+
+				ca2Crt := `-----BEGIN CERTIFICATE-----
+MIIDgTCCAmmgAwIBAgIUWb++79DZH43iqHeBItwkJYT5e+QwDQYJKoZIhvcNAQEL
+BQAwRjELMAkGA1UEBhMCVVMxFTATBgNVBAgMDEV4YW1wbGVTdGF0ZTEPMA0GA1UE
+CgwGUm9vdENBMQ8wDQYDVQQDDAZTdWIgQ0EwHhcNMjUwMjI1MTM1NTQ1WhcNMzUw
+MjIzMTM1NTQ1WjBKMQswCQYDVQQGEwJVUzEVMBMGA1UECAwMRXhhbXBsZVN0YXRl
+MQ8wDQYDVQQKDAZSb290Q0ExEzARBgNVBAMMClN1Yi1TdWIgQ0EwggEiMA0GCSqG
+SIb3DQEBAQUAA4IBDwAwggEKAoIBAQDhUi8oRQBDLAxKp74qGy3RbvgzaJxyxVSr
+U+N+l+iHJZ/N4K+papFnZGSc6TycJVW06msyvSdod/gaB3n6SfsOPjAFBGaDNFAz
+YHrIaQKPU/+uEQWMHekEqQmT3vdlgtl6vuBh3qjBKLUwCTwWdRhHckIgTgq7rMKW
+WT5Jsp5J0QSREIi5o99MILex+4p2OsAXC91a37snQ0HvzOsKoWilZvx/dpBCHWa8
+h8UlTo7bbttVCI2NbKXUMH3LNJBvO0gyysMhkEXIynNoZN3j0bxOHnm494wBN8bQ
+EEAb3ah9VEkN1EHXmoTwujQNL0YD9Us1Fv59Ff44EOW9uQn4nbK/AgMBAAGjYzBh
+MA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEGMB0GA1UdDgQWBBQNQvWi
+KOPK/XL5S7LAcEdBqkCxcjAfBgNVHSMEGDAWgBQe648gL+RRg/rTKweIvX2/nWvU
+oTANBgkqhkiG9w0BAQsFAAOCAQEAPjWq7neRIDnRO7DITs9YV97QW9TGfTWyIzhX
+f+SEi4q/OOuKz9lHFkL/aCQHcilmIn2dcBlQNJKW2w41fd7mB6AyM3b0qDvPAQkw
+xaLER5ox4EsIUJwpCjADCLIEEFQh1cjthiBI0tVuIAbUKoq08E+YdFutkMrnZuPs
+VnGK/wULw7ATS4jC+6wCfDQTCNuGWA7Fec/uznu4yyD5YNvBkSxk0fSn7B3uEe7c
+JzepKLZK9pKiq8PTzPOc/zGCRLF7qdquaeJkpRGI8a3pl3sUA521eYWjh6f+kkjf
+V4Ahz5up3arkTIU2XR40ge9x2+hlxmD+KF8aHMdB/89YXgp0MA==
+-----END CERTIFICATE-----
+`
+
+				cert0, err := chelpers.ParseCertificate(ca0Crt)
+				if err != nil {
+					t.Fatalf("could not parse root cert: %s", err)
+				}
+
+				cert1, err := chelpers.ParseCertificate(ca1Crt)
+				if err != nil {
+					t.Fatalf("could not parse ca-lvl-1 cert: %s", err)
+				}
+
+				cert2, err := chelpers.ParseCertificate(ca2Crt)
+				if err != nil {
+					t.Fatalf("could not parse ca-lvl-2 cert: %s", err)
+				}
+
+				duration, _ := models.ParseDuration("100d")
+
+				_, err = caSDK.ImportCA(context.Background(), services.ImportCAInput{
+					CAType: models.CertificateTypeExternal,
+					IssuanceExpiration: models.Validity{
+						Type:     models.Duration,
+						Duration: (models.TimeDuration)(duration),
+					},
+					CACertificate: (*models.X509Certificate)(cert0),
+				})
+				if err != nil {
+					t.Fatalf("could not import root CA: %s", err)
+				}
+
+				_, err = caSDK.ImportCA(context.Background(), services.ImportCAInput{
+					CAType: models.CertificateTypeExternal,
+					IssuanceExpiration: models.Validity{
+						Type:     models.Duration,
+						Duration: (models.TimeDuration)(duration),
+					},
+					CACertificate: (*models.X509Certificate)(cert1),
+				})
+				if err != nil {
+					t.Fatalf("could not import ca-lvl-1 CA: %s", err)
+				}
+
+				importedCALvl2, err := caSDK.ImportCA(context.Background(), services.ImportCAInput{
+					CAType: models.CertificateTypeExternal,
+					IssuanceExpiration: models.Validity{
+						Type:     models.Duration,
+						Duration: (models.TimeDuration)(duration),
+					},
+					CACertificate: (*models.X509Certificate)(cert2),
+				})
+				if err != nil {
+					t.Fatalf("could not import ca-lvl-2 CA: %s", err)
+				}
+
+				return importedCALvl2, err
+
+			},
+			resultCheck: func(ca *models.CACertificate, err error) error {
+				if err != nil {
+					return fmt.Errorf("got unexpected error: %s", err)
+				}
+
+				if ca.Level != 2 {
+					return fmt.Errorf("CA should be at level 2. Got %d", ca.Level)
+				}
+
+				if ca.Certificate.IssuerCAMetadata.Level != 1 {
+					return fmt.Errorf("CA parent should be at level 1. Got %d", ca.Certificate.IssuerCAMetadata.Level)
+				}
+
+				return nil
+			},
+		},
 	}
 
 	for _, tc := range testcases {
@@ -3924,7 +4227,8 @@ func TestHierarchy(t *testing.T) {
 				fmt.Println("CN:" + childCALvl1.Certificate.Subject.CommonName)
 				fmt.Println("ID:" + childCALvl1.ID)
 				fmt.Println("SN:" + childCALvl1.Certificate.SerialNumber)
-				fmt.Println("KeyID:" + childCALvl1.Certificate.KeyID)
+				fmt.Println("SKID:" + childCALvl1.Certificate.SubjectKeyID)
+				fmt.Println("AKID:" + childCALvl1.Certificate.AuthorityKeyID)
 				fmt.Println("Type:" + childCALvl1.Certificate.Type)
 				fmt.Println("=============================")
 
@@ -4011,7 +4315,7 @@ func TestHierarchy(t *testing.T) {
 			},
 		},
 		{
-			name: "OK/TesHightDateLimitRootCA",
+			name: "OK/TestHightDateLimitRootCA",
 			before: func(svc services.CAService) error {
 
 				return nil

--- a/backend/pkg/controllers/ca.go
+++ b/backend/pkg/controllers/ca.go
@@ -267,7 +267,6 @@ func (r *caHttpRoutes) ImportCA(ctx *gin.Context) {
 		CARSAKey:           rsaKey,
 		CAECKey:            ecKey,
 		EngineID:           requestBody.EngineID,
-		ParentID:           requestBody.ParentID,
 		CARequestID:        requestBody.CARequestID,
 	})
 	if err != nil {

--- a/backend/pkg/helpers/x509utils.go
+++ b/backend/pkg/helpers/x509utils.go
@@ -1,0 +1,14 @@
+package helpers
+
+import (
+	"fmt"
+	"strings"
+)
+
+func FormatHexWithColons(data []byte) string {
+	hexParts := make([]string, len(data))
+	for i, b := range data {
+		hexParts[i] = fmt.Sprintf("%02X", b) // Format each byte as uppercase hex
+	}
+	return strings.Join(hexParts, ":") // Join with colons
+}

--- a/backend/pkg/helpers/x509utils.go
+++ b/backend/pkg/helpers/x509utils.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"crypto/x509"
 	"fmt"
 	"strings"
 )
@@ -11,4 +12,9 @@ func FormatHexWithColons(data []byte) string {
 		hexParts[i] = fmt.Sprintf("%02X", b) // Format each byte as uppercase hex
 	}
 	return strings.Join(hexParts, ":") // Join with colons
+}
+
+func IsSelfSignedCertificate(akid, skid string, cert *x509.Certificate) bool {
+	return (akid == "" || akid == skid) &&
+		(cert.Subject.String() == cert.Issuer.String())
 }

--- a/backend/pkg/services/ca.go
+++ b/backend/pkg/services/ca.go
@@ -253,10 +253,8 @@ func (svc *CAServiceBackend) ImportCA(ctx context.Context, input services.Import
 		lFunc.Tracef("ImportCA struct validation success")
 	}
 
-	var keyID string
 	var engineID string
 	caCert := input.CACertificate
-	parentID := input.ParentID
 
 	if input.CAType == models.CertificateTypeImportedWithKey {
 		lFunc.Debugf("importing CA %s - %s  private key. CA type: %s", helpers.SerialNumberToString(input.CACertificate.SerialNumber), input.CACertificate.Subject.CommonName, input.CAType)
@@ -276,9 +274,9 @@ func (svc *CAServiceBackend) ImportCA(ctx context.Context, input services.Import
 		}
 
 		if input.CARSAKey != nil {
-			keyID, _, err = engine.ImportRSAPrivateKey(input.CARSAKey)
+			_, _, err = engine.ImportRSAPrivateKey(input.CARSAKey)
 		} else if input.CAECKey != nil {
-			keyID, _, err = engine.ImportECDSAPrivateKey(input.CAECKey)
+			_, _, err = engine.ImportECDSAPrivateKey(input.CAECKey)
 		} else {
 			lFunc.Errorf("key type %s not supported", input.KeyType)
 			return nil, fmt.Errorf("KeyType not supported")
@@ -372,32 +370,11 @@ func (svc *CAServiceBackend) ImportCA(ctx context.Context, input services.Import
 		}
 
 		engineID = caReq.EngineID
-		keyID = caReq.KeyId
 	}
 
 	caID := input.ID
 	if caID == "" {
 		caID = goid.NewV4UUID().String()
-	}
-
-	var parentCA *models.CACertificate
-	if parentID != "" {
-		parentCA, err = svc.service.GetCAByID(ctx, services.GetCAByIDInput{
-			CAID: parentID,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("parent CA not found: %w", err)
-		}
-
-		// Verify that the parent CA signed the certificate
-		parentCert := parentCA.Certificate.Certificate
-		p := x509.Certificate(*parentCert)
-		c := x509.Certificate(*caCert)
-		err = c.CheckSignatureFrom(&p)
-		if err != nil {
-			lFunc.Errorf("parent CA did not sign the certificate: %s", err)
-			return nil, fmt.Errorf("parent CA did not sign the certificate: %w", err)
-		}
 	}
 
 	issuerMeta := models.IssuerCAMetadata{
@@ -407,12 +384,54 @@ func (svc *CAServiceBackend) ImportCA(ctx context.Context, input services.Import
 	}
 	level := 0
 
-	if parentCA != nil {
-		level = parentCA.Level + 1
-		issuerMeta = models.IssuerCAMetadata{
-			ID:    parentCA.ID,
-			SN:    parentCA.Certificate.SerialNumber,
-			Level: parentCA.Level,
+	skid := helpers.FormatHexWithColons(input.CACertificate.SubjectKeyId)
+	akid := helpers.FormatHexWithColons(input.CACertificate.AuthorityKeyId)
+
+	isSelfSigned := (akid == "" || akid == skid) &&
+		(input.CACertificate.Subject.String() == input.CACertificate.Issuer.String())
+
+	if !isSelfSigned {
+		var parentCAs []models.CACertificate
+
+		svc.caStorage.SelectBySubjectAndSubjectKeyID(ctx, chelpers.PkixNameToSubject(input.CACertificate.Issuer), akid,
+			storage.StorageListRequest[models.CACertificate]{
+				ExhaustiveRun: true,
+				ApplyFunc: func(c models.CACertificate) {
+					parentCAs = append(parentCAs, c)
+				},
+			})
+
+		// Iterate over parent CAs to verify and assign values when found
+		for _, parentCA := range parentCAs {
+			p := x509.Certificate(*parentCA.Certificate.Certificate)
+			c := x509.Certificate(*caCert)
+			err = c.CheckSignatureFrom(&p)
+
+			if err != nil {
+				if akid != "" {
+					lFunc.Warnf("possible parent CA detected, but failed cryptographic validation: %s", err)
+				}
+				continue // Skip if verification fails
+			}
+
+			// When verification is successful, update the level and metadata
+			level = parentCA.Level + 1
+			issuerMeta = models.IssuerCAMetadata{
+				ID:    parentCA.ID,
+				SN:    parentCA.Certificate.SerialNumber,
+				Level: parentCA.Level,
+			}
+
+			break
+		}
+	} else {
+		// Verify that the parent CA signed the certificate
+		p := x509.Certificate(*caCert)
+		c := x509.Certificate(*caCert)
+		err = c.CheckSignatureFrom(&p)
+		if err != nil {
+			lFunc.Errorf("parent CA did not sign the certificate: %s", err)
+			return nil, fmt.Errorf("parent CA did not sign the certificate: %w", err)
 		}
 	}
 
@@ -423,12 +442,14 @@ func (svc *CAServiceBackend) ImportCA(ctx context.Context, input services.Import
 		CreationTS: time.Now(),
 		Level:      level,
 		Certificate: models.Certificate{
-			KeyID:               keyID,
+			SubjectKeyID:        skid,
+			AuthorityKeyID:      akid,
 			Certificate:         input.CACertificate,
 			Status:              models.StatusActive,
 			SerialNumber:        helpers.SerialNumberToString(caCert.SerialNumber),
 			KeyMetadata:         helpers.KeyStrengthMetadataFromCertificate((*x509.Certificate)(caCert)),
 			Subject:             chelpers.PkixNameToSubject(caCert.Subject),
+			Issuer:              chelpers.PkixNameToSubject(caCert.Issuer),
 			ValidFrom:           caCert.NotBefore,
 			ValidTo:             caCert.NotAfter,
 			RevocationTimestamp: time.Time{},
@@ -449,6 +470,52 @@ func (svc *CAServiceBackend) ImportCA(ctx context.Context, input services.Import
 		if err != nil {
 			lFunc.Warnf("could not update CA Request %s: %s", input.CARequestID, err)
 		}
+	}
+
+	// Flag to check if it's the first iteration
+	firstIteration := true
+	queue := []models.CACertificate{*ca}
+
+	for len(queue) > 0 {
+		parent := queue[0]
+		queue = queue[1:] // Dequeue
+
+		// In the future if we plan to support Cross Signed certs, it is important not fetching just by AKI,
+		// since two cross signed certs (using the same SKI) are signed by different AKIs. Hence, we select by AKI AND Issuer DSN
+		svc.caStorage.SelectByIssuerAndAuthorityKeyID(ctx, parent.Certificate.Subject, parent.Certificate.SubjectKeyID, storage.StorageListRequest[models.CACertificate]{
+			ExhaustiveRun: true,
+			ApplyFunc: func(child models.CACertificate) {
+				isSelfSignedChild := (child.Certificate.AuthorityKeyID == "" || child.Certificate.AuthorityKeyID == child.Certificate.SubjectKeyID) &&
+					(input.CACertificate.Subject.String() == input.CACertificate.Issuer.String())
+				if !isSelfSignedChild {
+					if firstIteration { //Check also with crypto validation to ensure child is actually signed by parent?
+						p := x509.Certificate(*parent.Certificate.Certificate)
+						c := x509.Certificate(*child.Certificate.Certificate)
+						err = c.CheckSignatureFrom(&p)
+
+						if err != nil {
+							if child.Certificate.AuthorityKeyID != "" {
+								lFunc.Warnf("possible child CA detected, but failed cryptographic validation: %s", err)
+							}
+							return // if verification fails, "tentative" parent CA did not sign the certificate being imported. skip update
+						}
+					}
+
+					// We are certain the parent CA did sign the certificate being imported
+					child.Level = parent.Level + 1
+					child.Certificate.IssuerCAMetadata.ID = parent.ID
+					child.Certificate.IssuerCAMetadata.Level = parent.Level
+					child.Certificate.IssuerCAMetadata.SN = parent.Certificate.SerialNumber
+
+					// Update the level in DB
+					svc.caStorage.Update(ctx, &child)
+
+					// Enqueue child for further processing
+					queue = append(queue, child)
+				}
+			},
+		})
+		firstIteration = false
 	}
 
 	return cert, err
@@ -656,7 +723,7 @@ func (svc *CAServiceBackend) CreateCA(ctx context.Context, input services.Create
 		CreationTS: time.Now(),
 		Level:      caLevel,
 		Certificate: models.Certificate{
-			KeyID:        keyID,
+			SubjectKeyID: keyID,
 			Certificate:  (*models.X509Certificate)(ca),
 			Status:       models.StatusActive,
 			SerialNumber: helpers.SerialNumberToString(ca.SerialNumber),
@@ -1147,12 +1214,14 @@ func (svc *CAServiceBackend) SignCertificate(ctx context.Context, input services
 		Status:              models.StatusActive,
 		KeyMetadata:         helpers.KeyStrengthMetadataFromCertificate(x509Cert),
 		Subject:             chelpers.PkixNameToSubject(x509Cert.Subject),
+		Issuer:              chelpers.PkixNameToSubject(x509Cert.Issuer),
 		SerialNumber:        helpers.SerialNumberToString(x509Cert.SerialNumber),
 		ValidFrom:           x509Cert.NotBefore,
 		ValidTo:             x509Cert.NotAfter,
 		RevocationTimestamp: time.Time{},
 		IsCA:                x509Cert.IsCA,
-		KeyID:               "",
+		SubjectKeyID:        helpers.FormatHexWithColons(x509Cert.SubjectKeyId),
+		AuthorityKeyID:      helpers.FormatHexWithColons(x509Cert.AuthorityKeyId),
 		EngineID:            "",
 	}
 

--- a/backend/pkg/services/crl.go
+++ b/backend/pkg/services/crl.go
@@ -107,7 +107,7 @@ func (svc crlServiceImpl) GetCRL(ctx context.Context, input services.GetCRLInput
 
 	extensions := []pkix.Extension{}
 
-	idp, err := svc.getDistributionPointExtension(crlCA.Certificate.KeyID)
+	idp, err := svc.getDistributionPointExtension(crlCA.Certificate.SubjectKeyID)
 	if err != nil {
 		lFunc.Errorf("something went wrong while creating Issuing Distribution Point extension: %s", err)
 		return nil, err

--- a/core/pkg/engines/storage/ca.go
+++ b/core/pkg/engines/storage/ca.go
@@ -33,6 +33,8 @@ type CACertificatesRepo interface {
 	SelectExistsBySerialNumber(ctx context.Context, serialNumber string) (bool, *models.CACertificate, error)
 	SelectByCommonName(ctx context.Context, commonName string, req StorageListRequest[models.CACertificate]) (string, error)
 	SelectByParentCA(ctx context.Context, parentCAID string, req StorageListRequest[models.CACertificate]) (string, error)
+	SelectBySubjectAndSubjectKeyID(ctx context.Context, sub models.Subject, skid string, req StorageListRequest[models.CACertificate]) (string, error)
+	SelectByIssuerAndAuthorityKeyID(ctx context.Context, iss models.Subject, akid string, req StorageListRequest[models.CACertificate]) (string, error)
 
 	Insert(ctx context.Context, caCertificate *models.CACertificate) (*models.CACertificate, error)
 	Update(ctx context.Context, caCertificate *models.CACertificate) (*models.CACertificate, error)

--- a/core/pkg/models/ca.go
+++ b/core/pkg/models/ca.go
@@ -31,12 +31,14 @@ const (
 
 type Certificate struct {
 	SerialNumber        string                 `json:"serial_number" gorm:"primaryKey"`
-	KeyID               string                 `json:"key_id"`
+	SubjectKeyID        string                 `json:"subject_key_id"`
+	AuthorityKeyID      string                 `json:"authority_key_id"`
 	Metadata            map[string]interface{} `json:"metadata" gorm:"serializer:json"`
 	Status              CertificateStatus      `json:"status"`
 	Certificate         *X509Certificate       `json:"certificate"`
 	KeyMetadata         KeyStrengthMetadata    `json:"key_metadata" gorm:"embedded;embeddedPrefix:key_meta_"`
 	Subject             Subject                `json:"subject" gorm:"embedded;embeddedPrefix:subject_"`
+	Issuer              Subject                `json:"issuer" gorm:"embedded;embeddedPrefix:issuer_"`
 	ValidFrom           time.Time              `json:"valid_from"`
 	IssuerCAMetadata    IssuerCAMetadata       `json:"issuer_metadata" gorm:"embedded;embeddedPrefix:issuer_meta_"`
 	ValidTo             time.Time              `json:"valid_to"`

--- a/core/pkg/services/ca.go
+++ b/core/pkg/services/ca.go
@@ -100,7 +100,6 @@ type ImportCAInput struct {
 	CAECKey            *ecdsa.PrivateKey
 	KeyType            models.KeyType
 	EngineID           string
-	ParentID           string
 	CARequestID        string
 }
 

--- a/engines/storage/postgres/castore.go
+++ b/engines/storage/postgres/castore.go
@@ -72,6 +72,42 @@ func (db *PostgresCAStore) SelectByParentCA(ctx context.Context, parentCAID stri
 	}, req.ExhaustiveRun, req.ApplyFunc)
 }
 
+func (db *PostgresCAStore) SelectBySubjectAndSubjectKeyID(ctx context.Context, sub models.Subject, skid string, req storage.StorageListRequest[models.CACertificate]) (string, error) {
+	return db.querier.SelectAll(ctx, req.QueryParams, []gormExtraOps{
+		{query: "certificates.subject_common_name = ? AND " +
+			"certificates.subject_organization = ? AND " +
+			"certificates.subject_organization_unit = ? AND " +
+			"certificates.subject_country = ? AND " +
+			"certificates.subject_state = ? AND " +
+			"certificates.subject_locality = ? AND " +
+			"subject_key_id = ?", additionalWhere: []any{sub.CommonName,
+			sub.Organization,
+			sub.OrganizationUnit,
+			sub.Country,
+			sub.State,
+			sub.Locality,
+			skid}, joins: []string{"JOIN certificates ON ca_certificates.serial_number = certificates.serial_number"}},
+	}, req.ExhaustiveRun, req.ApplyFunc)
+}
+
+func (db *PostgresCAStore) SelectByIssuerAndAuthorityKeyID(ctx context.Context, iss models.Subject, akid string, req storage.StorageListRequest[models.CACertificate]) (string, error) {
+	return db.querier.SelectAll(ctx, req.QueryParams, []gormExtraOps{
+		{query: "certificates.issuer_common_name = ? AND " +
+			"certificates.issuer_organization = ? AND " +
+			"certificates.issuer_organization_unit = ? AND " +
+			"certificates.issuer_country = ? AND " +
+			"certificates.issuer_state = ? AND " +
+			"certificates.issuer_locality = ? AND " +
+			"authority_key_id = ?", additionalWhere: []any{iss.CommonName,
+			iss.Organization,
+			iss.OrganizationUnit,
+			iss.Country,
+			iss.State,
+			iss.Locality,
+			akid}, joins: []string{"JOIN certificates ON ca_certificates.serial_number = certificates.serial_number"}},
+	}, req.ExhaustiveRun, req.ApplyFunc)
+}
+
 func (db *PostgresCAStore) SelectExistsByID(ctx context.Context, id string) (bool, *models.CACertificate, error) {
 	return db.querier.SelectExists(ctx, id, nil)
 }

--- a/engines/storage/postgres/migrations/ca/20250123125500_ca_aws_metadata.go
+++ b/engines/storage/postgres/migrations/ca/20250123125500_ca_aws_metadata.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pressly/goose/v3"
 )
 
-func Register_20250123125500_ca_aws_metadata() {
+func Register20250123125500CaAwsMetadata() {
 	goose.AddMigrationContext(upCaAwsMetadata, downCaAwsMetadata)
 }
 

--- a/engines/storage/postgres/migrations/ca/20250226114600_ca_add_kids.go
+++ b/engines/storage/postgres/migrations/ca/20250226114600_ca_add_kids.go
@@ -1,0 +1,129 @@
+package ca
+
+import (
+	"context"
+	"crypto/x509"
+	"database/sql"
+	"encoding/base64"
+	"encoding/pem"
+
+	"github.com/lamassuiot/lamassuiot/backend/v3/pkg/helpers"
+	mhelper "github.com/lamassuiot/lamassuiot/engines/storage/postgres/v3/migrations/helpers"
+	"github.com/pressly/goose/v3"
+)
+
+func Register_20250226114600_ca_add_kids() {
+	goose.AddMigrationContext(upCaAddKids, downCaAddKids)
+}
+
+func getFirstElementOrEmpty(strSlice []string) string {
+	if len(strSlice) > 0 {
+		return strSlice[0]
+	}
+	return ""
+}
+
+func upCaAddKids(ctx context.Context, tx *sql.Tx) error {
+	// List of SQL queries to modify the table
+	queries := []string{
+		"ALTER TABLE certificates RENAME COLUMN key_id TO subject_key_id;",
+		"ALTER TABLE certificates ADD COLUMN authority_key_id VARCHAR;",
+		"ALTER TABLE certificates ADD COLUMN issuer_common_name VARCHAR;",
+		"ALTER TABLE certificates ADD COLUMN issuer_organization VARCHAR;",
+		"ALTER TABLE certificates ADD COLUMN issuer_organization_unit VARCHAR;",
+		"ALTER TABLE certificates ADD COLUMN issuer_country VARCHAR;",
+		"ALTER TABLE certificates ADD COLUMN issuer_state VARCHAR;",
+		"ALTER TABLE certificates ADD COLUMN issuer_locality VARCHAR;",
+	}
+
+	// Execute each query in the transaction
+	for _, query := range queries {
+		_, err := tx.Exec(query)
+		if err != nil {
+			tx.Rollback()
+			return err
+		}
+	}
+
+	rows, err := tx.QueryContext(ctx, "SELECT serial_number, certificate FROM certificates")
+	if err != nil {
+		return err
+	}
+
+	result, err := mhelper.RowsToMap(rows)
+	if err != nil {
+		return err
+	}
+
+	// Process each certificate
+	for _, r := range result {
+		base64Cert := r["certificate"].(string)
+
+		// Decode PEM certificate
+		decodedPEM, err := base64.StdEncoding.DecodeString(base64Cert)
+		if err != nil {
+			return err
+		}
+
+		certBlock, _ := pem.Decode(decodedPEM)
+		if certBlock != nil {
+			// Parse the certificate and update the database
+			certificate, err := x509.ParseCertificate(certBlock.Bytes)
+			if err != nil {
+				return err
+			}
+
+			_, err = tx.ExecContext(ctx, `
+				UPDATE certificates 
+				SET 
+					authority_key_id = $1,
+					issuer_common_name = $2,
+					issuer_organization = $3,
+					issuer_organization_unit = $4,
+					issuer_country = $5,
+					issuer_state = $6,
+					issuer_locality = $7
+				WHERE serial_number = $8
+			`,
+				helpers.FormatHexWithColons(certificate.AuthorityKeyId),
+				certificate.Issuer.CommonName,
+				getFirstElementOrEmpty(certificate.Issuer.Organization),
+				getFirstElementOrEmpty(certificate.Issuer.OrganizationalUnit),
+				getFirstElementOrEmpty(certificate.Issuer.Country),
+				getFirstElementOrEmpty(certificate.Issuer.Province),
+				getFirstElementOrEmpty(certificate.Issuer.Locality),
+				r["serial_number"],
+			)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func downCaAddKids(ctx context.Context, tx *sql.Tx) error {
+	// List of SQL queries to undo the previous changes
+	queries := []string{
+		"ALTER TABLE certificates RENAME COLUMN subject_key_id TO key_id;",
+		"ALTER TABLE certificates DROP COLUMN authority_key_id;",
+		"ALTER TABLE certificates DROP COLUMN issuer_common_name;",
+		"ALTER TABLE certificates DROP COLUMN issuer_organization;",
+		"ALTER TABLE certificates DROP COLUMN issuer_organization_unit;",
+		"ALTER TABLE certificates DROP COLUMN issuer_country;",
+		"ALTER TABLE certificates DROP COLUMN issuer_state;",
+		"ALTER TABLE certificates DROP COLUMN issuer_locality;",
+	}
+
+	// Execute each query in the transaction
+	for _, query := range queries {
+		_, err := tx.Exec(query)
+		if err != nil {
+			// Rollback the transaction if an error occurs
+			tx.Rollback()
+			return err
+		}
+	}
+	return nil
+}

--- a/engines/storage/postgres/migrations/dmsmanager/20241230124809_serverkeygen_revokereenroll.go
+++ b/engines/storage/postgres/migrations/dmsmanager/20241230124809_serverkeygen_revokereenroll.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pressly/goose/v3"
 )
 
-func Register_20241230124809_serverkeygen_revokereenroll() {
+func Register20241230124809ServerkeygenRevokereenroll() {
 	goose.AddMigrationContext(upRelationalDms, downRelationalDms)
 }
 

--- a/engines/storage/postgres/migrations/gomigrations.go
+++ b/engines/storage/postgres/migrations/gomigrations.go
@@ -9,9 +9,9 @@ import (
 func RegisterGoMigrations(dbname string) {
 	switch dbname {
 	case "ca":
-		ca.Register_20250123125500_ca_aws_metadata()
-		ca.Register_20250226114600_ca_add_kids()
+		ca.Register20250123125500CaAwsMetadata()
+		ca.Register20250226114600CaAddKids()
 	case "dmsmanager":
-		dmsmanager.Register_20241230124809_serverkeygen_revokereenroll()
+		dmsmanager.Register20241230124809ServerkeygenRevokereenroll()
 	}
 }

--- a/engines/storage/postgres/migrations/gomigrations.go
+++ b/engines/storage/postgres/migrations/gomigrations.go
@@ -10,6 +10,7 @@ func RegisterGoMigrations(dbname string) {
 	switch dbname {
 	case "ca":
 		ca.Register_20250123125500_ca_aws_metadata()
+		ca.Register_20250226114600_ca_add_kids()
 	case "dmsmanager":
 		dmsmanager.Register_20241230124809_serverkeygen_revokereenroll()
 	}

--- a/engines/storage/postgres/migrations_test/ca_test.go
+++ b/engines/storage/postgres/migrations_test/ca_test.go
@@ -294,6 +294,30 @@ func MigrationTest_CA_20250123125500_ca_aws_metadata(t *testing.T, logger *logru
 	assert.Equal(t, expectedMeta, result)
 }
 
+func MigrationTest_CA_20250226114600_ca_add_kids(t *testing.T, logger *logrus.Entry, con *gorm.DB) {
+	con.Exec(`INSERT INTO public.certificates 
+		(serial_number, metadata, issuer_meta_serial_number, issuer_meta_id, issuer_meta_level, status, certificate, key_meta_type, key_meta_bits, key_meta_strength, subject_common_name, subject_organization, subject_organization_unit, subject_country, subject_state, subject_locality, valid_from, valid_to, revocation_timestamp, revocation_reason, type, engine_id, key_id, is_ca) 
+		VALUES ('37-65-cd-86-f0-bf-c5-c8-1b-7f-10-f8-15-4e-4e-35-81-4c-d8-79', '{}', '37-65-cd-86-f0-bf-c5-c8-1b-7f-10-f8-15-4e-4e-35-81-4c-d8-79', 'b0db9cc7-2cce-45be-8085-88f7aff40ca2', 0, 'ACTIVE', 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURsRENDQW55Z0F3SUJBZ0lVTjJYTmh2Qy94Y2diZnhENEZVNU9OWUZNMkhrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1hURUxNQWtHQTFVRUJoTUNWVk14RlRBVEJnTlZCQWdNREVWNFlXMXdiR1ZUZEdGMFpURVVNQklHQTFVRQpCd3dMUlhoaGJYQnNaVU5wZEhreER6QU5CZ05WQkFvTUJsSnZiM1JEUVRFUU1BNEdBMVVFQXd3SFVtOXZkQ0JEClFUQWVGdzB5TlRBeU1qVXhNelUwTVRoYUZ3MHpOVEF5TWpNeE16VTBNVGhhTUVZeEN6QUpCZ05WQkFZVEFsVlQKTVJVd0V3WURWUVFJREF4RmVHRnRjR3hsVTNSaGRHVXhEekFOQmdOVkJBb01CbEp2YjNSRFFURVBNQTBHQTFVRQpBd3dHVTNWaUlFTkJNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQTJIay91Ri9VClJNdHAzengyYmltUllvSEFxMXJ6OUgyL1F3S2d0RTRkTkk1R01ISUh4ZWVJZk9sYnh4T2hyMVBhTUtTb3hJdjEKM1NqMWFycEloUUVGc2V0NDJ0WU9FS2dUTzB4NUtRSFFSbnNYOUY1dXVjNURyajZFNFUxcUF2MGtxQlMvN2NobQpqc3pwc1oyK1ExOWordjNHM0NNa2twT09ZWmFUQW8wWlBFdFJCYU5HM3hYMlg0akdidmlNMWFDeDZ2MmNDM0s4CnJmYXVoNzR4T3lLaldNME1PVm5kS2N0VUFzNW9VckZjTkM2c3BwOGtqQk1XcFhjQ3RjWStZTm5ISDVhRDcvTEIKakdaSmxaTkROS0NDdFIwR050d2xxUHZiQ3pUYnV2UHZqVkY2aFdQaEIwZFdYUDVqRTFuc05BUkxnWW51RTJXTQpoQWx5cU92bWdlaGZVUUlEQVFBQm8yTXdZVEFQQmdOVkhSTUJBZjhFQlRBREFRSC9NQTRHQTFVZER3RUIvd1FFCkF3SUJCakFkQmdOVkhRNEVGZ1FVSHV1UElDL2tVWVA2MHlzSGlMMTl2NTFyMUtFd0h3WURWUjBqQkJnd0ZvQVUKNUZpMVFQOFc5KzRSaS8wdFZFNENhaVg1cHY0d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFJdTFsQVp0ZVUrbgorNmwvd3VFb2V2K0FkOEQzVHZIREVqeHlIbll0RTRNZitITGsyU2d1WXZYSkpSRkZjOXVzRzNGbW1CMGhUUG14CktEck1rOVFPYmdIc1pIY05hZ3doQjZVcm4rRUtyai9ZVW5JSkUyVHJYL2JsRllvTUJQYXhiV3J3cm1GQWpLc2wKOHV1Sm9OWTY0RzZzT016SEJwZUVMaGRaVS94Z0Rzck5rK2RHeVZ0WUFqbWZrc1FMT1NnRjE0WFpuWEw5K3dQYwpqU200bjhXNVlRMHpzS0FaNVRtQjBWcFRDa3ZWUy9nR0RIb1pmZE8zOENTcnk0ejhuTTNXNHpka212bzc2RzhVCjJmdkMxMUZTWHh6UlZRcmJ4ZmFPTUVjZHpUMHUxd2NzUVF6TTQrdjBOanQzdlZ5K2dSbGptK0dtdDBEYzkvTGIKTzN2MkFmbWhQaVU9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K', 'RSA', 2048, 'MEDIUM', 'Sub CA', 'RootCA', '', 'US', 'ExampleState', '', '2025-02-25 13:54:18+00', '2035-02-23 13:54:18+00', '0001-01-01 00:00:00+00', 'Unspecified', 'EXTERNAL', '', '1E:EB:8F:20:2F:E4:51:83:FA:D3:2B:07:88:BD:7D:BF:9D:6B:D4:A1', true);
+	`)
+
+	ApplyMigration(t, logger, con, CADBName)
+
+	var result map[string]interface{}
+	tx := con.Raw("SELECT * FROM certificates").Scan(&result)
+	if tx.RowsAffected != 1 {
+		t.Fatalf("expected 1 row, got %d", tx.RowsAffected)
+	}
+
+	assert.Equal(t, "1E:EB:8F:20:2F:E4:51:83:FA:D3:2B:07:88:BD:7D:BF:9D:6B:D4:A1", result["subject_key_id"])
+	assert.Equal(t, "E4:58:B5:40:FF:16:F7:EE:11:8B:FD:2D:54:4E:02:6A:25:F9:A6:FE", result["authority_key_id"])
+	assert.Equal(t, "Root CA", result["issuer_common_name"])
+	assert.Equal(t, "RootCA", result["issuer_organization"])
+	assert.Equal(t, "", result["issuer_organization_unit"])
+	assert.Equal(t, "US", result["issuer_country"])
+	assert.Equal(t, "ExampleState", result["issuer_state"])
+	assert.Equal(t, "ExampleCity", result["issuer_locality"])
+}
+
 func TestMigrations(t *testing.T) {
 	logger := helpers.SetupLogger(config.Trace, "test", "test")
 	cleanup, con := RunDB(t, logger, CADBName)
@@ -334,5 +358,12 @@ func TestMigrations(t *testing.T) {
 	MigrationTest_CA_20250123125500_ca_aws_metadata(t, logger, con)
 	if t.Failed() {
 		t.Fatalf("failed while running migration v20250123125500_ca_aws_metadata")
+	}
+
+	CleanAllTables(t, logger, con)
+
+	MigrationTest_CA_20250226114600_ca_add_kids(t, logger, con)
+	if t.Failed() {
+		t.Fatalf("failed while running migration v20250226114600_ca_add_kids")
 	}
 }

--- a/sdk/ca.go
+++ b/sdk/ca.go
@@ -161,7 +161,6 @@ func (cli *httpCAClient) ImportCA(ctx context.Context, input services.ImportCAIn
 		CAChain:            input.CAChain,
 		CAPrivateKey:       privKey,
 		EngineID:           input.EngineID,
-		ParentID:           input.ParentID,
 	}, map[int][]error{})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This pull request includes several changes to the `backend/pkg` package to improve the handling and testing of certificate authorities (CAs). The most important changes include adding new test cases for CA import, updating the CA import logic to handle parent-child relationships, and adding utility functions for formatting hex data.

### Test Enhancements:
* [`backend/pkg/assemblers/ca_test.go`](diffhunk://#diff-9ea5abd3d84e44a0f09b39eab353b4f3dbb36eb90cfa68c4299f37d17ef828b0R2888-R3189): Added new test cases `OK/ImportingHierarchyBottomUp` and `OK/ImportingHierarchyTopDown` to validate the import of CAs in hierarchical order.
* [`backend/pkg/assemblers/ca_test.go`](diffhunk://#diff-9ea5abd3d84e44a0f09b39eab353b4f3dbb36eb90cfa68c4299f37d17ef828b0L4014-R4318): Fixed a typo in the test case name from `TesHightDateLimitRootCA` to `TestHightDateLimitRootCA`.

### CA Import Logic:
* [`backend/pkg/services/ca.go`](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L279-R279): Updated the `ImportCA` method to handle parent-child relationships by verifying the parent CA's signature and updating the CA's metadata accordingly. [[1]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L279-R279) [[2]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L375-R435) [[3]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L426-R452) [[4]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9R475-R520)
* [`backend/pkg/controllers/ca.go`](diffhunk://#diff-890029db072b34e676b8be2ad079d4f437a467f848c5b5782a9b07876eb56732L270): Removed the `ParentID` field from the `ImportCA` request body.

### Utility Functions:
* [`backend/pkg/helpers/x509utils.go`](diffhunk://#diff-86f28a8675b4aed8994c3a17244794f8764bf12baf584254bbed7f9a68d5df16R1-R14): Added a new utility function `FormatHexWithColons` to format byte slices as colon-separated hex strings.

### Miscellaneous:
* [`backend/pkg/assemblers/ca_test.go`](diffhunk://#diff-9ea5abd3d84e44a0f09b39eab353b4f3dbb36eb90cfa68c4299f37d17ef828b0L3927-R4231): Updated the `TestHierarchy` method to print `SubjectKeyID` and `AuthorityKeyID` instead of `KeyID`.