### PR TITLE
fix: Monolithic: Enable MonitoringJob using negated value of disableMonitor flag

### DIFF
--- a/monolithic/cmd/development/main.go
+++ b/monolithic/cmd/development/main.go
@@ -386,7 +386,7 @@ func main() {
 		AssemblyMode:       pkg.Http,
 		CryptoEngines:      cryptoEnginesConfig.CryptoEngines,
 		Monitoring: cconfig.MonitoringJob{
-			Enabled:   *disableMonitor,
+			Enabled:   !*disableMonitor,
 			Frequency: "* * * * *",
 		},
 		Storage: *pluglableStorageConfig,


### PR DESCRIPTION
This pull request includes a small but important change to the `monolithic/cmd/development/main.go` file. The change modifies the `Enabled` field in the `Monitoring` configuration to correctly reflect the state of the `disableMonitor` flag.

* [`monolithic/cmd/development/main.go`](diffhunk://#diff-2986ca8d4d81d984e49859ed7ae335a6effcb228c4f419dfa2362f7dff0e607dL389-R389): Changed the `Enabled` field in the `Monitoring` job configuration to use the negation of the `disableMonitor` flag.