### PR TITLE
feat: CA: implement AWS KMS import keys

### DIFF
--- a/core/pkg/engines/cryptoengines/cryptoengine_testset.go
+++ b/core/pkg/engines/cryptoengines/cryptoengine_testset.go
@@ -164,3 +164,31 @@ func SharedTestECDSASignature(t *testing.T, engine CryptoEngine) {
 	res := ecdsa.VerifyASN1(signer2.Public().(*ecdsa.PublicKey), hashed, signature)
 	assert.True(t, res)
 }
+
+func SharedTestImportRSAPrivateKey(t *testing.T, engine CryptoEngine) {
+	key, err := rsa.GenerateKey(rand.Reader, 3072)
+	assert.NoError(t, err)
+
+	pubKey := key.Public().(*rsa.PublicKey)
+
+	_, importedSigner, err := engine.ImportRSAPrivateKey(key)
+	assert.NoError(t, err)
+
+	importedPubKey := importedSigner.Public().(*rsa.PublicKey)
+	assert.Equal(t, pubKey.N, importedPubKey.N)
+	assert.Equal(t, pubKey.E, importedPubKey.E)
+}
+
+func SharedTestImportECDSAPrivateKey(t *testing.T, engine CryptoEngine) {
+	key, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	assert.NoError(t, err)
+
+	pubKey := key.Public().(*ecdsa.PublicKey)
+
+	_, importedSigner, err := engine.ImportECDSAPrivateKey(key)
+	assert.NoError(t, err)
+
+	importedPubKey := importedSigner.Public().(*ecdsa.PublicKey)
+	assert.Equal(t, pubKey.X, importedPubKey.X)
+	assert.Equal(t, pubKey.Y, importedPubKey.Y)
+}

