### PR TITLE
Fix: ReEnroll - Add a check to validate the presence of a CommonName in the CSR

### DIFF
--- a/backend/pkg/services/dmsmanager.go
+++ b/backend/pkg/services/dmsmanager.go
@@ -567,6 +567,11 @@ func (svc DMSManagerServiceBackend) Reenroll(ctx context.Context, csr *x509.Cert
 
 	lFunc.Infof("starting reenrollment process for device")
 
+	if csr.Subject.CommonName == "" {
+		lFunc.Errorf("aborting reenrollment. No CommonName in CSR")
+		return nil, fmt.Errorf("no CommonName in CSR")
+	}
+
 	lFunc.Debugf("checking if DMS '%s' exists", aps)
 	dms, err := svc.service.GetDMSByID(ctx, services.GetDMSByIDInput{
 		ID: aps,
@@ -709,6 +714,7 @@ func (svc DMSManagerServiceBackend) Reenroll(ctx context.Context, csr *x509.Cert
 		switch err {
 		case errs.ErrDeviceNotFound:
 			lFunc.Debugf("device doesn't exist")
+			return nil, err
 		default:
 			lFunc.Errorf("could not get device: %s", err)
 			return nil, err


### PR DESCRIPTION
This pull request introduces error handling improvements in the `Reenroll` function of the `DMSManagerServiceBackend` to ensure proper validation and early exits in specific failure scenarios.

### Error handling improvements:

* Added a check to validate the presence of a `CommonName` in the CSR. If missing, the function logs an error and aborts the reenrollment process with an appropriate error message. (`backend/pkg/services/dmsmanager.go`, [backend/pkg/services/dmsmanager.goR570-R574](diffhunk://#diff-23d4c4af43f96397c134a3299f77ed31fc20dce780dda0b7f06c97af98e07533R570-R574))
* Updated the error handling for the `ErrDeviceNotFound` case to return the error immediately after logging a debug message, ensuring consistent behavior for this scenario. (`backend/pkg/services/dmsmanager.go`, [backend/pkg/services/dmsmanager.goR717](diffhunk://#diff-23d4c4af43f96397c134a3299f77ed31fc20dce780dda0b7f06c97af98e07533R717))

