### PR TITLE
feat: VA: assemble service conditionally based on config

### DIFF
--- a/monolithic/pkg/assembler.go
+++ b/monolithic/pkg/assembler.go
@@ -109,10 +109,7 @@ func RunMonolithicLamassuPKI(conf MonolithicConfig) (int, int, error) {
 					"storage_directory": conf.VAStorageDir,
 				},
 			},
-			CRLMonitoringJob: cconfig.MonitoringJob{
-				Enabled:   true,
-				Frequency: "30s",
-			},
+			CRLMonitoringJob:   conf.Monitoring,
 			SubscriberEventBus: conf.SubscriberEventBus,
 			PublisherEventBus:  conf.PublisherEventBus,
 			Storage:            conf.Storage,


### PR DESCRIPTION
This pull request refactors the `AssembleVAService` functionality in `backend/pkg/assemblers/va.go` to improve modularity, enhance readability, and add support for additional configurations like event buses and monitoring jobs. The changes include extracting logic into new helper functions and introducing conditional handling for optional features.

### Refactoring and Modularization:
* Moved the `serviceID` variable to a global scope for reuse across multiple functions, reducing redundancy. [[1]](diffhunk://#diff-8fe0cfe52a16a3428bd5e2d7acc13d21907c0208a6c3195e4942df5de462af8cR23-R24) [[2]](diffhunk://#diff-8fe0cfe52a16a3428bd5e2d7acc13d21907c0208a6c3195e4942df5de462af8cL43)
* Extracted the logic for setting up the Publisher Event Bus, Subscriber Event Bus, and CRL Monitoring Job into separate helper functions: `createPublisherEventBus`, `createSubscriberEventBus`, and `createCRLMonitoringJob`. This improves code organization and readability.

### Feature Enhancements:
* Added conditional checks to enable or disable the Publisher Event Bus, Subscriber Event Bus, and CRL Monitoring Job based on the configuration provided in `VAconfig`. This makes the service more configurable and adaptable.

### Error Handling Improvements:
* Refined error handling in the newly created helper functions to ensure meaningful error messages and proper propagation of errors.

These changes collectively make the `AssembleVAService` implementation more maintainable and extendable while introducing new capabilities for event handling and monitoring.