### PR TITLE
fix: CA:  fix filtering CAs by CN

### DIFF
--- a/engines/storage/postgres/castore.go
+++ b/engines/storage/postgres/castore.go
@@ -10,6 +10,7 @@ import (
 )
 
 const caDBName = "ca_certificates"
+const caJoinCaCertificatesAndCertificates = "JOIN certificates ON ca_certificates.serial_number = certificates.serial_number"
 
 type PostgresCAStore struct {
 	db      *gorm.DB
@@ -34,26 +35,34 @@ func (db *PostgresCAStore) Count(ctx context.Context) (int, error) {
 
 func (db *PostgresCAStore) CountByEngine(ctx context.Context, engineID string) (int, error) {
 	return db.querier.Count(ctx, []gormExtraOps{
-		{query: "certificates.engine_id = ? ", additionalWhere: []any{engineID}, joins: []string{"JOIN certificates ON ca_certificates.serial_number = certificates.serial_number"}},
+		{query: "certificates.engine_id = ? ", additionalWhere: []any{engineID}, joins: []string{caJoinCaCertificatesAndCertificates}},
 	})
 }
 
 func (db *PostgresCAStore) CountByStatus(ctx context.Context, status models.CertificateStatus) (int, error) {
 	return db.querier.Count(ctx, []gormExtraOps{
-		{query: "certificates.status = ? ", additionalWhere: []any{status}, joins: []string{"JOIN certificates ON ca_certificates.serial_number = certificates.serial_number"}},
+		{query: "certificates.status = ? ", additionalWhere: []any{status}, joins: []string{caJoinCaCertificatesAndCertificates}},
 	})
 }
 
 func (db *PostgresCAStore) SelectByType(ctx context.Context, CAType models.CertificateType, req storage.StorageListRequest[models.CACertificate]) (string, error) {
 	opts := []gormExtraOps{
-		{query: "certificates.type = ? ", additionalWhere: []any{CAType}, joins: []string{"JOIN certificates ON ca_certificates.serial_number = certificates.serial_number"}},
+		{query: "certificates.type = ? ", additionalWhere: []any{CAType}, joins: []string{caJoinCaCertificatesAndCertificates}},
 	}
 	return db.querier.SelectAll(ctx, req.QueryParams, opts, req.ExhaustiveRun, req.ApplyFunc)
 }
 
 func (db *PostgresCAStore) SelectAll(ctx context.Context, req storage.StorageListRequest[models.CACertificate]) (string, error) {
-	opts := []gormExtraOps{
-		{joins: []string{"JOIN certificates ON ca_certificates.serial_number = certificates.serial_number"}},
+	opts := []gormExtraOps{}
+	if req.QueryParams != nil {
+		for _, filter := range req.QueryParams.Filters {
+			if filter.Field == "subject.common_name" {
+				opts = []gormExtraOps{
+					{joins: []string{caJoinCaCertificatesAndCertificates}},
+				}
+				break
+			}
+		}
 	}
 
 	return db.querier.SelectAll(ctx, req.QueryParams, opts, req.ExhaustiveRun, req.ApplyFunc)
@@ -61,7 +70,7 @@ func (db *PostgresCAStore) SelectAll(ctx context.Context, req storage.StorageLis
 
 func (db *PostgresCAStore) SelectByCommonName(ctx context.Context, commonName string, req storage.StorageListRequest[models.CACertificate]) (string, error) {
 	return db.querier.SelectAll(ctx, req.QueryParams, []gormExtraOps{
-		{query: "certificates.subject_common_name = ? ", additionalWhere: []any{commonName}, joins: []string{"JOIN certificates ON ca_certificates.serial_number = certificates.serial_number"}},
+		{query: "certificates.subject_common_name = ? ", additionalWhere: []any{commonName}, joins: []string{caJoinCaCertificatesAndCertificates}},
 	}, req.ExhaustiveRun, req.ApplyFunc)
 }
 
@@ -72,43 +81,51 @@ func (db *PostgresCAStore) SelectExistsBySerialNumber(ctx context.Context, seria
 
 func (db *PostgresCAStore) SelectByParentCA(ctx context.Context, parentCAID string, req storage.StorageListRequest[models.CACertificate]) (string, error) {
 	return db.querier.SelectAll(ctx, req.QueryParams, []gormExtraOps{
-		{query: "certificates.issuer_meta_id = ? AND id != ?", additionalWhere: []any{parentCAID, parentCAID}, joins: []string{"JOIN certificates ON ca_certificates.serial_number = certificates.serial_number"}},
+		{query: "certificates.issuer_meta_id = ? AND id != ?", additionalWhere: []any{parentCAID, parentCAID}, joins: []string{caJoinCaCertificatesAndCertificates}},
 	}, req.ExhaustiveRun, req.ApplyFunc)
 }
 
 func (db *PostgresCAStore) SelectBySubjectAndSubjectKeyID(ctx context.Context, sub models.Subject, skid string, req storage.StorageListRequest[models.CACertificate]) (string, error) {
 	return db.querier.SelectAll(ctx, req.QueryParams, []gormExtraOps{
-		{query: "certificates.subject_common_name = ? AND " +
-			"certificates.subject_organization = ? AND " +
-			"certificates.subject_organization_unit = ? AND " +
-			"certificates.subject_country = ? AND " +
-			"certificates.subject_state = ? AND " +
-			"certificates.subject_locality = ? AND " +
-			"subject_key_id = ?", additionalWhere: []any{sub.CommonName,
-			sub.Organization,
-			sub.OrganizationUnit,
-			sub.Country,
-			sub.State,
-			sub.Locality,
-			skid}, joins: []string{"JOIN certificates ON ca_certificates.serial_number = certificates.serial_number"}},
+		{
+			query: "certificates.subject_common_name = ? AND " +
+				"certificates.subject_organization = ? AND " +
+				"certificates.subject_organization_unit = ? AND " +
+				"certificates.subject_country = ? AND " +
+				"certificates.subject_state = ? AND " +
+				"certificates.subject_locality = ? AND " +
+				"subject_key_id = ?",
+			additionalWhere: []any{sub.CommonName,
+				sub.Organization,
+				sub.OrganizationUnit,
+				sub.Country,
+				sub.State,
+				sub.Locality,
+				skid},
+			joins: []string{caJoinCaCertificatesAndCertificates},
+		},
 	}, req.ExhaustiveRun, req.ApplyFunc)
 }
 
 func (db *PostgresCAStore) SelectByIssuerAndAuthorityKeyID(ctx context.Context, iss models.Subject, akid string, req storage.StorageListRequest[models.CACertificate]) (string, error) {
 	return db.querier.SelectAll(ctx, req.QueryParams, []gormExtraOps{
-		{query: "certificates.issuer_common_name = ? AND " +
-			"certificates.issuer_organization = ? AND " +
-			"certificates.issuer_organization_unit = ? AND " +
-			"certificates.issuer_country = ? AND " +
-			"certificates.issuer_state = ? AND " +
-			"certificates.issuer_locality = ? AND " +
-			"authority_key_id = ?", additionalWhere: []any{iss.CommonName,
-			iss.Organization,
-			iss.OrganizationUnit,
-			iss.Country,
-			iss.State,
-			iss.Locality,
-			akid}, joins: []string{"JOIN certificates ON ca_certificates.serial_number = certificates.serial_number"}},
+		{
+			query: "certificates.issuer_common_name = ? AND " +
+				"certificates.issuer_organization = ? AND " +
+				"certificates.issuer_organization_unit = ? AND " +
+				"certificates.issuer_country = ? AND " +
+				"certificates.issuer_state = ? AND " +
+				"certificates.issuer_locality = ? AND " +
+				"authority_key_id = ?",
+			additionalWhere: []any{iss.CommonName,
+				iss.Organization,
+				iss.OrganizationUnit,
+				iss.Country,
+				iss.State,
+				iss.Locality,
+				akid},
+			joins: []string{caJoinCaCertificatesAndCertificates},
+		},
 	}, req.ExhaustiveRun, req.ApplyFunc)
 }
 

--- a/engines/storage/postgres/castore.go
+++ b/engines/storage/postgres/castore.go
@@ -52,7 +52,11 @@ func (db *PostgresCAStore) SelectByType(ctx context.Context, CAType models.Certi
 }
 
 func (db *PostgresCAStore) SelectAll(ctx context.Context, req storage.StorageListRequest[models.CACertificate]) (string, error) {
-	return db.querier.SelectAll(ctx, req.QueryParams, []gormExtraOps{}, req.ExhaustiveRun, req.ApplyFunc)
+	opts := []gormExtraOps{
+		{joins: []string{"JOIN certificates ON ca_certificates.serial_number = certificates.serial_number"}},
+	}
+
+	return db.querier.SelectAll(ctx, req.QueryParams, opts, req.ExhaustiveRun, req.ApplyFunc)
 }
 
 func (db *PostgresCAStore) SelectByCommonName(ctx context.Context, commonName string, req storage.StorageListRequest[models.CACertificate]) (string, error) {


### PR DESCRIPTION
This pull request fixes the filtering of CAs by Common Name. To be able to filter by CN, **certificates** table has to be queried:

- `engines/storage/postgres/castore.go`: added a JOIN between **ca_certificates** and **certificates** tables in the query of the `SelectAll` method.

Fixes #253