### PR TITLE
feat: enhance event filters to use encoded event data for processing

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -89,7 +89,7 @@ jobs:
           sudo apt-get install -y libseccomp-dev #Required for building pkcs11-proxy
           git clone https://github.com/SUNET/pkcs11-proxy
           cd pkcs11-proxy
-          cmake . 
+          cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 . 
           make
           sudo make install 
           sudo cp pkcs11-daemon /usr/local/bin/

--- a/backend/pkg/assemblers/alerts_test.go
+++ b/backend/pkg/assemblers/alerts_test.go
@@ -187,7 +187,7 @@ func TestSubscriptionWithJSONPathFilter(t *testing.T) {
 			},
 			Conditions: []models.SubscriptionCondition{
 				{
-					Condition: "$.[?(@.name == 'John')]",
+					Condition: "$.data[?(@.name == 'John')]",
 					Type:      models.JSONPath,
 				},
 			},
@@ -239,7 +239,7 @@ func TestSubscriptionWithJavascriptFilter(t *testing.T) {
 			},
 			Conditions: []models.SubscriptionCondition{
 				{
-					Condition: "function(event) { return event.person.name === 'John'; }",
+					Condition: "function(event) { return event.data.person.name === 'John'; }",
 					Type:      models.Javascript,
 				},
 			},
