### PR TITLE
chore: adjust monolithic monitoring job

### DIFF
--- a/monolithic/cmd/development/main.go
+++ b/monolithic/cmd/development/main.go
@@ -388,7 +388,7 @@ func main() {
 		CryptoEngines:      cryptoEnginesConfig.CryptoEngines,
 		Monitoring: cconfig.MonitoringJob{
 			Enabled:   !*disableMonitor,
-			Frequency: "* * * * *",
+			Frequency: "2m",
 		},
 		Storage: *pluglableStorageConfig,
 		AWSIoTManager: pkg.MonolithicAWSIoTManagerConfig{


### PR DESCRIPTION
This pull request includes a change to the monitoring job frequency configuration in the `monolithic/cmd/development/main.go` file. The frequency has been updated from a cron expression to a more straightforward interval format.

Configuration update:

* [`monolithic/cmd/development/main.go`](diffhunk://#diff-2986ca8d4d81d984e49859ed7ae335a6effcb228c4f419dfa2362f7dff0e607dL391-R391): Changed the `MonitoringJob` frequency configuration from `"* * * * *"` to `"2m"`.