### PR TITLE
Potential fix for code scanning alert no. 277: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main-release.yaml
+++ b/.github/workflows/main-release.yaml
@@ -1,5 +1,8 @@
 name: "Release Workflow: (create repo release, docker images and go packages)"
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:
@@ -224,6 +227,9 @@ jobs:
 
   build_docker_image:
     needs: [create_module_release, version_info]
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         service: [ca, devmanager, dmsmanager, va, alerts, aws-connector]


### PR DESCRIPTION
Potential fix for [https://github.com/lamassuiot/lamassuiot/security/code-scanning/277](https://github.com/lamassuiot/lamassuiot/security/code-scanning/277)

To fix the issue, we will add a `permissions` block to the root of the workflow file to define the minimal permissions required for all jobs. Additionally, we will add job-specific `permissions` blocks where necessary to grant additional permissions for specific tasks. For example:
- The `build_docker_image` job requires `contents: read` to fetch the repository code and `packages: write` to push Docker images to the GitHub Container Registry.
- Other jobs will be reviewed to ensure they have the least privileges required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
