### PR TITLE
Refactor: Adding kid uri refactor

### DIFF
--- a/backend/pkg/services/alerts/output_channels/msteams.go
+++ b/backend/pkg/services/alerts/output_channels/msteams.go
@@ -81,7 +81,7 @@ func (s *MSTeamsWebhookOutputService) SendNotification(logger *logrus.Entry, ctx
 		return err
 	}
 
-	_, err = webhookclient.InvokeWebhook(logger, models.WebhookCall{
+	_, err = webhookclient.InvokeWebhook(ctx, logger, models.WebhookCall{
 		Name:   s.name,
 		Url:    s.config.WebhookURL,
 		Method: "POST",

--- a/backend/pkg/services/alerts/output_channels/webhook.go
+++ b/backend/pkg/services/alerts/output_channels/webhook.go
@@ -32,7 +32,7 @@ func (s *WebhookOutputService) SendNotification(logger *logrus.Entry, ctx contex
 
 	if s.config.WebhookURL != "" {
 
-		_, err = webhookclient.InvokeWebhook(logger, models.WebhookCall{
+		_, err = webhookclient.InvokeWebhook(ctx, logger, models.WebhookCall{
 			Name:   s.name,
 			Url:    s.config.WebhookURL,
 			Method: s.config.WebhookMethod,

--- a/backend/pkg/services/dmsmanager.go
+++ b/backend/pkg/services/dmsmanager.go
@@ -390,7 +390,7 @@ func (svc DMSManagerServiceBackend) Enroll(ctx context.Context, csr *x509.Certif
 			Authorized bool `json:"authorized"`
 		}
 
-		resp, err := webhookclient.InvokeJSONWebhook[WebhookResponse](lFunc, webhookConf, webhookRequestBody)
+		resp, err := webhookclient.InvokeJSONWebhook[WebhookResponse](ctx, lFunc, webhookConf, webhookRequestBody)
 		if err != nil {
 			lFunc = lFunc.WithField("auth-status", "failed")
 			lFunc.Errorf("aborting enrollment. got error while calling external webhook: %s", err)

--- a/backend/pkg/x509engines/x509engine_test.go
+++ b/backend/pkg/x509engines/x509engine_test.go
@@ -22,8 +22,6 @@ import (
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
 	cmodels "github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
 	"github.com/lamassuiot/lamassuiot/engines/crypto/filesystem/v3"
-	"github.com/lamassuiot/lamassuiot/engines/crypto/software/v3"
-	"github.com/sirupsen/logrus"
 )
 
 func setup(t *testing.T) (string, cryptoengines.CryptoEngine, X509Engine) {
@@ -170,16 +168,16 @@ func checkCACertificate(cert *x509.Certificate, ca *x509.Certificate, tcSubject 
 		return fmt.Errorf("unexpected result, got: %s, want: %s", cert.OCSPServer[1], "http://va.lamassuiot.com/ocsp")
 	}
 
-	v2CrlID, err := software.NewSoftwareCryptoEngine(logrus.NewEntry(logrus.StandardLogger())).EncodePKIXPublicKeyDigest(ca.PublicKey)
+	v2CrlID, err := cryptoengines.GetKeyLRN(ca.PublicKey)
 	if err != nil {
 		return fmt.Errorf("unexpected error: %s", err)
 	}
 
-	if cert.CRLDistributionPoints[0] != "http://ocsp.lamassu.io/crl/"+v2CrlID {
+	if cert.CRLDistributionPoints[0] != "http://ocsp.lamassu.io/crl/"+v2CrlID.GetBaseID() {
 		return fmt.Errorf("unexpected result, got: %s, want: %s", cert.CRLDistributionPoints[0], "http://crl.lamassuiot.com/crl/"+v2CrlID)
 	}
 
-	if cert.CRLDistributionPoints[1] != "http://va.lamassu.io/crl/"+v2CrlID {
+	if cert.CRLDistributionPoints[1] != "http://va.lamassu.io/crl/"+v2CrlID.GetBaseID() {
 		return fmt.Errorf("unexpected result, got: %s, want: %s", cert.CRLDistributionPoints[1], "http://va.lamassuiot.com/crl/"+v2CrlID)
 	}
 

--- a/core/pkg/engines/cryptoengines/cryptoengine.go
+++ b/core/pkg/engines/cryptoengines/cryptoengine.go
@@ -14,18 +14,18 @@ import (
 type CryptoEngine interface {
 	GetEngineConfig() models.CryptoEngineInfo
 
-	ListPrivateKeyIDs() ([]string, error)
-	GetPrivateKeyByID(keyID string) (crypto.Signer, error)
+	ListPrivateKeyIDs() ([]KeyID, error)
+	GetPrivateKeyByID(keyID KeyID) (crypto.Signer, error)
 
-	CreateRSAPrivateKey(keySize int) (string, crypto.Signer, error)
-	CreateECDSAPrivateKey(curve elliptic.Curve) (string, crypto.Signer, error)
+	CreateRSAPrivateKey(keySize int) (KeyID, crypto.Signer, error)
+	CreateECDSAPrivateKey(curve elliptic.Curve) (KeyID, crypto.Signer, error)
 
-	ImportRSAPrivateKey(key *rsa.PrivateKey) (string, crypto.Signer, error)
-	ImportECDSAPrivateKey(key *ecdsa.PrivateKey) (string, crypto.Signer, error)
+	ImportRSAPrivateKey(key *rsa.PrivateKey) (KeyID, crypto.Signer, error)
+	ImportECDSAPrivateKey(key *ecdsa.PrivateKey) (KeyID, crypto.Signer, error)
 
-	DeleteKey(keyID string) error
+	DeleteKey(keyID KeyID) error
 
-	RenameKey(oldID, newID string) error
+	RenameKey(oldID, newID KeyID) error
 }
 
 var cryptoEngineBuilders = make(map[config.CryptoEngineProvider]func(*logrus.Entry, config.CryptoEngineConfig) (CryptoEngine, error))

--- a/core/pkg/engines/cryptoengines/cryptoengine_test.go
+++ b/core/pkg/engines/cryptoengines/cryptoengine_test.go
@@ -20,37 +20,37 @@ func (m *mockCryptoEngine) GetEngineConfig() models.CryptoEngineInfo {
 	return models.CryptoEngineInfo{}
 }
 
-func (m *mockCryptoEngine) GetPrivateKeyByID(keyID string) (crypto.Signer, error) {
+func (m *mockCryptoEngine) GetPrivateKeyByID(keyID KeyID) (crypto.Signer, error) {
 	return nil, nil
 }
 
-func (m *mockCryptoEngine) ListPrivateKeyIDs() ([]string, error) {
+func (m *mockCryptoEngine) ListPrivateKeyIDs() ([]KeyID, error) {
 	return nil, nil
 }
 
-func (m *mockCryptoEngine) CreateRSAPrivateKey(keySize int) (string, crypto.Signer, error) {
+func (m *mockCryptoEngine) CreateRSAPrivateKey(keySize int) (KeyID, crypto.Signer, error) {
 	key, err := rsa.GenerateKey(rand.Reader, keySize)
 	return "", key, err
 }
 
-func (m *mockCryptoEngine) CreateECDSAPrivateKey(curve elliptic.Curve) (string, crypto.Signer, error) {
+func (m *mockCryptoEngine) CreateECDSAPrivateKey(curve elliptic.Curve) (KeyID, crypto.Signer, error) {
 	key, err := ecdsa.GenerateKey(curve, rand.Reader)
 	return "", key, err
 }
 
-func (m *mockCryptoEngine) ImportRSAPrivateKey(key *rsa.PrivateKey) (string, crypto.Signer, error) {
+func (m *mockCryptoEngine) ImportRSAPrivateKey(key *rsa.PrivateKey) (KeyID, crypto.Signer, error) {
 	return "", key, nil
 }
 
-func (m *mockCryptoEngine) ImportECDSAPrivateKey(key *ecdsa.PrivateKey) (string, crypto.Signer, error) {
+func (m *mockCryptoEngine) ImportECDSAPrivateKey(key *ecdsa.PrivateKey) (KeyID, crypto.Signer, error) {
 	return "", key, nil
 }
 
-func (m *mockCryptoEngine) DeleteKey(keyID string) error {
+func (m *mockCryptoEngine) DeleteKey(keyID KeyID) error {
 	return nil
 }
 
-func (m *mockCryptoEngine) RenameKey(keyID string, newKeyID string) error {
+func (m *mockCryptoEngine) RenameKey(keyID KeyID, newKeyID KeyID) error {
 	return nil
 }
 

--- a/core/pkg/engines/cryptoengines/kms-schemaversions.go
+++ b/core/pkg/engines/cryptoengines/kms-schemaversions.go
@@ -1,0 +1,44 @@
+package cryptoengines
+
+import (
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"fmt"
+)
+
+// v1: plain serial number. Example: 11-22-33-44-55-66-77
+// v2: hex encoded SHA256 of the public key, a string of 64 characters. Example: 258abc860d364eb39561d69cdaec40164fd54dbad47c8a887112ba19f903757c
+// v3: lrn:keyid:v3:<hex encoded SHA256 of the public key, a string of 64 characters>. Example: lrn:keyid:v3:258abc860d364eb39561d69cdaec40164fd54dbad47c8a887112ba19f903757c
+type KeyID string
+
+// Should always return a valid key id using the latest SchemaVersion
+func GetKeyLRN(key any) (KeyID, error) {
+	var pubkeyBytes []byte
+	var err error
+
+	pubkeyBytes, err = x509.MarshalPKIXPublicKey(key)
+	if err != nil {
+		return "", fmt.Errorf("could not marshal public key: %s", err)
+	}
+
+	hash := sha256.New()
+	hash.Write(pubkeyBytes)
+	digest := hash.Sum(nil)
+	// p.logger.Tracef("public key digest (bytes): %x", digest)
+
+	hexDigest := hex.EncodeToString(digest)
+	// p.logger.Debugf("public key digest (hex encoded bytes): %s", hexDigest)
+
+	lrn := fmt.Sprintf("lrn:keyid:v3:%s", hexDigest)
+	return KeyID(lrn), nil
+}
+
+func (k KeyID) GetBaseID() string {
+	// Remove the prefix "lrn:keyid:v3:"
+	if len(k) > 14 {
+		return string(k[14:])
+	}
+
+	return ""
+}


### PR DESCRIPTION
This pull request includes several changes to the `backend/pkg/services`, `core/pkg/engines/cryptoengines`, and `engines/crypto/aws` directories. The primary focus is on refactoring the code to use a new `KeyID` type and improving the handling of key identifiers across various services. Additionally, there are some context-related improvements and cleanup of unused imports.

Refactoring for `KeyID` type:

* [`backend/pkg/services/ca.go`](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L64-L113): Removed the code for key migration and refactored functions to use the new `KeyID` type instead of `string` for key identifiers. [[1]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L64-L113) [[2]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L571-R519)
* [`core/pkg/engines/cryptoengines/cryptoengine.go`](diffhunk://#diff-e2fd7f170533086bce9f5e392e17c76a57ea77da2d36eaf674b42694b8d6a7d0L17-R28): Updated the `CryptoEngine` interface to use the new `KeyID` type for key identifiers.
* [`core/pkg/engines/cryptoengines/cryptoengine_test.go`](diffhunk://#diff-7ed284349d156a75610d9bebc4a9eb264ba867dc178d2095f5b50195e934b930L23-R53): Adjusted the mock implementation to align with the new `KeyID` type.
* [`engines/crypto/aws/awskms.go`](diffhunk://#diff-1e5f2c4933cb676f63fa8b7621ddc5d27dde9c2262c0faeb29a85b89df25cef4L83-R83): Modified AWS KMS engine to use the `KeyID` type for key identifiers.

Context-related improvements:

* [`backend/pkg/services/alerts/output_channels/msteams.go`](diffhunk://#diff-b445ead3bb31c310d35d6f392348d0dd859bf543edfda5f15e290f8cfa1e9c3dL84-R84): Changed the `InvokeWebhook` function to pass the `ctx` parameter.
* [`backend/pkg/services/alerts/output_channels/webhook.go`](diffhunk://#diff-e614da688e1be99197d2dc04d20219bcaf0e11aabb597ae1c32eb6fa3c4aefb2L35-R35): Updated the `InvokeWebhook` function to use the `ctx` parameter.
* [`backend/pkg/services/dmsmanager.go`](diffhunk://#diff-23d4c4af43f96397c134a3299f77ed31fc20dce780dda0b7f06c97af98e07533L393-R393): Modified the `InvokeJSONWebhook` function to include the `ctx` parameter.

Cleanup:

* [`backend/pkg/services/ca.go`](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L8): Removed unused import for `unicode`.
* [`backend/pkg/services/ca.go`](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L21): Removed unused import for `software` crypto engine.
* [`backend/pkg/x509engines/x509engine_test.go`](diffhunk://#diff-215f32d72265a21acc3eb5d226f13c27ec59d258e2d8c079385e07298c444c3fL25-L26): Cleaned up unused imports for `software` crypto engine and `logrus`.

New `KeyID` type implementation:

* [`core/pkg/engines/cryptoengines/kms-schemaversions.go`](diffhunk://#diff-9d673c87a970339600fd1dd28404a9ea02ce1236c51d0725508855cf2eb6bcf3R1-R44): Introduced the `KeyID` type and helper functions for key identifier management.