### PR TITLE
feat: refactor by adding InitCRLRole method to CRLService and its implementations

### DIFF
--- a/backend/pkg/middlewares/eventpub/crl.go
+++ b/backend/pkg/middlewares/eventpub/crl.go
@@ -52,3 +52,7 @@ func (mw *clrEventPublisher) CalculateCRL(ctx context.Context, input services.Ca
 	}()
 	return mw.next.CalculateCRL(ctx, input)
 }
+
+func (mw *clrEventPublisher) InitCRLRole(ctx context.Context, caSki string) (output *models.VARole, err error) {
+	return mw.next.InitCRLRole(ctx, caSki)
+}

--- a/backend/pkg/services/handlers/va-handlers.go
+++ b/backend/pkg/services/handlers/va-handlers.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/cloudevents/sdk-go/v2/event"
 	"github.com/lamassuiot/lamassuiot/backend/v3/pkg/helpers"
-	beService "github.com/lamassuiot/lamassuiot/backend/v3/pkg/services"
 	chelpers "github.com/lamassuiot/lamassuiot/core/v3/pkg/helpers"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/services"
@@ -14,7 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func NewVAEventHandler(l *logrus.Entry, crlSvc *beService.CRLServiceBackend) *eventhandling.CloudEventHandler {
+func NewVAEventHandler(l *logrus.Entry, crlSvc services.CRLService) *eventhandling.CloudEventHandler {
 	return &eventhandling.CloudEventHandler{
 		Logger: l,
 		DispatchMap: map[string]func(*event.Event) error{
@@ -24,7 +23,7 @@ func NewVAEventHandler(l *logrus.Entry, crlSvc *beService.CRLServiceBackend) *ev
 	}
 }
 
-func createCAHandler(event *event.Event, crlSvc *beService.CRLServiceBackend, lMessaging *logrus.Entry) error {
+func createCAHandler(event *event.Event, crlSvc services.CRLService, lMessaging *logrus.Entry) error {
 	ctx := context.Background()
 
 	ca, err := chelpers.GetEventBody[models.CACertificate](event)
@@ -46,7 +45,7 @@ func createCAHandler(event *event.Event, crlSvc *beService.CRLServiceBackend, lM
 	return nil
 }
 
-func updateCertificateStatus(event *event.Event, crlSvc *beService.CRLServiceBackend, lMessaging *logrus.Entry) error {
+func updateCertificateStatus(event *event.Event, crlSvc services.CRLService, lMessaging *logrus.Entry) error {
 	ctx := context.Background()
 
 	cert, err := chelpers.GetEventBody[models.UpdateModel[models.Certificate]](event)

--- a/core/pkg/services/crl.go
+++ b/core/pkg/services/crl.go
@@ -15,6 +15,7 @@ type CRLService interface {
 	GetVARole(ctx context.Context, input GetVARoleInput) (*models.VARole, error)
 	GetVARoles(ctx context.Context, input GetVARolesInput) (string, error)
 	UpdateVARole(ctx context.Context, input UpdateVARoleInput) (*models.VARole, error)
+	InitCRLRole(ctx context.Context, caSki string) (*models.VARole, error)
 }
 
 type GetCRLInput struct {

--- a/core/pkg/services/mock/crl_mock.go
+++ b/core/pkg/services/mock/crl_mock.go
@@ -46,3 +46,8 @@ func (m *MockVAService) UpdateVARole(ctx context.Context, input services.UpdateV
 	args := m.Called(ctx, input)
 	return args.Get(0).(*models.VARole), args.Error(1)
 }
+
+func (m *MockVAService) InitCRLRole(ctx context.Context, caSki string) (*models.VARole, error) {
+	args := m.Called(ctx, caSki)
+	return args.Get(0).(*models.VARole), args.Error(1)
+}


### PR DESCRIPTION
This pull request introduces a new method, `InitCRLRole`, to the CRL service and updates the codebase to integrate this method. Additionally, it refactors type references for better consistency and updates the mock service to support the new functionality.

This allows to use the interface and not the underlying implementation in the va-handlers.

### New functionality:
* Added the `InitCRLRole` method to the `CRLService` interface in `core/pkg/services/crl.go`, allowing initialization of CRL roles based on a CA SKI.
* Implemented the `InitCRLRole` method in the `clrEventPublisher` middleware in `backend/pkg/middlewares/eventpub/crl.go`.

### Refactoring and integration:
* Updated type references in `backend/pkg/services/handlers/va-handlers.go` to replace `CRLServiceBackend` with `CRLService` for consistency and alignment with the core package. [[1]](diffhunk://#diff-9ce3e6346b9ee4ca7958c42d6a80b19925b4e35fb2aff1c8d5847a697bbaa8d2L9-R17) [[2]](diffhunk://#diff-9ce3e6346b9ee4ca7958c42d6a80b19925b4e35fb2aff1c8d5847a697bbaa8d2L27-R27) [[3]](diffhunk://#diff-9ce3e6346b9ee4ca7958c42d6a80b19925b4e35fb2aff1c8d5847a697bbaa8d2L49-R49)

### Mock service updates:
* Added a mock implementation of the `InitCRLRole` method in `core/pkg/services/mock/crl_mock.go` for testing purposes.