### PR TITLE
fix: ui port now being served correctly

### DIFF
--- a/monolithic/cmd/development/main.go
+++ b/monolithic/cmd/development/main.go
@@ -264,7 +264,7 @@ func main() {
 			hc.AutoRemove = true
 		})
 
-		uiPort, _ = strconv.Atoi(container.GetPort("4566/tcp"))
+		uiPort, _ = strconv.Atoi(container.GetPort("80/tcp"))
 
 		uiCleanup = func() {
 			containerCleanup()


### PR DESCRIPTION
This pull request includes a change to the `monolithic/cmd/development/main.go` file to update the port used for the `uiPort` variable.

* [`monolithic/cmd/development/main.go`](diffhunk://#diff-2986ca8d4d81d984e49859ed7ae335a6effcb228c4f419dfa2362f7dff0e607dL267-R267): Changed the port from `4566/tcp` to `80/tcp` for the `uiPort` variable in the `main` function.