### PR TITLE
fix: update bookmark encoding to use URL-safe base64 encoding

### DIFF
--- a/engines/storage/postgres/utils.go
+++ b/engines/storage/postgres/utils.go
@@ -240,14 +240,14 @@ func (db *postgresDBQuerier[E]) SelectAll(ctx context.Context, queryParams *reso
 
 		} else {
 			nextBookmark = ""
-			decodedBookmark, err := base64.StdEncoding.DecodeString(queryParams.NextBookmark)
+			decodedBookmark, err := base64.RawURLEncoding.DecodeString(queryParams.NextBookmark)
 			if err != nil {
 				return "", fmt.Errorf("not a valid bookmark")
 			}
 
-			splits := strings.Split(string(decodedBookmark), ";")
+			splits := strings.SplitSeq(string(decodedBookmark), ";")
 
-			for _, splitPart := range splits {
+			for splitPart := range splits {
 				queryPart := strings.Split(splitPart, ":")
 				switch queryPart[0] {
 				case "off":
@@ -358,7 +358,7 @@ func (db *postgresDBQuerier[E]) SelectAll(ctx context.Context, queryParams *reso
 			return "", nil
 		}
 
-		return base64.StdEncoding.EncodeToString([]byte(nextBookmark)), nil
+		return base64.RawURLEncoding.EncodeToString([]byte(nextBookmark)), nil
 	}
 }
 


### PR DESCRIPTION
This pull request updates the `SelectAll` function in `engines/storage/postgres/utils.go` to improve URL encoding and decoding for bookmarks and refines string splitting logic for better performance and clarity.

Changes related to bookmark encoding and decoding:

* Updated bookmark decoding to use `base64.URLEncoding` instead of `base64.StdEncoding` for compatibility with URL-safe encoding.
* Updated bookmark encoding to use `base64.URLEncoding` instead of `base64.StdEncoding` to ensure consistency with the decoding process.

Changes related to string splitting:

* Replaced `strings.Split` with `strings.SplitSeq` for handling bookmark splits, potentially improving performance and readability.