### PR TITLE
feat: add case-insensitive filtering support

### DIFF
--- a/backend/pkg/controllers/utils.go
+++ b/backend/pkg/controllers/utils.go
@@ -71,16 +71,28 @@ func FilterQuery(r *http.Request, filterFieldMap map[string]resources.FilterFiel
 							switch operand {
 							case "eq", "equal":
 								filterOperand = resources.StringEqual
+							case "eq_ic", "equal_ignorecase":
+								filterOperand = resources.StringEqualIgnoreCase
 							case "ne", "notequal":
 								filterOperand = resources.StringNotEqual
+							case "ne_ic", "notequal_ignorecase":
+								filterOperand = resources.StringNotEqualIgnoreCase
 							case "ct", "contains":
 								filterOperand = resources.StringContains
+							case "ct_ic", "contains_ignorecase":
+								filterOperand = resources.StringContainsIgnoreCase
 							case "nc", "notcontains":
 								filterOperand = resources.StringNotContains
+							case "nc_ic", "notcontains_ignorecase":
+								filterOperand = resources.StringNotContainsIgnoreCase
 							}
 
 						case resources.StringArrayFilterFieldType:
-							filterOperand = resources.StringArrayContains
+							if strings.Contains(operand, "ignorecase") {
+								filterOperand = resources.StringArrayContainsIgnoreCase
+							} else {
+								filterOperand = resources.StringArrayContains
+							}
 
 						case resources.DateFilterFieldType:
 							switch operand {

--- a/core/pkg/resources/query.go
+++ b/core/pkg/resources/query.go
@@ -51,11 +51,16 @@ const (
 	UnspecifiedFilter FilterOperation = iota
 
 	StringEqual
+	StringEqualIgnoreCase
 	StringNotEqual
+	StringNotEqualIgnoreCase
 	StringContains
+	StringContainsIgnoreCase
 	StringNotContains
+	StringNotContainsIgnoreCase
 
 	StringArrayContains
+	StringArrayContainsIgnoreCase
 
 	DateEqual
 	DateBefore

--- a/engines/storage/postgres/utils.go
+++ b/engines/storage/postgres/utils.go
@@ -426,15 +426,26 @@ func FilterOperandToWhereClause(filter resources.FilterOption, tx *gorm.DB) *gor
 	switch filter.FilterOperation {
 	case resources.StringEqual:
 		return tx.Where(fmt.Sprintf("%s = ?", filter.Field), filter.Value)
+	case resources.StringEqualIgnoreCase:
+		return tx.Where(fmt.Sprintf("%s ILIKE ?", filter.Field), filter.Value)
 	case resources.StringNotEqual:
 		return tx.Where(fmt.Sprintf("%s <> ?", filter.Field), filter.Value)
+	case resources.StringNotEqualIgnoreCase:
+		return tx.Where(fmt.Sprintf("%s NOT ILIKE ?", filter.Field), filter.Value)
 	case resources.StringContains:
 		return tx.Where(fmt.Sprintf("%s LIKE ?", filter.Field), fmt.Sprintf("%%%s%%", filter.Value))
+	case resources.StringContainsIgnoreCase:
+		return tx.Where(fmt.Sprintf("%s ILIKE ?", filter.Field), fmt.Sprintf("%%%s%%", filter.Value))
 	case resources.StringArrayContains:
 		// return tx.Where(fmt.Sprintf("? = ANY(%s)", filter.Field), filter.Value)
 		return tx.Where(fmt.Sprintf("%s LIKE ?", filter.Field), fmt.Sprintf("%%%s%%", filter.Value))
+	case resources.StringArrayContainsIgnoreCase:
+		// return tx.Where(fmt.Sprintf("? = ANY(%s)", filter.Field), filter.Value)
+		return tx.Where(fmt.Sprintf("%s ILIKE ?", filter.Field), fmt.Sprintf("%%%s%%", filter.Value))
 	case resources.StringNotContains:
 		return tx.Where(fmt.Sprintf("%s NOT LIKE ?", filter.Field), fmt.Sprintf("%%%s%%", filter.Value))
+	case resources.StringNotContainsIgnoreCase:
+		return tx.Where(fmt.Sprintf("%s NOT ILIKE ?", filter.Field), fmt.Sprintf("%%%s%%", filter.Value))
 	case resources.DateEqual:
 		return tx.Where(fmt.Sprintf("%s = ?", filter.Field), filter.Value)
 	case resources.DateBefore:


### PR DESCRIPTION
This pull request introduces **case-insensitive** filtering support for queries in the backend. The main goal is to ensure that filter operations on string fields (such as ID, CN or tags) ignore case, providing a more user-friendly and predictable search experience.

This update improves the usability of filtering features by making them case-insensitive, ensuring consistent results for users regardless of input casing.

### Case-Insensitive Filtering
- Updates query logic to perform case-insensitive comparisons when applying filters to string fields.
- Ensures that filters on IDs, Common Names, tags, and other relevant fields match regardless of letter casing.

Closes #269 


