### PR TITLE
Potential fix for code scanning alert no. 246: Clear-text logging of sensitive information

### DIFF
--- a/shared/http/pkg/utils/gindump/request.go
+++ b/shared/http/pkg/utils/gindump/request.go
@@ -13,8 +13,8 @@ import (
 )
 
 func DumpRequest(req *http.Request, showHeaders bool, showBody bool) string {
-	headerHiddenFields := make([]string, 0)
-	bodyHiddenFields := make([]string, 0)
+	headerHiddenFields := []string{"Authorization", "Cookie"}
+	bodyHiddenFields := []string{"password", "token"}
 
 	var strB strings.Builder
 


### PR DESCRIPTION
Potential fix for [https://github.com/lamassuiot/lamassuiot/security/code-scanning/246](https://github.com/lamassuiot/lamassuiot/security/code-scanning/246)

To fix the problem, we need to ensure that sensitive information is not logged in clear text. This can be achieved by obfuscating or omitting sensitive data from the logs. Specifically, we should modify the `DumpRequest` function to exclude or mask sensitive information in the request headers and body before logging it.

1. Modify the `DumpRequest` function in `shared/http/pkg/utils/gindump/request.go` to exclude or mask sensitive information.
2. Update the `RoundTrip` method in `shared/http/pkg/helpers/httpclientbuilder.go` to use the modified `DumpRequest` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