@@ -282,22 +282,27 @@ func TestSubscriptionWithJSONSchemaFilter(t *testing.T) {
 	alertsTest := serverTest.Alerts
 
 	schema := `{
-   "$schema":"https://json-schema.org/draft/2020-12/schema",
-   "type":"object",
-   "properties":{
-      "person":{
-	     "type": "object",
-         "properties":{
-            "name":{
-               "const":"John"
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "object",
+      "properties": {
+        "person": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "const": "John"
             }
-         },
-         "required":[
+          },
+          "required": [
             "name"
-         ]
-       }
-   	  }
-	}`
+          ]
+        }
+      }
+    }
+  }
+}`
 
 	alertsTest.Service.Subscribe(context.TODO(),
 		&services.SubscribeInput{

--- a/backend/pkg/services/alerts/event_filters/javascriptfilter.go
+++ b/backend/pkg/services/alerts/event_filters/javascriptfilter.go
@@ -23,9 +23,13 @@ func RegisterJavascriptFilter() {
 // and false otherwise
 func javascriptFilter(event cloudevents.Event, script string) (bool, error) {
 	vm := otto.New()
+	encoded, err := json.Marshal(event)
+	if err != nil {
+		return false, err
+	}
 
 	var parsed interface{}
-	if err := json.Unmarshal(event.Data(), &parsed); err != nil {
+	if err := json.Unmarshal(encoded, &parsed); err != nil {
 		return false, err
 	}
 	vm.Set("event", parsed)

--- a/backend/pkg/services/alerts/event_filters/javascriptfilter_test.go
+++ b/backend/pkg/services/alerts/event_filters/javascriptfilter_test.go
@@ -23,7 +23,7 @@ func TestJavascriptFilter(t *testing.T) {
 				e.SetData(cloudevents.ApplicationJSON, map[string]interface{}{"key": "value"})
 				return e
 			}(),
-			script:   "function(event) { return event.key === 'value'; }",
+			script:   "function(event) { return event.data.key === 'value'; }",
 			expected: true,
 			wantErr:  false,
 		},
@@ -34,7 +34,7 @@ func TestJavascriptFilter(t *testing.T) {
 				e.SetData(cloudevents.ApplicationJSON, map[string]interface{}{"key": "other"})
 				return e
 			}(),
-			script:   "function(event) { return event.key === 'value'; }",
+			script:   "function(event) { return event.data.key === 'value'; }",
 			expected: false,
 			wantErr:  false,
 		},
@@ -45,7 +45,7 @@ func TestJavascriptFilter(t *testing.T) {
 				e.SetData(cloudevents.ApplicationJSON, map[string]interface{}{"key": "value"})
 				return e
 			}(),
-			script:  "function(event) { return event.key === 'value' ",
+			script:  "function(event) { return event.data.key === 'value' ",
 			wantErr: true,
 		},
 		{
@@ -55,7 +55,7 @@ func TestJavascriptFilter(t *testing.T) {
 				e.SetData(cloudevents.ApplicationJSON, map[string]interface{}{"key": "value"})
 				return e
 			}(),
-			script:   "function(event) { return event.key }",
+			script:   "function(event) { return event.data.key }",
 			expected: false,
 			wantErr:  true,
 		},

--- a/backend/pkg/services/alerts/event_filters/jsonpathfilter.go
+++ b/backend/pkg/services/alerts/event_filters/jsonpathfilter.go
@@ -1,6 +1,8 @@
 package eventfilters
 
 import (
+	"encoding/json"
+
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
 	"github.com/spyzhov/ajson"
@@ -9,8 +11,16 @@ import (
 func RegisterJSONPathFilter() {
 	RegisterEventFilter(models.JSONPath,
 		func(c models.SubscriptionCondition, event cloudevents.Event) (bool, error) {
-			return JsonPathExists(event.Data(), c.Condition)
+			return jsonPathFilter(event, c.Condition)
 		})
+}
+
+func jsonPathFilter(event cloudevents.Event, path string) (bool, error) {
+	encoded, err := json.Marshal(event)
+	if err != nil {
+		return false, err
+	}
+	return JsonPathExists(encoded, path)
 }
 
 func JsonPathExists(data []byte, path string) (bool, error) {

--- a/backend/pkg/services/alerts/event_filters/jsonpathfilter_test.go
+++ b/backend/pkg/services/alerts/event_filters/jsonpathfilter_test.go
@@ -1,9 +1,9 @@
 package eventfilters
 
 import (
-	"encoding/json"
 	"testing"
 
+	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,7 +21,7 @@ func TestJsonPathExists(t *testing.T) {
 				"name": "John",
 				"age":  30,
 			},
-			path:     "$.name",
+			path:     "$.data.name",
 			expected: true,
 			wantErr:  false,
 		},
@@ -31,7 +31,7 @@ func TestJsonPathExists(t *testing.T) {
 				"name": "John",
 				"age":  30,
 			},
-			path:     "$.address",
+			path:     "$.data.address",
 			expected: false,
 			wantErr:  false,
 		},
@@ -53,7 +53,7 @@ func TestJsonPathExists(t *testing.T) {
 					"age":  30,
 				},
 			},
-			path:     "$.person.name",
+			path:     "$.data.person.name",
 			expected: true,
 			wantErr:  false,
 		},
@@ -65,7 +65,7 @@ func TestJsonPathExists(t *testing.T) {
 					"age":  30,
 				},
 			},
-			path:     "$.person.address",
+			path:     "$.data.person.address",
 			expected: false,
 			wantErr:  false,
 		},
@@ -77,7 +77,7 @@ func TestJsonPathExists(t *testing.T) {
 					"age":  30,
 				},
 			},
-			path:     "$.[?(@.name == 'John')]",
+			path:     "$.data[?(@.name == 'John')]",
 			expected: true,
 			wantErr:  false,
 		},
@@ -89,7 +89,7 @@ func TestJsonPathExists(t *testing.T) {
 					"age":  30,
 				},
 			},
-			path:     `$.[?(@.name=="James")]`,
+			path:     `$.data[?(@.name=="James")]`,
 			expected: false,
 			wantErr:  false,
 		},
@@ -97,9 +97,11 @@ func TestJsonPathExists(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
-			b, _ := json.Marshal(tt.data)
-			result, err := JsonPathExists(b, tt.path)
+			e := cloudevents.NewEvent()
+			e.SetData(cloudevents.ApplicationJSON, tt.data)
+			result, err := jsonPathFilter(e, tt.path)
+			// b, _ := json.Marshal(tt.data)
+			// result, err := JsonPathExists(b, tt.path)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/backend/pkg/services/alerts/event_filters/jsonschemafilter.go
+++ b/backend/pkg/services/alerts/event_filters/jsonschemafilter.go
@@ -1,6 +1,8 @@
 package eventfilters
 
 import (
+	"encoding/json"
+
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/kaptinlin/jsonschema"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
@@ -9,15 +11,27 @@ import (
 func RegisterJSONSchemaFilter() {
 	RegisterEventFilter(models.JSONSchema,
 		func(c models.SubscriptionCondition, event cloudevents.Event) (bool, error) {
-
-			compiler := jsonschema.NewCompiler()
-			schema, err := compiler.Compile([]byte(c.Condition))
-			if err != nil {
-				return false, err
-			}
-			data := make(map[string]interface{})
-			event.DataAs(&data)
-			result := schema.Validate(data)
-			return result.Valid, nil
+			return filterJSONSchema(event, c.Condition)
 		})
+}
+
+func filterJSONSchema(event cloudevents.Event, schemaCondition string) (bool, error) {
+	compiler := jsonschema.NewCompiler()
+	schema, err := compiler.Compile([]byte(schemaCondition))
+	if err != nil {
+		return false, err
+	}
+	encoded, err := json.Marshal(event)
+	if err != nil {
+		return false, err
+	}
+
+	var data map[string]interface{}
+	err = json.Unmarshal(encoded, &data)
+	if err != nil {
+		return false, err
+	}
+
+	result := schema.Validate(data)
+	return result.Valid, nil
 }

--- a/backend/pkg/services/alerts/event_filters/jsonschemafilter_test.go
+++ b/backend/pkg/services/alerts/event_filters/jsonschemafilter_test.go
@@ -1,0 +1,143 @@
+package eventfilters
+
+import (
+	"testing"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterJSONSchema(t *testing.T) {
+	tests := []struct {
+		name           string
+		eventData      interface{}
+		schema         string
+		expectedResult bool
+		wantErr        bool
+	}{
+		{
+			name: "ValidSchemaAndMatchingData",
+			eventData: map[string]interface{}{
+				"name": "John",
+				"age":  30,
+			},
+			schema: `{
+					"type": "object",
+					"properties": {
+						"data": {
+						"type": "object",
+						"properties": {
+							"name": {
+							"type": "string"
+							},
+							"age": {
+							"type": "integer"
+							}
+						},
+						"required": [
+							"name",
+							"age"
+						]
+						}
+					}
+					}`,
+			expectedResult: true,
+			wantErr:        false,
+		},
+		{
+			name: "ValidSchemaAndNonMatchingData",
+			eventData: map[string]interface{}{
+				"name": "John",
+			},
+			schema: `{
+					"type": "object",
+					"properties": {
+						"data": {
+						"type": "object",
+						"properties": {
+							"name": {
+							"type": "string"
+							},
+							"age": {
+							"type": "integer"
+							}
+						},
+						"required": [
+							"name",
+							"age"
+						]
+						}
+					}
+					}`,
+			expectedResult: false,
+			wantErr:        false,
+		},
+		{
+			name: "InvalidSchema",
+			eventData: map[string]interface{}{
+				"name": "John",
+				"age":  30,
+			},
+			schema:         `{"type": "object", "properties": {"name": {"type": "string"}, "age": {"type": "integer"}`,
+			expectedResult: false,
+			wantErr:        true,
+		},
+		{
+			name: "EmptySchema",
+			eventData: map[string]interface{}{
+				"name": "John",
+				"age":  30,
+			},
+			schema:         ``,
+			expectedResult: false,
+			wantErr:        true,
+		},
+		{
+			name: "ValidSchemaWithAdditionalProperties",
+			eventData: map[string]interface{}{
+				"name":    "John",
+				"age":     30,
+				"address": "123 Street",
+			},
+			schema: `{
+					"type": "object",
+					"properties": {
+						"data": {
+						"type": "object",
+						"properties": {
+							"name": {
+							"type": "string"
+							},
+							"age": {
+							"type": "integer"
+							}
+						},
+						"required": [
+							"name",
+							"age"
+						],
+						"additionalProperties": false
+						}
+					}
+					}`,
+			expectedResult: false,
+			wantErr:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := cloudevents.NewEvent()
+			err := event.SetData(cloudevents.ApplicationJSON, tt.eventData)
+			assert.NoError(t, err)
+
+			result, err := filterJSONSchema(event, tt.schema)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectedResult, result)
+		})
+	}
+}


### PR DESCRIPTION
This pull request includes changes to enhance the event filtering functionality by ensuring consistent data handling and improving test coverage. The most important changes involve modifications to the `javascriptFilter`, `jsonPathFilter`, and `jsonSchemaFilter` functions, as well as updates to their corresponding tests.

Enhancements to event filtering functions:

* [`backend/pkg/services/alerts/event_filters/javascriptfilter.go`](diffhunk://#diff-04b50cd293c8cb61825c648232d94585f1a4a921503c0d8d11375ff23db25048R26-R32): Modified the `javascriptFilter` function to handle the event data consistently by encoding the event to JSON before unmarshalling it.
* [`backend/pkg/services/alerts/event_filters/jsonpathfilter.go`](diffhunk://#diff-7725de5c3c6e5d663a82a18996e5d9e284773d706d28c732337a99c7fd9fa527L12-R25): Introduced a new `jsonPathFilter` function to handle the event data consistently by encoding the event to JSON before passing it to the `JsonPathExists` function.
* [`backend/pkg/services/alerts/event_filters/jsonschemafilter.go`](diffhunk://#diff-2fca1866b9fb2e27099ce1c1640278d40199a612313c157467ab76500d635d47R14-L22): Added a new `filterJSONSchema` function to handle the event data consistently by encoding the event to JSON before validating it against the JSON schema.

Improvements to test coverage:

* [`backend/pkg/services/alerts/event_filters/javascriptfilter_test.go`](diffhunk://#diff-f94a7606cb0aace5098175c572b967be485bcbf23bfcb8499980fd877c3bdab9L26-R26): Updated test cases to reflect the changes in how event data is accessed within the `javascriptFilter` function. [[1]](diffhunk://#diff-f94a7606cb0aace5098175c572b967be485bcbf23bfcb8499980fd877c3bdab9L26-R26) [[2]](diffhunk://#diff-f94a7606cb0aace5098175c572b967be485bcbf23bfcb8499980fd877c3bdab9L37-R37) [[3]](diffhunk://#diff-f94a7606cb0aace5098175c572b967be485bcbf23bfcb8499980fd877c3bdab9L48-R48) [[4]](diffhunk://#diff-f94a7606cb0aace5098175c572b967be485bcbf23bfcb8499980fd877c3bdab9L58-R58)
* [`backend/pkg/services/alerts/event_filters/jsonpathfilter_test.go`](diffhunk://#diff-c1378e8ddbd1c6b099c574ae6477cea61a5ae143be33d624b90286ad58b8ce07L24-R24): Updated test cases to reflect the changes in how event data is accessed within the `jsonPathFilter` function. [[1]](diffhunk://#diff-c1378e8ddbd1c6b099c574ae6477cea61a5ae143be33d624b90286ad58b8ce07L24-R24) [[2]](diffhunk://#diff-c1378e8ddbd1c6b099c574ae6477cea61a5ae143be33d624b90286ad58b8ce07L34-R34) [[3]](diffhunk://#diff-c1378e8ddbd1c6b099c574ae6477cea61a5ae143be33d624b90286ad58b8ce07L56-R56) [[4]](diffhunk://#diff-c1378e8ddbd1c6b099c574ae6477cea61a5ae143be33d624b90286ad58b8ce07L68-R68) [[5]](diffhunk://#diff-c1378e8ddbd1c6b099c574ae6477cea61a5ae143be33d624b90286ad58b8ce07L80-R80) [[6]](diffhunk://#diff-c1378e8ddbd1c6b099c574ae6477cea61a5ae143be33d624b90286ad58b8ce07L92-R104)
* [`backend/pkg/services/alerts/event_filters/jsonschemafilter_test.go`](diffhunk://#diff-3e6fd86c8065dc29ff005ccf39cda7d62b3f341191fcebf1ea32902217459300R1-R143): Added new test cases to ensure comprehensive coverage of the `filterJSONSchema` function.

This PR aligns the backend behaviour with the UI. This PR closes https://github.com/lamassuiot/lamassu-ui/issues/66