### PR TITLE
Fix: CRL Initialization on event

### DIFF
--- a/backend/pkg/services/crl.go
+++ b/backend/pkg/services/crl.go
@@ -149,7 +149,7 @@ func (svc CRLServiceBackend) InitCRLRole(ctx context.Context, caSki string) (*mo
 	}
 
 	_, err = svc.CalculateCRL(ctx, services.CalculateCRLInput{
-		CASubjectKeyID: string(ca.Certificate.Certificate.SubjectKeyId),
+		CASubjectKeyID: caSki,
 	})
 	if err != nil {
 		lFunc.Errorf("something went wrong while calculating first CRL: %s", err)

--- a/backend/pkg/services/handlers/va-handlers.go
+++ b/backend/pkg/services/handlers/va-handlers.go
@@ -38,6 +38,7 @@ func createCAHandler(event *event.Event, crlSvc services.CRLService, lMessaging 
 	if err != nil {
 		err = fmt.Errorf("could not initialize CRL role: %s", err)
 		lMessaging.Error(err)
+		return err
 	}
 
 	lMessaging.Infof("CRL role initialized for CA %s", ca.ID)

--- a/core/pkg/engines/eventbus/messaging.go
+++ b/core/pkg/engines/eventbus/messaging.go
@@ -31,8 +31,8 @@ func NewMessageRouter(logger *logrus.Entry) (*message.Router, error) {
 		// After MaxRetries, the message is Nacked and it's up to the PubSub to resend it.
 		middleware.Retry{
 			MaxRetries:      3,
-			InitialInterval: time.Second * 10,
-			MaxInterval:     time.Second * 30,
+			InitialInterval: time.Second * 2,
+			MaxInterval:     time.Second * 10,
 			Multiplier:      3,
 			Logger:          lEventBus,
 		}.Middleware,

--- a/core/pkg/resources/careq.go
+++ b/core/pkg/resources/careq.go
@@ -18,7 +18,7 @@ var CAFiltrableFields = map[string]FilterFieldType{
 	"revocation_timestamp": DateFilterFieldType,
 	"revocation_reason":    EnumFilterFieldType,
 	"subject.common_name":  StringFilterFieldType,
-	"key_id":               StringFilterFieldType,
+	"subject_key_id":       StringFilterFieldType,
 }
 
 var CARequestFiltrableFields = map[string]FilterFieldType{

--- a/engines/storage/postgres/castore.go
+++ b/engines/storage/postgres/castore.go
@@ -53,17 +53,19 @@ func (db *PostgresCAStore) SelectByType(ctx context.Context, CAType models.Certi
 }
 
 func (db *PostgresCAStore) SelectAll(ctx context.Context, req storage.StorageListRequest[models.CACertificate]) (string, error) {
-	opts := []gormExtraOps{}
-	if req.QueryParams != nil {
-		for _, filter := range req.QueryParams.Filters {
-			if filter.Field == "subject.common_name" {
-				opts = []gormExtraOps{
-					{joins: []string{caJoinCaCertificatesAndCertificates}},
-				}
-				break
-			}
-		}
+	opts := []gormExtraOps{
+		{joins: []string{caJoinCaCertificatesAndCertificates}},
 	}
+	// if req.QueryParams != nil {
+	// 	for _, filter := range req.QueryParams.Filters {
+	// 		if filter.Field == "subject.common_name" {
+	// 			opts = []gormExtraOps{
+	// 				{joins: []string{caJoinCaCertificatesAndCertificates}},
+	// 			}
+	// 			break
+	// 		}
+	// 	}
+	// }
 
 	return db.querier.SelectAll(ctx, req.QueryParams, opts, req.ExhaustiveRun, req.ApplyFunc)
 }

--- a/monolithic/cmd/development/main.go
+++ b/monolithic/cmd/development/main.go
@@ -264,7 +264,7 @@ func main() {
 			hc.AutoRemove = true
 		})
 
-		uiPort, _ = strconv.Atoi(container.GetPort("80/tcp"))
+		uiPort, _ = strconv.Atoi(container.GetPort("8080/tcp"))
 
 		uiCleanup = func() {
 			containerCleanup()

--- a/sdk/utils.go
+++ b/sdk/utils.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/config"
@@ -253,7 +255,7 @@ func Delete(ctx context.Context, client *http.Client, url string, knownErrors ma
 	return nil
 }
 
-func IterGet[E any, T resources.Iterator[E]](ctx context.Context, client *http.Client, url string, exhaustiveRun bool, queryParams *resources.QueryParameters, applyFunc func(E), knownErrors map[int][]error) (string, error) {
+func IterGet[E any, T resources.Iterator[E]](ctx context.Context, client *http.Client, urlQuery string, exhaustiveRun bool, queryParams *resources.QueryParameters, applyFunc func(E), knownErrors map[int][]error) (string, error) {
 	continueIter := true
 	if queryParams == nil {
 		queryParams = &resources.QueryParameters{}
@@ -263,8 +265,16 @@ func IterGet[E any, T resources.Iterator[E]](ctx context.Context, client *http.C
 		queryParams.NextBookmark = ""
 	}
 
+	u, err := url.Parse(urlQuery)
+	if err != nil {
+		return "", fmt.Errorf("could not parse URL %s: %w", urlQuery, err)
+	}
+
+	queryParamsValues := encodeQueryParams(queryParams)
+	u.RawQuery = queryParamsValues.Encode()
+
 	for continueIter {
-		response, err := Get[T](ctx, client, url, queryParams, knownErrors)
+		response, err := Get[T](ctx, client, u.String(), queryParams, knownErrors)
 		if err != nil {
 			return "", err
 		}
@@ -313,4 +323,79 @@ func nonOKResponseToError(resStatusCode int, resBody []byte, knownErrors map[int
 	}
 
 	return fmt.Errorf("unexpected status code %d. No expected error matching found: %s", resStatusCode, string(resBody))
+}
+
+func encodeQueryParams(queryParams *resources.QueryParameters) url.Values {
+	query := url.Values{}
+	if queryParams.NextBookmark != "" {
+		query.Add("bookmark", queryParams.NextBookmark)
+	}
+
+	if queryParams.Sort.SortField != "" {
+		query.Add("sort_by", queryParams.Sort.SortField)
+	}
+
+	if queryParams.Sort.SortMode != resources.SortModeAsc {
+		query.Add("sort_mode", "desc")
+	} else {
+		query.Add("sort_mode", "asc")
+	}
+
+	if queryParams.PageSize > 0 {
+		query.Add("page_size", strconv.Itoa(queryParams.PageSize))
+	}
+
+	for _, filter := range queryParams.Filters {
+		var op string
+		switch filter.FilterOperation {
+		case resources.StringEqual:
+			op = "eq"
+		case resources.StringEqualIgnoreCase:
+			op = "eq_ic"
+		case resources.StringNotEqual:
+			op = "ne"
+		case resources.StringNotEqualIgnoreCase:
+			op = "ne_ic"
+		case resources.StringContains:
+			op = "ct"
+		case resources.StringContainsIgnoreCase:
+			op = "ct_ic"
+		case resources.StringNotContains:
+			op = "nc"
+		case resources.StringNotContainsIgnoreCase:
+			op = "nc_ic"
+		case resources.StringArrayContains:
+			op = "ct"
+		case resources.StringArrayContainsIgnoreCase:
+			op = "ct_ic"
+		case resources.DateBefore:
+			op = "bf"
+		case resources.DateEqual:
+			op = "eq"
+		case resources.DateAfter:
+			op = "af"
+		case resources.NumberEqual:
+			op = "eq"
+		case resources.NumberNotEqual:
+			op = "ne"
+		case resources.NumberLessThan:
+			op = "lt"
+		case resources.NumberLessOrEqualThan:
+			op = "le"
+		case resources.NumberGreaterThan:
+			op = "gt"
+		case resources.NumberGreaterOrEqualThan:
+			op = "ge"
+		case resources.EnumEqual:
+			op = "eq"
+		case resources.EnumNotEqual:
+			op = "ne"
+		default:
+			continue // skip unsupported operations
+		}
+
+		query.Add("filter", filter.Field+"["+op+"]"+filter.Value)
+	}
+
+	return query
 }

--- a/sdk/utils.go
+++ b/sdk/utils.go
@@ -198,8 +198,11 @@ func Get[T any](ctx context.Context, client *http.Client, url string, queryParam
 		return m, err
 	}
 
-	queryParamsValues := encodeQueryParams(r.URL.Query(), queryParams)
-	r.URL.RawQuery = queryParamsValues.Encode()
+	if queryParams != nil {
+		queryParamsValues := encodeQueryParams(r.URL.Query(), queryParams)
+		r.URL.RawQuery = queryParamsValues.Encode()
+	}
+
 	// Important to set
 	r.Header.Add("Content-Type", "application/json")
 	res, err := client.Do(r)

--- a/sdk/utils.go
+++ b/sdk/utils.go
@@ -270,11 +270,12 @@ func IterGet[E any, T resources.Iterator[E]](ctx context.Context, client *http.C
 		return "", fmt.Errorf("could not parse URL %s: %w", urlQuery, err)
 	}
 
-	queryParamsValues := encodeQueryParams(queryParams)
+	queryParamsValues := encodeQueryParams(u.Query(), queryParams)
 	u.RawQuery = queryParamsValues.Encode()
+	urlString := u.String()
 
 	for continueIter {
-		response, err := Get[T](ctx, client, u.String(), queryParams, knownErrors)
+		response, err := Get[T](ctx, client, urlString, queryParams, knownErrors)
 		if err != nil {
 			return "", err
 		}
@@ -325,8 +326,7 @@ func nonOKResponseToError(resStatusCode int, resBody []byte, knownErrors map[int
 	return fmt.Errorf("unexpected status code %d. No expected error matching found: %s", resStatusCode, string(resBody))
 }
 
-func encodeQueryParams(queryParams *resources.QueryParameters) url.Values {
-	query := url.Values{}
+func encodeQueryParams(query url.Values, queryParams *resources.QueryParameters) url.Values {
 	if queryParams.NextBookmark != "" {
 		query.Add("bookmark", queryParams.NextBookmark)
 	}


### PR DESCRIPTION
This pull request introduces several changes across multiple files to improve functionality, enhance code readability, and fix issues. The most significant updates include modifications to query parameter handling, adjustments to retry intervals, and updates to filter field mappings.

### Query Parameter Handling:
* [`sdk/utils.go`](diffhunk://#diff-b430959ee0d3e59202d926089f0a27cac7b5a05d15fa6efee7bc1a9deb1e49a1L256-R258): Refactored the `IterGet` function to use `url.Parse` for safer URL handling and introduced the `encodeQueryParams` function to dynamically encode query parameters based on `resources.QueryParameters`. This improves the flexibility and reliability of query construction. [[1]](diffhunk://#diff-b430959ee0d3e59202d926089f0a27cac7b5a05d15fa6efee7bc1a9deb1e49a1L256-R258) [[2]](diffhunk://#diff-b430959ee0d3e59202d926089f0a27cac7b5a05d15fa6efee7bc1a9deb1e49a1R268-R277) [[3]](diffhunk://#diff-b430959ee0d3e59202d926089f0a27cac7b5a05d15fa6efee7bc1a9deb1e49a1R327-R401)

### Retry Interval Adjustments:
* [`core/pkg/engines/eventbus/messaging.go`](diffhunk://#diff-81e9b1a4692eb0f1d35d22c50e758c1fa11e4116e430b312e30c6fe3e2fe4aedL34-R35): Reduced the `InitialInterval` and `MaxInterval` for retries in the `Retry` middleware to optimize response time and reduce delays.

### Filter Field Updates:
* [`core/pkg/resources/careq.go`](diffhunk://#diff-7c550d5cf040571fb768e55125a263412c6fed735ca5c2c129e4d0c4dcb87951L21-R21): Renamed the `key_id` filter field to `subject_key_id` for consistency with the naming conventions used elsewhere in the codebase.

### Error Handling Improvements:
* [`backend/pkg/services/handlers/va-handlers.go`](diffhunk://#diff-9ce3e6346b9ee4ca7958c42d6a80b19925b4e35fb2aff1c8d5847a697bbaa8d2R41): Added a missing `return` statement after logging an error to ensure proper error propagation.

### Port Configuration Fix:
* [`monolithic/cmd/development/main.go`](diffhunk://#diff-2986ca8d4d81d984e49859ed7ae335a6effcb228c4f419dfa2362f7dff0e607dL267-R267): Updated the UI container port from `80/tcp` to `8080/tcp` to align with the expected configuration.