### PR TITLE
feat: CA: refactor crypto engine keys migration

### DIFF
--- a/backend/pkg/assemblers/service-assembler_test.go
+++ b/backend/pkg/assemblers/service-assembler_test.go
@@ -228,9 +228,10 @@ func PrepareCryptoEnginesForTest(engines []CryptoEngine) *TestCryptoEngineConfig
 	afterSuiteActions := []func(){}
 
 	cryptoEngineConf := config.CryptoEngines{
-		LogLevel:      cconfig.Info,
-		DefaultEngine: "filesystem-1",
-		CryptoEngines: []cconfig.CryptoEngineConfig{},
+		LogLevel:          cconfig.Info,
+		DefaultEngine:     "filesystem-1",
+		MigrateKeysFormat: true,
+		CryptoEngines:     []cconfig.CryptoEngineConfig{},
 	}
 
 	fsid := fmt.Sprintf("/tmp/%s", uuid.NewString())

--- a/backend/pkg/config/ca.go
+++ b/backend/pkg/config/ca.go
@@ -15,7 +15,8 @@ type CAConfig struct {
 }
 
 type CryptoEngines struct {
-	LogLevel      cconfig.LogLevel             `mapstructure:"log_level"`
-	DefaultEngine string                       `mapstructure:"default_id"`
-	CryptoEngines []cconfig.CryptoEngineConfig `mapstructure:"engines"`
+	LogLevel          cconfig.LogLevel             `mapstructure:"log_level"`
+	DefaultEngine     string                       `mapstructure:"default_id"`
+	MigrateKeysFormat bool                         `mapstructure:"migrate_keys_format"`
+	CryptoEngines     []cconfig.CryptoEngineConfig `mapstructure:"engines"`
 }

--- a/backend/pkg/services/ca.go
+++ b/backend/pkg/services/ca.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"time"
-	"unicode"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/jakehl/goid"
@@ -18,7 +17,6 @@ import (
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/resources"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/services"
-	"github.com/lamassuiot/lamassuiot/engines/crypto/software/v3"
 	"github.com/sirupsen/logrus"
 
 	"golang.org/x/crypto/ocsp"
@@ -66,48 +64,6 @@ func NewCAService(builder CAServiceBuilder) (services.CAService, error) {
 		if engineInstance.Default {
 			defaultCryptoEngine = &engineInstance.Service
 			defaultCryptoEngineID = engineID
-		}
-
-		// Check if engine keys should be renamed
-		keyIDs, err := engineInstance.Service.ListPrivateKeyIDs()
-		if err != nil {
-			return nil, fmt.Errorf("could not list private keys for engine %s: %s", engineID, err)
-		}
-
-		keyMigLog := builder.Logger.WithField("engine", engineID)
-		softCrypto := software.NewSoftwareCryptoEngine(keyMigLog)
-		keyMigLog.Infof("checking engine keys format")
-
-		for _, keyID := range keyIDs {
-			// check if they are in V1 format (serial number).
-			// V2 format is the hex encoded SHA256 of the public key, a string of 64 characters
-			containsNonHex := false
-			for _, char := range keyID {
-				if !unicode.IsLetter(char) && !unicode.IsDigit(char) {
-					// Not a hex character. Exit loop
-					containsNonHex = true
-					break
-				}
-			}
-
-			if len(keyID) != 64 || containsNonHex {
-				// Transform to V2 format
-				key, err := engineInstance.Service.GetPrivateKeyByID(keyID)
-				if err != nil {
-					return nil, fmt.Errorf("could not get key %s: %w", keyID, err)
-				}
-
-				newKeyID, err := softCrypto.EncodePKIXPublicKeyDigest(key.Public())
-				if err != nil {
-					return nil, fmt.Errorf("could not encode public key digest: %w", err)
-				}
-
-				keyMigLog.Debugf("renaming key %s to %s", keyID, newKeyID)
-				err = engineInstance.Service.RenameKey(keyID, newKeyID)
-				if err != nil {
-					return nil, fmt.Errorf("could not rename key %s: %w", keyID, err)
-				}
-			}
 		}
 	}
 


### PR DESCRIPTION
This pull request refactors the V1 to V2 format keys migration process in the Crypto Engines to perform the action from the assembler `backend/pkg/assemblers/ca.go` and not from the service `backend/pkg/services/ca.go`. In addition, this action is conditioned to a new config attribute in `backend/pkg/config/ca.go` in order to give much more control to PKI administrators in situations where this migration should be done by an ad-hoc process.

### Refactoring:

- Moved the keys migration process from `backend/pkg/services/ca.go` to `backend/pkg/assemblers/ca.go`. [[1]](https://github.com/lamassuiot/lamassuiot/compare/feat/migrate_keys_optionally?expand=1#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9) [[2]](https://github.com/lamassuiot/lamassuiot/compare/feat/migrate_keys_optionally?expand=1#diff-b87f82107570fc7f691218a78e530d765a3d9469c0206a3acbf3fd9316ee690d).
- Extracted the keys migration process to a helper function in `backend/pkg/assemblers/ca.go`.

### Feature Enhancements:

- Added new property to CA service config in `backend/pkg/config/ca.go` to be able to specify if the migration should be done automatically by Lamassu or not.

This pull request adds the need to update the Helm Chart by introducing the new property in `charts/lamassu/templates/ca-configmap.yml` and `charts/lamassu/values.yaml`.
