### PR TITLE
feat: DMS Manager: add option to toggle CSR signature verification during Enrollment/Reenrollment

### DIFF
--- a/backend/pkg/assemblers/device-manager_test.go
+++ b/backend/pkg/assemblers/device-manager_test.go
@@ -466,6 +466,7 @@ func TestGetDevicesByDMS(t *testing.T) {
 					},
 					RegistrationMode:            models.JITP,
 					EnableReplaceableEnrollment: true,
+					VerifyCSRSignature:          true,
 				},
 				ReEnrollmentSettings: models.ReEnrollmentSettings{
 					AdditionalValidationCAs:     []string{},
@@ -789,6 +790,7 @@ func TestDecommissionDevice(t *testing.T) {
 					},
 					RegistrationMode:            models.JITP,
 					EnableReplaceableEnrollment: true,
+					VerifyCSRSignature:          true,
 				},
 				ReEnrollmentSettings: models.ReEnrollmentSettings{
 					AdditionalValidationCAs:     []string{},

--- a/backend/pkg/assemblers/dms-manager_events_test.go
+++ b/backend/pkg/assemblers/dms-manager_events_test.go
@@ -64,6 +64,7 @@ func TestBindIDEvent(t *testing.T) {
 					},
 					RegistrationMode:            models.JITP,
 					EnableReplaceableEnrollment: true,
+					VerifyCSRSignature:          true,
 				},
 				ReEnrollmentSettings: models.ReEnrollmentSettings{
 					AdditionalValidationCAs:     []string{},

--- a/backend/pkg/assemblers/dms-manager_test.go
+++ b/backend/pkg/assemblers/dms-manager_test.go
@@ -255,6 +255,7 @@ func TestESTEnroll(t *testing.T) {
 					},
 					RegistrationMode:            models.JITP,
 					EnableReplaceableEnrollment: true,
+					VerifyCSRSignature:          true,
 				},
 				ReEnrollmentSettings: models.ReEnrollmentSettings{
 					AdditionalValidationCAs:     []string{},
@@ -1705,6 +1706,7 @@ func TestESTGetCACerts(t *testing.T) {
 					},
 					RegistrationMode:            models.JITP,
 					EnableReplaceableEnrollment: true,
+					VerifyCSRSignature:          true,
 				},
 				ReEnrollmentSettings: models.ReEnrollmentSettings{
 					AdditionalValidationCAs:     []string{},
@@ -1929,6 +1931,7 @@ func TestESTServerKeyGen(t *testing.T) {
 					},
 					RegistrationMode:            models.JITP,
 					EnableReplaceableEnrollment: true,
+					VerifyCSRSignature:          true,
 				},
 				ReEnrollmentSettings: models.ReEnrollmentSettings{
 					AdditionalValidationCAs:     []string{},
@@ -2343,6 +2346,7 @@ func TestESTReEnroll(t *testing.T) {
 					},
 					RegistrationMode:            models.JITP,
 					EnableReplaceableEnrollment: true,
+					VerifyCSRSignature:          true,
 				},
 				ReEnrollmentSettings: models.ReEnrollmentSettings{
 					RevokeOnReEnrollment:        true,
@@ -2912,6 +2916,7 @@ func TestGetAllDMS(t *testing.T) {
 					},
 					RegistrationMode:            models.JITP,
 					EnableReplaceableEnrollment: true,
+					VerifyCSRSignature:          true,
 				},
 				ReEnrollmentSettings: models.ReEnrollmentSettings{
 					AdditionalValidationCAs:     []string{},

--- a/backend/pkg/services/dmsmanager.go
+++ b/backend/pkg/services/dmsmanager.go
@@ -453,7 +453,7 @@ func (svc DMSManagerServiceBackend) Enroll(ctx context.Context, csr *x509.Certif
 	if enrollSettings.VerifyCSRSignature {
 		err = checkCSRSignature(lFunc, csr, "enrollment")
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("invalid CSR signature")
 		}
 	} else {
 		lFunc.Warn("DMS is configured with no CSR signature verification, allowing enrollment")
@@ -814,7 +814,7 @@ func (svc DMSManagerServiceBackend) Reenroll(ctx context.Context, csr *x509.Cert
 	if enrollSettings.VerifyCSRSignature {
 		err = checkCSRSignature(lFunc, csr, "reenrollment")
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("invalid CSR signature")
 		}
 	} else {
 		lFunc.Warn("DMS is configured with no CSR signature verification, allowing reenrollment")

--- a/backend/pkg/services/dmsmanager.go
+++ b/backend/pkg/services/dmsmanager.go
@@ -295,12 +295,14 @@ func (svc DMSManagerServiceBackend) Enroll(ctx context.Context, csr *x509.Certif
 	}
 
 	lFunc = lFunc.WithField("dms", dms.ID)
-	if dms.Settings.EnrollmentSettings.EnrollmentProtocol != models.EST {
+	enrollSettings := dms.Settings.EnrollmentSettings
+
+	if enrollSettings.EnrollmentProtocol != models.EST {
 		lFunc.Errorf("aborting enrollment. DMS doesn't support EST Protocol")
 		return nil, errs.ErrDMSOnlyEST
 	}
 
-	estAuthOptions := dms.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030
+	estAuthOptions := enrollSettings.EnrollmentOptionsESTRFC7030
 
 	lFunc = lFunc.WithField("step", "Authenticating")
 	lFunc.Infof("starting authentication process")
@@ -320,11 +322,11 @@ func (svc DMSManagerServiceBackend) Enroll(ctx context.Context, csr *x509.Certif
 		//check if certificate is a certificate issued by bootstrap CA
 		validCertificate := false
 		var validationCA *models.CACertificate
-		estEnrollOpts := dms.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030
+		estEnrollOpts := enrollSettings.EnrollmentOptionsESTRFC7030
 
 		// Allow enrolment with expired certificates
 		allowExpiredEnroll := false
-		if dms.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthOptionsMTLS.AllowExpired {
+		if enrollSettings.EnrollmentOptionsESTRFC7030.AuthOptionsMTLS.AllowExpired {
 			lFunc.Warnf("enrollment with expired certificates is allowed by DMS")
 			allowExpiredEnroll = true
 		} else {
@@ -447,6 +449,16 @@ func (svc DMSManagerServiceBackend) Enroll(ctx context.Context, csr *x509.Certif
 		lFunc.Errorf("aborting enrollment. DMS is not correctly configured. No auth method configured. Specify an authentication method")
 	}
 
+	lFunc = lFunc.WithField("step", "CSRCheck")
+	if enrollSettings.VerifyCSRSignature {
+		err = checkCSRSignature(lFunc, csr, "enrollment")
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		lFunc.Warn("DMS is configured with no CSR signature verification, allowing enrollment")
+	}
+
 	lFunc.Infof("authentication process completed successfully")
 	lFunc = lFunc.WithField("step", "DeviceReg")
 
@@ -469,7 +481,7 @@ func (svc DMSManagerServiceBackend) Enroll(ctx context.Context, csr *x509.Certif
 			return nil, fmt.Errorf("device already registered to another DMS")
 		}
 
-		if dms.Settings.EnrollmentSettings.EnableReplaceableEnrollment {
+		if enrollSettings.EnableReplaceableEnrollment {
 			lFunc.Debugf("DMS allows new enrollments. Continuing enrollment for device '%s'", csr.Subject.CommonName)
 			//revoke active certificate
 			defer func() {
@@ -497,17 +509,17 @@ func (svc DMSManagerServiceBackend) Enroll(ctx context.Context, csr *x509.Certif
 		}
 	}
 
-	if dms.Settings.EnrollmentSettings.RegistrationMode == models.JITP {
+	if enrollSettings.RegistrationMode == models.JITP {
 		if device == nil {
 			lFunc.Debugf("DMS is configured with JustInTime registration. will create device with ID %s", csr.Subject.CommonName)
 			//contact device manager and register device first
 			device, err = svc.deviceManagerCli.CreateDevice(ctx, services.CreateDeviceInput{
 				ID:        csr.Subject.CommonName,
 				Alias:     csr.Subject.CommonName,
-				Tags:      dms.Settings.EnrollmentSettings.DeviceProvisionProfile.Tags,
-				Metadata:  dms.Settings.EnrollmentSettings.DeviceProvisionProfile.Metadata,
-				Icon:      dms.Settings.EnrollmentSettings.DeviceProvisionProfile.Icon,
-				IconColor: dms.Settings.EnrollmentSettings.DeviceProvisionProfile.IconColor,
+				Tags:      enrollSettings.DeviceProvisionProfile.Tags,
+				Metadata:  enrollSettings.DeviceProvisionProfile.Metadata,
+				Icon:      enrollSettings.DeviceProvisionProfile.Icon,
+				IconColor: enrollSettings.DeviceProvisionProfile.IconColor,
 				DMSID:     dms.ID,
 			})
 			if err != nil {
@@ -529,7 +541,7 @@ func (svc DMSManagerServiceBackend) Enroll(ctx context.Context, csr *x509.Certif
 	lFunc = lFunc.WithField("step", "Signature")
 	lFunc.Infof("starting signature process")
 
-	enrollCAID := dms.Settings.EnrollmentSettings.EnrollmentCA
+	enrollCAID := enrollSettings.EnrollmentCA
 	enrollCA, err := svc.caClient.GetCAByID(ctx, services.GetCAByIDInput{
 		CAID: enrollCAID,
 	})
@@ -540,7 +552,7 @@ func (svc DMSManagerServiceBackend) Enroll(ctx context.Context, csr *x509.Certif
 
 	lFunc.Infof("requesting certificate signature")
 	crt, err := svc.caClient.SignCertificate(ctx, services.SignCertificateInput{
-		CAID:        dms.Settings.EnrollmentSettings.EnrollmentCA,
+		CAID:        enrollSettings.EnrollmentCA,
 		CertRequest: (*models.X509CertificateRequest)(csr),
 		IssuanceProfile: models.IssuanceProfile{
 			Validity: enrollCA.Validity,
@@ -554,7 +566,7 @@ func (svc DMSManagerServiceBackend) Enroll(ctx context.Context, csr *x509.Certif
 		},
 	})
 	if err != nil {
-		lFunc.Errorf("could issue certificate for device: %s", err)
+		lFunc.Errorf("could not issue certificate for device: %s", err)
 		return nil, err
 	}
 
@@ -610,12 +622,13 @@ func (svc DMSManagerServiceBackend) Reenroll(ctx context.Context, csr *x509.Cert
 		return nil, errs.ErrDMSNotFound
 	}
 
-	if dms.Settings.EnrollmentSettings.EnrollmentProtocol != models.EST {
+	enrollSettings := dms.Settings.EnrollmentSettings
+	if enrollSettings.EnrollmentProtocol != models.EST {
 		lFunc.Errorf("aborting reenrollment. DMS doesn't support EST Protocol")
 		return nil, errs.ErrDMSOnlyEST
 	}
 
-	enrollCAID := dms.Settings.EnrollmentSettings.EnrollmentCA
+	enrollCAID := enrollSettings.EnrollmentCA
 	enrollCA, err := svc.caClient.GetCAByID(ctx, services.GetCAByIDInput{
 		CAID: enrollCAID,
 	})
@@ -624,7 +637,9 @@ func (svc DMSManagerServiceBackend) Reenroll(ctx context.Context, csr *x509.Cert
 		return nil, err
 	}
 
-	if dms.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthMode == models.ESTAuthMode(identityextractors.IdentityExtractorClientCertificate) {
+	reEnrollSettings := dms.Settings.ReEnrollmentSettings
+
+	if enrollSettings.EnrollmentOptionsESTRFC7030.AuthMode == models.ESTAuthMode(identityextractors.IdentityExtractorClientCertificate) {
 		lFunc = lFunc.WithField("auth-method", identityextractors.IdentityExtractorClientCertificate)
 		clientCert, hasValue := ctx.Value(string(identityextractors.IdentityExtractorClientCertificate)).(*x509.Certificate)
 		if !hasValue {
@@ -652,13 +667,13 @@ func (svc DMSManagerServiceBackend) Reenroll(ctx context.Context, csr *x509.Cert
 
 		//try secondary validation with additional CAs
 		if !validCertificate {
-			estReEnrollOpts := dms.Settings.ReEnrollmentSettings
-			aValCAsCtr := len(estReEnrollOpts.AdditionalValidationCAs)
+
+			aValCAsCtr := len(reEnrollSettings.AdditionalValidationCAs)
 			lFunc.Debugf("could not validate client certificate using enroll CA. Will try validating using Additional Validation CAs")
 			lFunc.Debugf("DMS has %d additional validation CAs", aValCAsCtr)
 
 			//check if certificate is a certificate issued by Extra Val CAs
-			for idx, caID := range estReEnrollOpts.AdditionalValidationCAs {
+			for idx, caID := range reEnrollSettings.AdditionalValidationCAs {
 				lFunc.Debugf("[%d/%d] obtainig validation with ID %s", idx, aValCAsCtr, caID)
 				ca, err := svc.caClient.GetCAByID(ctx, services.GetCAByIDInput{CAID: caID})
 				if err != nil {
@@ -689,7 +704,7 @@ func (svc DMSManagerServiceBackend) Reenroll(ctx context.Context, csr *x509.Cert
 			return nil, errs.ErrDMSEnrollInvalidCert
 		}
 
-		if dms.Settings.ReEnrollmentSettings.EnableExpiredRenewal {
+		if reEnrollSettings.EnableExpiredRenewal {
 			lFunc.Warnf("DMS configured to allow reenrollment with expired certificates")
 		} else {
 			lFunc.Info("DMS configured to NOT allow reenrollment with expired certificates")
@@ -698,7 +713,7 @@ func (svc DMSManagerServiceBackend) Reenroll(ctx context.Context, csr *x509.Cert
 		//Check if EXPIRED
 		now := time.Now()
 		if now.After(clientCert.NotAfter) {
-			if dms.Settings.ReEnrollmentSettings.EnableExpiredRenewal {
+			if reEnrollSettings.EnableExpiredRenewal {
 				lFunc.Warnf("presented an expired certificate: %s", now.Sub(clientCert.NotBefore))
 			} else {
 				lFunc = lFunc.WithField("auth-status", "failed")
@@ -796,6 +811,15 @@ func (svc DMSManagerServiceBackend) Reenroll(ctx context.Context, csr *x509.Cert
 
 	}
 
+	if enrollSettings.VerifyCSRSignature {
+		err = checkCSRSignature(lFunc, csr, "reenrollment")
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		lFunc.Warn("DMS is configured with no CSR signature verification, allowing reenrollment")
+	}
+
 	now := time.Now()
 	lFunc.Debugf("checking if DMS allows enrollment at current delta for device %s", device.ID)
 
@@ -804,7 +828,7 @@ func (svc DMSManagerServiceBackend) Reenroll(ctx context.Context, csr *x509.Cert
 		"current device certificate expires at %s (%s duration). DMS allows reenrolling %s. Reenroll window opens %s. (delta=%s)",
 		currentDeviceCert.Certificate.NotAfter.UTC().Format("2006-01-02T15:04:05Z07:00"),
 		models.TimeDuration(currentDeviceCert.Certificate.NotAfter.Sub(now)).String(),
-		dms.Settings.ReEnrollmentSettings.ReEnrollmentDelta.String(),
+		reEnrollSettings.ReEnrollmentDelta.String(),
 		comparisonTimeThreshold.UTC().Format("2006-01-02T15:04:05Z07:00"),
 		models.TimeDuration(now.Sub(comparisonTimeThreshold)).String(),
 	)
@@ -822,7 +846,7 @@ func (svc DMSManagerServiceBackend) Reenroll(ctx context.Context, csr *x509.Cert
 	}
 
 	crt, err := svc.caClient.SignCertificate(ctx, services.SignCertificateInput{
-		CAID:        dms.Settings.EnrollmentSettings.EnrollmentCA,
+		CAID:        enrollSettings.EnrollmentCA,
 		CertRequest: (*models.X509CertificateRequest)(csr),
 		IssuanceProfile: models.IssuanceProfile{
 			Validity: enrollCA.Validity,
@@ -855,7 +879,7 @@ func (svc DMSManagerServiceBackend) Reenroll(ctx context.Context, csr *x509.Cert
 
 	//revoke superseded cert if active. Don't try revoking expired or already revoked since is not a valid transition for the CA service.
 	if currentDeviceCert.Status == models.StatusActive {
-		if dms.Settings.ReEnrollmentSettings.RevokeOnReEnrollment {
+		if reEnrollSettings.RevokeOnReEnrollment {
 			lFunc.Infof("revoking superseded certificate %s", currentDeviceCertSN)
 			_, err = svc.caClient.UpdateCertificateStatus(ctx, services.UpdateCertificateStatusInput{
 				SerialNumber:     currentDeviceCertSN,
@@ -881,6 +905,18 @@ func (svc DMSManagerServiceBackend) Reenroll(ctx context.Context, csr *x509.Cert
 	}
 
 	return (*x509.Certificate)(crt.Certificate), nil
+}
+
+func checkCSRSignature(lFunc *logrus.Entry, csr *x509.CertificateRequest, operation string) error {
+
+	lFunc.Info("checking CSR signature")
+	if err := csr.CheckSignature(); err != nil {
+		lFunc.Errorf("aborting %s. Invalid CSR signature: %v", operation, err)
+		return err
+	}
+	lFunc.Info("Valid CSR signature")
+
+	return nil
 }
 
 func (svc DMSManagerServiceBackend) ServerKeyGen(ctx context.Context, csr *x509.CertificateRequest, aps string) (*x509.Certificate, any, error) {

--- a/backend/pkg/services/dmsmanager.go
+++ b/backend/pkg/services/dmsmanager.go
@@ -674,7 +674,7 @@ func (svc DMSManagerServiceBackend) Reenroll(ctx context.Context, csr *x509.Cert
 
 			//check if certificate is a certificate issued by Extra Val CAs
 			for idx, caID := range reEnrollSettings.AdditionalValidationCAs {
-				lFunc.Debugf("[%d/%d] obtainig validation with ID %s", idx, aValCAsCtr, caID)
+				lFunc.Debugf("[%d/%d] obtaining validation with ID %s", idx, aValCAsCtr, caID)
 				ca, err := svc.caClient.GetCAByID(ctx, services.GetCAByIDInput{CAID: caID})
 				if err != nil {
 					lFunc.Warnf("[%d/%d] could not obtain lamassu CA with ID %s. Skipping to next validation CA: %s", idx, aValCAsCtr, caID, err)

--- a/backend/pkg/test/e2e/usecase-1.go
+++ b/backend/pkg/test/e2e/usecase-1.go
@@ -216,6 +216,7 @@ func RunUseCase1(input UseCase1Input) error {
 				EnrollmentCA:                ca1.ID,
 				RegistrationMode:            models.JITP,
 				EnableReplaceableEnrollment: true,
+				VerifyCSRSignature:          true,
 			},
 			ReEnrollmentSettings: models.ReEnrollmentSettings{
 				AdditionalValidationCAs:     []string{},

--- a/core/pkg/models/dms.go
+++ b/core/pkg/models/dms.go
@@ -65,6 +65,7 @@ type EnrollmentSettings struct {
 	EnrollmentCA                string                      `json:"enrollment_ca"`
 	EnableReplaceableEnrollment bool                        `json:"enable_replaceable_enrollment"` //switch-like option that enables enrolling, already enrolled devices
 	RegistrationMode            RegistrationMode            `json:"registration_mode"`
+	VerifyCSRSignature          bool                        `json:"verify_csr_signature"` //switch-like option that enables CSR signature verification
 }
 
 type EnrollmentOptionsESTRFC7030 struct {

--- a/engines/storage/postgres/migrations/dmsmanager/20250612100530_est_verify_csr_signature.go
+++ b/engines/storage/postgres/migrations/dmsmanager/20250612100530_est_verify_csr_signature.go
@@ -1,0 +1,64 @@
+package dmsmanager
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	mhelper "github.com/lamassuiot/lamassuiot/engines/storage/postgres/v3/migrations/helpers"
+	"github.com/pressly/goose/v3"
+)
+
+func Register20250612100530ESTVerifyCSRSignature() {
+	goose.AddMigrationContext(upDms, downDms)
+}
+
+func upDms(ctx context.Context, tx *sql.Tx) error {
+	// This code is executed when the migration is applied.
+	rows, err := tx.QueryContext(ctx, "SELECT * FROM dms")
+	if err != nil {
+		return err
+	}
+
+	result, err := mhelper.RowsToMap(rows)
+	if err != nil {
+		return err
+	}
+
+	for _, r := range result {
+		settings := r["settings"].(string)
+
+		// Unmarshal the JSON into a map
+		var config map[string]any
+		if err := json.Unmarshal([]byte(settings), &config); err != nil {
+			return fmt.Errorf("failed to unmarshal JSON: %v", err)
+		}
+
+		// set enrollment_settings.verify_csr_signature to false
+		if _, ok := config["enrollment_settings"].(map[string]any); ok {
+			config["enrollment_settings"].(map[string]any)["verify_csr_signature"] = false
+		} else {
+			return fmt.Errorf("enrollment_settings not found")
+		}
+
+		// Marshal the map back into JSON
+		newSettings, err := json.Marshal(config)
+		if err != nil {
+			return fmt.Errorf("failed to marshal JSON: %v", err)
+		}
+
+		// Update the row
+		_, err = tx.ExecContext(ctx, "UPDATE dms SET settings = $1 WHERE id = $2", string(newSettings), r["id"])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func downDms(ctx context.Context, tx *sql.Tx) error {
+	// This code is executed when the migration is rolled back.
+	return nil
+}

--- a/engines/storage/postgres/migrations/dmsmanager/20250612100530_est_verify_csr_signature.go
+++ b/engines/storage/postgres/migrations/dmsmanager/20250612100530_est_verify_csr_signature.go
@@ -36,8 +36,9 @@ func upDms(ctx context.Context, tx *sql.Tx) error {
 		}
 
 		// set enrollment_settings.verify_csr_signature to false
-		if _, ok := config["enrollment_settings"].(map[string]any); ok {
-			config["enrollment_settings"].(map[string]any)["verify_csr_signature"] = false
+		enrollmentSettings, ok := config["enrollment_settings"].(map[string]any)
+		if ok {
+			enrollmentSettings["verify_csr_signature"] = false
 		} else {
 			return fmt.Errorf("enrollment_settings not found")
 		}

--- a/engines/storage/postgres/migrations/gomigrations.go
+++ b/engines/storage/postgres/migrations/gomigrations.go
@@ -13,5 +13,6 @@ func RegisterGoMigrations(dbname string) {
 		ca.Register20250226114600CaAddKids()
 	case "dmsmanager":
 		dmsmanager.Register20241230124809ServerkeygenRevokereenroll()
+		dmsmanager.Register20250612100530ESTVerifyCSRSignature()
 	}
 }


### PR DESCRIPTION
This pull request introduces support for verifying **CSR** (Certificate Signing Request) signatures during device **enrollment/reenrollment** in the **DMS** (Device Management Service) and adds corresponding database migration and tests. This update ensures that the DMS supports CSR signature verification as a configurable option, with robust migration and test coverage.

Closes #248 

### Database Migration
- Adds a new migration that introduces the `verify_csr_signature `field to the `enrollment_settings` JSON object in the DMS table.
- The new field defaults to `false` for existing records.

### Migration Tests
- Adds and updates migration tests to ensure the new `verify_csr_signature` field is correctly added and defaults to `false`.

### General Improvements
- Refactors and cleans up migration test code for maintainability.
- Ensures all migrations are tested in sequence for proper upgrade paths.