--- a/engines/crypto/aws/awskms.go
+++ b/engines/crypto/aws/awskms.go
@@ -3,10 +3,15 @@ package aws
 import (
 	"context"
 	"crypto"
+	"crypto/aes"
+	"crypto/cipher"
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/x509"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -232,13 +237,177 @@ func (p *AWSKMSCryptoEngine) createPrivateKey(keySpec types.KeySpec) (string, cr
 }
 
 func (p *AWSKMSCryptoEngine) ImportRSAPrivateKey(key *rsa.PrivateKey) (string, crypto.Signer, error) {
-	lAWSKMS.Warnf("KMS does not support asymmetric key import. See https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html")
-	return "", nil, fmt.Errorf("KMS does not support asymmetric key import")
+	var spec types.KeySpec
+	keySize := key.PublicKey.N.BitLen()
+	switch keySize {
+	case 2048:
+		spec = types.KeySpecRsa2048
+	case 3072:
+		spec = types.KeySpecRsa3072
+	case 4096:
+		spec = types.KeySpecRsa4096
+	default:
+		err := fmt.Errorf("key size not supported by AWS KMS")
+		lAWSKMS.Error(err)
+		return "", nil, err
+	}
+
+	createKeyOut, err := p.kmscli.CreateKey(context.Background(), &kms.CreateKeyInput{
+		Origin:   types.OriginTypeExternal,
+		KeySpec:  spec,
+		KeyUsage: types.KeyUsageTypeSignVerify,
+	})
+	if err != nil {
+		lAWSKMS.Errorf("could not create key: %s", err)
+		return "", nil, err
+	}
+
+	keyID, err := p.softCryptoEngine.EncodePKIXPublicKeyDigest(key.Public())
+	if err != nil {
+		lAWSKMS.Errorf("could not encode public key digest: %s", err)
+		return "", nil, err
+	}
+
+	_, err = p.kmscli.CreateAlias(context.Background(), &kms.CreateAliasInput{
+		AliasName:   aws.String(fmt.Sprintf("alias/%s", keyID)),
+		TargetKeyId: createKeyOut.KeyMetadata.Arn,
+	})
+
+	if err != nil {
+		lAWSKMS.Warnf("Could not create alias for key ARN [%s]: %s", *createKeyOut.KeyMetadata.Arn, err)
+	}
+
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		lAWSKMS.Errorf("could not marshal private key: %s", err)
+		return "", nil, err
+	}
+
+	err = p.importPrivateKeyDer(der, *createKeyOut.KeyMetadata.Arn)
+	if err != nil {
+		lAWSKMS.Errorf("could not import private key to AWS KMS Service: %s", err)
+		return "", nil, err
+	}
+
+	signer, err := newKmsKeyCryptoSingerWrapper(p.kmscli, *createKeyOut.KeyMetadata.Arn)
+	if err != nil {
+		lAWSKMS.Errorf("could not create private key: %s", err)
+		return "", nil, err
+	}
+
+	return keyID, signer, nil
 }
 
 func (p *AWSKMSCryptoEngine) ImportECDSAPrivateKey(key *ecdsa.PrivateKey) (string, crypto.Signer, error) {
-	lAWSKMS.Warnf("KMS does not support asymmetric key import. See https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html")
-	return "", nil, fmt.Errorf("KMS does not support asymmetric key import")
+	var spec types.KeySpec
+	switch key.Curve {
+	case elliptic.P256():
+		spec = types.KeySpecEccNistP256
+	case elliptic.P384():
+		spec = types.KeySpecEccNistP384
+	case elliptic.P521():
+		spec = types.KeySpecEccNistP521
+	default:
+		err := fmt.Errorf("key size not supported by AWS KMS")
+		lAWSKMS.Error(err)
+		return "", nil, err
+	}
+
+	createKeyOut, err := p.kmscli.CreateKey(context.Background(), &kms.CreateKeyInput{
+		Origin:   types.OriginTypeExternal,
+		KeySpec:  spec,
+		KeyUsage: types.KeyUsageTypeSignVerify,
+	})
+	if err != nil {
+		lAWSKMS.Errorf("could not create key: %s", err)
+		return "", nil, err
+	}
+
+	keyID, err := p.softCryptoEngine.EncodePKIXPublicKeyDigest(key.Public())
+	if err != nil {
+		lAWSKMS.Errorf("could not encode public key digest: %s", err)
+		return "", nil, err
+	}
+
+	_, err = p.kmscli.CreateAlias(context.Background(), &kms.CreateAliasInput{
+		AliasName:   aws.String(fmt.Sprintf("alias/%s", keyID)),
+		TargetKeyId: createKeyOut.KeyMetadata.Arn,
+	})
+
+	if err != nil {
+		lAWSKMS.Warnf("Could not create alias for key ARN [%s]: %s", *createKeyOut.KeyMetadata.Arn, err)
+	}
+
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		lAWSKMS.Errorf("could not marshal private key: %s", err)
+		return "", nil, err
+	}
+
+	err = p.importPrivateKeyDer(der, *createKeyOut.KeyMetadata.Arn)
+	if err != nil {
+		lAWSKMS.Errorf("could not import private key to AWS KMS Service: %s", err)
+		return "", nil, err
+	}
+
+	signer, err := newKmsKeyCryptoSingerWrapper(p.kmscli, *createKeyOut.KeyMetadata.Arn)
+	if err != nil {
+		lAWSKMS.Errorf("could not create private key: %s", err)
+		return "", nil, err
+	}
+
+	return keyID, signer, nil
+}
+
+func (p *AWSKMSCryptoEngine) importPrivateKeyDer(der []byte, arn string) error {
+	symmetricKey := make([]byte, 32)
+	_, err := rand.Read(symmetricKey)
+	if err != nil {
+		lAWSKMS.Errorf("could not generate symmetric encryption key: %s", err)
+		return err
+	}
+
+	lAWSKMS.Debugf("generated symmetric encryption wrapping key")
+
+	outImportParams, err := p.kmscli.GetParametersForImport(context.Background(), &kms.GetParametersForImportInput{
+		WrappingAlgorithm: types.AlgorithmSpecRsaAesKeyWrapSha256,
+		KeyId:             &arn,
+		WrappingKeySpec:   types.WrappingKeySpecRsa4096,
+	})
+
+	if err != nil {
+		lAWSKMS.Errorf("could not get import parameters: %s", err)
+		return err
+	}
+
+	// Encrypt the key material with the wrapping key using AES
+	encryptedPrivateKey, err := wrapAESKeyWithPad(symmetricKey, der)
+	if err != nil {
+		lAWSKMS.Errorf("could not encrypt private key with AES: %s", err)
+		return err
+	}
+
+	// Encrypt the symmetric key with the wrapping key
+	encryptedAesKey, err := encryptWithRSAOAEP(symmetricKey, outImportParams.PublicKey)
+	if err != nil {
+		lAWSKMS.Errorf("could not encrypt symmetric key with wrapping key: %s", err)
+		return err
+	}
+
+	combinedEncryptedMaterial := append(encryptedAesKey, encryptedPrivateKey...)
+
+	_, err = p.kmscli.ImportKeyMaterial(context.Background(), &kms.ImportKeyMaterialInput{
+		KeyId:                &arn,
+		ImportToken:          outImportParams.ImportToken,
+		EncryptedKeyMaterial: combinedEncryptedMaterial,
+		ExpirationModel:      types.ExpirationModelTypeKeyMaterialDoesNotExpire,
+	})
+	if err != nil {
+		lAWSKMS.Errorf("could not import key material: %s", err)
+		return err
+	}
+
+	return nil
 }
 
 func (p *AWSKMSCryptoEngine) RenameKey(oldID, newID string) error {
@@ -363,4 +532,111 @@ func getSigningAlgorithm(key crypto.PublicKey, opts crypto.SignerOpts) (types.Si
 	default:
 		return "", fmt.Errorf("unsupported key type %T", key)
 	}
+}
+
+func encryptWithRSAOAEP(msg []byte, pubKeyDer []byte) ([]byte, error) {
+	// Parse public key
+	pubInterface, err := x509.ParsePKIXPublicKey(pubKeyDer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse DER public key: %w", err)
+	}
+
+	pubKey, ok := pubInterface.(*rsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("public key is not an RSA key")
+	}
+
+	// Encrypt using RSA-OAEP with SHA-256
+	label := []byte("") // no label
+	hash := sha256.New()
+	encryptedKey, err := rsa.EncryptOAEP(hash, rand.Reader, pubKey, msg, label)
+	if err != nil {
+		return nil, fmt.Errorf("RSA OAEP encryption failed: %w", err)
+	}
+
+	// Return the encrypted key
+	return encryptedKey, nil
+}
+
+// wrapWithPad implements AES-256 key wrap with padding
+func wrapAESKeyWithPad(kek, plaintext []byte) ([]byte, error) {
+	// Default IV for AES Key Wrap with Padding (RFC 5649)
+	var defaultIV = []byte{0xA6, 0x59, 0x59, 0xA6}
+
+	// padKey pads the input according to RFC 5649
+	padKey := func(key []byte) []byte {
+		m := len(key)
+		if m%8 == 0 && m >= 16 {
+			return key // No padding needed
+		}
+
+		// Append 0x00 padding to make it multiple of 8
+		padLen := 8 - (m % 8)
+		padded := make([]byte, m+padLen)
+		copy(padded, key)
+		return padded
+	}
+
+	// buildIV builds the 8-byte alternative initial value
+	buildIV := func(mli int) []byte {
+		iv := make([]byte, 8)
+		copy(iv[:4], defaultIV)
+		binary.BigEndian.PutUint32(iv[4:], uint32(mli))
+		return iv
+	}
+
+	// aesEncryptBlock performs ECB AES encryption for a single block
+	aesEncryptBlock := func(block cipher.Block, plaintext []byte) []byte {
+		dst := make([]byte, len(plaintext))
+		block.Encrypt(dst, plaintext)
+		return dst
+	}
+
+	// xorBlocks returns a ^ b (byte-wise)
+	xorBlocks := func(a, b []byte) []byte {
+		out := make([]byte, len(a))
+		for i := range a {
+			out[i] = a[i] ^ b[i]
+		}
+		return out
+	}
+
+	block, err := aes.NewCipher(kek)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cipher: %w", err)
+	}
+
+	mli := len(plaintext)
+	padded := padKey(plaintext)
+	n := len(padded) / 8
+	r := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		r[i] = make([]byte, 8)
+		copy(r[i], padded[i*8:(i+1)*8])
+	}
+
+	a := buildIV(mli)
+
+	// Perform 6 * n iterations
+	for j := 0; j < 6; j++ {
+		for i := 0; i < n; i++ {
+			b := append(a, r[i]...)
+			bEncrypted := aesEncryptBlock(block, b)
+
+			t := uint64(n*j + i + 1)
+			tBytes := make([]byte, 8)
+			binary.BigEndian.PutUint64(tBytes, t)
+
+			a = xorBlocks(bEncrypted[:8], tBytes)
+			copy(r[i], bEncrypted[8:])
+		}
+	}
+
+	// Output: A || R[0] || R[1] || ...
+	result := append(a, []byte{}...)
+	for _, block := range r {
+		result = append(result, block...)
+	}
+
+	return result, nil
 }

