### PR TITLE
chore: launch monolithic UI in a random docker port

### DIFF
--- a/monolithic/pkg/assembler.go
+++ b/monolithic/pkg/assembler.go
@@ -266,7 +266,7 @@ func RunMonolithicLamassuPKI(conf MonolithicConfig) (int, int, error) {
 		}
 
 		defaultHander := func(c *gin.Context) {
-			remote, err := url.Parse(fmt.Sprintf("http://127.0.0.1:%d", 8081))
+			remote, err := url.Parse(fmt.Sprintf("http://127.0.0.1:%d", conf.UIPort))
 			if err != nil {
 				panic(err)
 			}

--- a/monolithic/pkg/config.go
+++ b/monolithic/pkg/config.go
@@ -28,6 +28,7 @@ type MonolithicConfig struct {
 	GatewayPortHttp    int                            `mapstructure:"gateway_port_http"`
 	AWSIoTManager      MonolithicAWSIoTManagerConfig  `mapstructure:"aws_iot_manager"`
 	VAStorageDir       string                         `mapstructure:"va_storage_directory"`
+	UIPort             int                            `mapstructure:"ui_port"`
 }
 
 type MonolithicAWSIoTManagerConfig struct {


### PR DESCRIPTION
This pull request includes several changes to the `monolithic` project, primarily focusing on enabling dynamic UI port configuration and improving the handling of the UI container. The most important changes are summarized below:

### Dynamic UI Port Configuration:

* [`monolithic/cmd/development/main.go`](diffhunk://#diff-2986ca8d4d81d984e49859ed7ae335a6effcb228c4f419dfa2362f7dff0e607dR12): Added import for `strconv` to convert string to integer for the UI port.
* [`monolithic/cmd/development/main.go`](diffhunk://#diff-2986ca8d4d81d984e49859ed7ae335a6effcb228c4f419dfa2362f7dff0e607dL249-L275): Introduced a new variable `uiPort` to store the dynamically assigned port for the UI container and updated the log message to indicate whether the UI is enabled.
* [`monolithic/cmd/development/main.go`](diffhunk://#diff-2986ca8d4d81d984e49859ed7ae335a6effcb228c4f419dfa2362f7dff0e607dR380): Updated the `MonolithicConfig` struct initialization to include the new `UIPort` field.
* [`monolithic/pkg/assembler.go`](diffhunk://#diff-1fd28d344eca02197a07bd2e0673671df38e8981ca118c71aa029c08d93ac244L269-R269): Changed the default handler to use the dynamically assigned UI port from the `MonolithicConfig`.
* [`monolithic/pkg/config.go`](diffhunk://#diff-f3459c9a51d29a6d42e3a30ed28efd40375f9e3c0981b9d598aee9be8e1b28f8R31): Added a new field `UIPort` to the `MonolithicConfig` struct to store the UI port.