### PR TITLE
No tmp_dir for fileblob persistence

### DIFF
--- a/engines/fs-storage/localfs/registrar.go
+++ b/engines/fs-storage/localfs/registrar.go
@@ -18,7 +18,7 @@ func Register() {
 
 		os.MkdirAll(engineConfig.Config.StorageDirectory, os.ModePerm)
 
-		uri := fmt.Sprintf("file://%s", engineConfig.Config.StorageDirectory)
+		uri := fmt.Sprintf("file://%s?no_tmp_dir", engineConfig.Config.StorageDirectory)
 		bucket, err := blob.OpenBucket(context.Background(), uri)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This pull request introduces a small but important change to the `Register` function in `engines/fs-storage/localfs/registrar.go`. The change modifies the `uri` string to include a `no_tmp_dir` query parameter, which  impacts how temporary directories are handled during bucket initialization: https://pkg.go.dev/gocloud.dev/blob/fileblob