### PR TITLE
fix: CA: discard aws reserved kms aliases

### DIFF
--- a/engines/crypto/aws/awskms.go
+++ b/engines/crypto/aws/awskms.go
@@ -150,6 +150,9 @@ func (p *AWSKMSCryptoEngine) ListPrivateKeyIDs() ([]string, error) {
 		}
 
 		for _, alias := range aliases.Aliases {
+			if strings.HasPrefix(*alias.AliasName, "alias/aws/") {
+				continue
+			}
 			aliasName := strings.Replace(*alias.AliasName, "alias/", "", -1)
 			keyIDs = append(keyIDs, aliasName)
 		}


### PR DESCRIPTION
This pull request fixes listing AWS reserved KMS key aliases.

- `engines/crypto/aws/awskms.go`: Added a condition to filter KMS keys starting with `alias/aws/` aliases.