--- a/engines/crypto/aws/awskms_test.go
+++ b/engines/crypto/aws/awskms_test.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"crypto/elliptic"
 	"crypto/x509"
 	"testing"
 
@@ -9,7 +8,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/engines/cryptoengines"
-	chelpers "github.com/lamassuiot/lamassuiot/core/v3/pkg/helpers"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -62,22 +60,6 @@ func testDeleteKeyOnKMS(t *testing.T, engine cryptoengines.CryptoEngine) {
 	assert.EqualError(t, err, "cannot delete key [test-key]. Go to your aws account and do it manually")
 }
 
-func testImportRSAKeyOnKMS(t *testing.T, engine cryptoengines.CryptoEngine) {
-	key, err := chelpers.GenerateRSAKey(2048)
-	assert.NoError(t, err)
-
-	_, _, err = engine.ImportRSAPrivateKey(key)
-	assert.EqualError(t, err, "KMS does not support asymmetric key import")
-}
-
-func testImportECDSAKeyOnKMS(t *testing.T, engine cryptoengines.CryptoEngine) {
-	key, err := chelpers.GenerateECDSAKey(elliptic.P256())
-	assert.NoError(t, err)
-
-	_, _, err = engine.ImportECDSAPrivateKey(key)
-	assert.EqualError(t, err, "KMS does not support asymmetric key import")
-}
-
 func TestAWSKMSCryptoEngine(t *testing.T) {
 	cleanupBeforeTest, engine, err := prepareKMSCryptoEngine(t)
 	if err != nil {
@@ -99,10 +81,12 @@ func TestAWSKMSCryptoEngine(t *testing.T) {
 		// {"DeleteKey", cryptoengines.SharedTestDeleteKey},
 		{"GetPrivateKeyByID", cryptoengines.SharedGetKey},
 		{"GetPrivateKeyByIDNotFound", cryptoengines.SharedGetKeyNotFound},
-		{"ImportRSAKey", testImportRSAKeyOnKMS},
-		{"ImportECDSAKey", testImportECDSAKeyOnKMS},
 		{"ListPrivateKeyIDs", cryptoengines.SharedListKeys},
 		{"RenameKey", cryptoengines.SharedRenameKey},
+		//TODO: LocalStack Has some open issues regarding KMS Import keys. Follow issues:
+		// - https://github.com/localstack/localstack/issues/10921
+		// {"ImportRSAPrivateKey", cryptoengines.SharedTestImportRSAPrivateKey},
+		// {"ImportECDSAPrivateKey", cryptoengines.SharedTestImportECDSAPrivateKey},
 	}
 
 	for _, tt := range table {


### PR DESCRIPTION
This pull request introduces the capability to import RSA and ECDSA private keys into the AWS KMS crypto engine, alongside the necessary utilities for key wrapping and encryption. The changes include new methods for handling key imports, updates to the test suite, and the addition of cryptographic utilities to support these operations.

### Key Import Functionality Enhancements:

* Added `ImportRSAPrivateKey` and `ImportECDSAPrivateKey` methods to the `AWSKMSCryptoEngine` to enable importing RSA and ECDSA private keys. These methods create keys in AWS KMS, generate aliases, and securely import private key material using AES and RSA-OAEP encryption. (`engines/crypto/aws/awskms.go`)
* Introduced the `importPrivateKeyDer` method to handle the encryption and import of private key material into AWS KMS, utilizing AES key wrapping and RSA-OAEP encryption. (`engines/crypto/aws/awskms.go`)

### Cryptographic Utilities:

* Added `encryptWithRSAOAEP` for RSA-OAEP encryption and `wrapAESKeyWithPad` for AES key wrapping with padding, supporting secure key material import. (`engines/crypto/aws/awskms.go`)

### Testing Improvements:

* Added shared test helpers `SharedTestImportRSAPrivateKey` and `SharedTestImportECDSAPrivateKey` to validate the functionality of RSA and ECDSA key imports. (`core/pkg/engines/cryptoengines/cryptoengine_testset.go`)
* Updated the AWS KMS test suite to include placeholders for key import tests, with comments referencing unresolved LocalStack issues that prevent full integration testing. (`engines/crypto/aws/awskms_test.go`)

### Dependency Updates:

* Imported additional cryptographic packages (`crypto/aes`, `crypto/cipher`, `crypto/rand`, `crypto/sha256`, `encoding/binary`) to support AES and RSA-OAEP encryption. (`engines/crypto/aws/awskms.go`) 