### PR TITLE
chore: monolithic: add labels and standard ports in docker containers

### DIFF
--- a/backend/pkg/assemblers/service-assembler_test.go
+++ b/backend/pkg/assemblers/service-assembler_test.go
@@ -193,7 +193,7 @@ type TestServer struct {
 func PrepareRabbitMQForTest() (*TestEventBusConfig, error) {
 	rabbitmqSubsystem := subsystems.GetSubsystemBuilder[subsystems.Subsystem](subsystems.RabbitMQ)
 
-	backend, err := rabbitmqSubsystem.Run()
+	backend, err := rabbitmqSubsystem.Run(false)
 	if err != nil {
 		return nil, err
 	}
@@ -210,7 +210,7 @@ func PreparePostgresForTest(dbs []string) (*TestStorageEngineConfig, error) {
 	postgresSubsystem := subsystems.GetSubsystemBuilder[subsystems.StorageSubsystem](subsystems.Postgres)
 
 	postgresSubsystem.Prepare(dbs)
-	backend, err := postgresSubsystem.Run()
+	backend, err := postgresSubsystem.Run(false)
 	if err != nil {
 		return nil, err
 	}
@@ -256,7 +256,7 @@ func PrepareCryptoEnginesForTest(engines []CryptoEngine) *TestCryptoEngineConfig
 
 	if slices.Contains(engines, VAULT) {
 
-		backend, err := subsystems.GetSubsystemBuilder[subsystems.Subsystem](subsystems.Vault).Run()
+		backend, err := subsystems.GetSubsystemBuilder[subsystems.Subsystem](subsystems.Vault).Run(false)
 		if err != nil {
 			panic(fmt.Sprintf("could not run Vault subsystem: %s", err))
 		}

--- a/engines/crypto/aws/awskms_test.go
+++ b/engines/crypto/aws/awskms_test.go
@@ -98,7 +98,7 @@ func TestAWSKMSCryptoEngine(t *testing.T) {
 }
 
 func prepareKMSCryptoEngine(t *testing.T) (func() error, cryptoengines.CryptoEngine, error) {
-	beforeTestCleanup, containerCleanup, conf, err := laws.RunAWSEmulationLocalStackDocker()
+	beforeTestCleanup, containerCleanup, conf, err := laws.RunAWSEmulationLocalStackDocker(false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/engines/crypto/aws/secretsmanager_test.go
+++ b/engines/crypto/aws/secretsmanager_test.go
@@ -85,7 +85,7 @@ func TestAWSSecretsManagerCryptoEngine(t *testing.T) {
 }
 
 func prepareSecretsManagerCryptoEngine(t *testing.T) (func() error, cryptoengines.CryptoEngine, error) {
-	beforeTestCleanup, containerCleanup, conf, err := laws.RunAWSEmulationLocalStackDocker()
+	beforeTestCleanup, containerCleanup, conf, err := laws.RunAWSEmulationLocalStackDocker(false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/engines/crypto/aws/subsystem/subsystem.go
+++ b/engines/crypto/aws/subsystem/subsystem.go
@@ -15,8 +15,8 @@ func Register() {
 type AwsSubsystem struct {
 }
 
-func (p *AwsSubsystem) Run() (*subsystems.SubsystemBackend, error) {
-	awsCleanup, _, awsCfg, err := aws.RunAWSEmulationLocalStackDocker()
+func (p *AwsSubsystem) Run(exposeAsStandardPort bool) (*subsystems.SubsystemBackend, error) {
+	awsCleanup, _, awsCfg, err := aws.RunAWSEmulationLocalStackDocker(exposeAsStandardPort)
 	if err != nil {
 		log.Fatalf("could not launch AWS Platform: %s", err)
 	}

--- a/engines/crypto/pkcs11/pkcs11_test.go
+++ b/engines/crypto/pkcs11/pkcs11_test.go
@@ -62,7 +62,7 @@ func preparePKCS11CryptoEngine(t *testing.T) (func() (cryptoengines.CryptoEngine
 		t.Skip("PKCS11_MODULE_PATH not set")
 	}
 
-	beforeEach, _, engineConf, err := docker.RunSoftHsmV2Docker(soPath)
+	beforeEach, _, engineConf, err := docker.RunSoftHsmV2Docker(false, soPath)
 	if err != nil {
 		return nil, err
 	}

--- a/engines/crypto/pkcs11/subsystem/subsystem.go
+++ b/engines/crypto/pkcs11/subsystem/subsystem.go
@@ -20,8 +20,8 @@ func (p *Pkcs11Subsystem) Prepare(config map[string]interface{}) error {
 	return nil
 }
 
-func (p *Pkcs11Subsystem) Run() (*subsystems.SubsystemBackend, error) {
-	_, softhsmCleanup, pkcs11Cfg, err := docker.RunSoftHsmV2Docker(p.hsmModulePath)
+func (p *Pkcs11Subsystem) Run(exposeAsStandardPort bool) (*subsystems.SubsystemBackend, error) {
+	_, softhsmCleanup, pkcs11Cfg, err := docker.RunSoftHsmV2Docker(exposeAsStandardPort, p.hsmModulePath)
 	if err != nil {
 		return nil, err
 	}

--- a/engines/crypto/vaultkv2/docker/test_suite.go
+++ b/engines/crypto/vaultkv2/docker/test_suite.go
@@ -12,8 +12,8 @@ type VaultSuite struct {
 	beforeEach    func() error
 }
 
-func BeforeSuite() (vconfig.HashicorpVaultSDK, VaultSuite) {
-	beforeEach, cleanup, conf, rootToken, err := RunHashicorpVaultDocker()
+func BeforeSuite(exposeAsStandardPort bool) (vconfig.HashicorpVaultSDK, VaultSuite) {
+	beforeEach, cleanup, conf, rootToken, err := RunHashicorpVaultDocker(exposeAsStandardPort)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/engines/crypto/vaultkv2/subsystem/subsystem.go
+++ b/engines/crypto/vaultkv2/subsystem/subsystem.go
@@ -14,9 +14,8 @@ func Register() {
 type VaultKV2Subsystem struct {
 }
 
-func (p *VaultKV2Subsystem) Run() (*subsystems.SubsystemBackend, error) {
-
-	vaultSDKConf, vaultSuite := vault_test.BeforeSuite()
+func (p *VaultKV2Subsystem) Run(exposeAsStandardPort bool) (*subsystems.SubsystemBackend, error) {
+	vaultSDKConf, vaultSuite := vault_test.BeforeSuite(exposeAsStandardPort)
 
 	config, err := config.CryptoEngineConfigAdapter[vconfig.HashicorpVaultSDK]{
 		ID:       "vault-1",

--- a/engines/crypto/vaultkv2/vaultkv2_test.go
+++ b/engines/crypto/vaultkv2/vaultkv2_test.go
@@ -75,7 +75,7 @@ func TestVaultCryptoEngine(t *testing.T) {
 }
 
 func prepareVaultkv2CryptoEngine(t *testing.T) (func() error, cryptoengines.CryptoEngine, error) {
-	beforeEachCleanup, vCleanup, vaultConfig, _, err := keyvaultkv2_test.RunHashicorpVaultDocker()
+	beforeEachCleanup, vCleanup, vaultConfig, _, err := keyvaultkv2_test.RunHashicorpVaultDocker(false)
 	t.Cleanup(func() { _ = vCleanup() })
 	if err != nil {
 		return nil, nil, err

--- a/engines/eventbus/amqp/engine_test.go
+++ b/engines/eventbus/amqp/engine_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func prepareEventBusForTest(t *testing.T) (func() error, message.Publisher, func(serviceID string) message.Subscriber) {
-	cleanup, conf, _, err := rabbitmq_test.RunRabbitMQDocker()
+	cleanup, conf, _, err := rabbitmq_test.RunRabbitMQDocker(false)
 	if err != nil {
 		t.Fatalf("could not run RabbitMQ docker: %s", err)
 	}

--- a/engines/eventbus/amqp/subsystem/subsystem.go
+++ b/engines/eventbus/amqp/subsystem/subsystem.go
@@ -13,9 +13,8 @@ func Register() {
 type RabbitMQSubsystem struct {
 }
 
-func (p *RabbitMQSubsystem) Run() (*subsystems.SubsystemBackend, error) {
-
-	cleanup, conf, adminPort, err := rabbitmq_test.RunRabbitMQDocker()
+func (p *RabbitMQSubsystem) Run(exposeAsStandardPort bool) (*subsystems.SubsystemBackend, error) {
+	cleanup, conf, adminPort, err := rabbitmq_test.RunRabbitMQDocker(exposeAsStandardPort)
 	if err != nil {
 		return nil, err
 	}

--- a/engines/eventbus/aws/engine_test.go
+++ b/engines/eventbus/aws/engine_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func prepareEventBusForTest(t *testing.T) (func() error, message.Publisher, func(serviceID string) message.Subscriber) {
-	cleanup, _, conf, err := aws.RunAWSEmulationLocalStackDocker()
+	cleanup, _, conf, err := aws.RunAWSEmulationLocalStackDocker(false)
 	if err != nil {
 		t.Fatalf("could not run RabbitMQ docker: %s", err)
 	}

--- a/engines/storage/postgres/migrations_test/utils.go
+++ b/engines/storage/postgres/migrations_test/utils.go
@@ -20,7 +20,7 @@ import (
 func RunDB(t *testing.T, logger *logrus.Entry, dbName string) (func() error, *gorm.DB) {
 	cleanup, cfg, err := postgres_test.RunPostgresDocker(map[string]string{
 		dbName: "",
-	})
+	}, false)
 	if err != nil {
 		t.Fatalf("could not launch Postgres: %s", err)
 	}

--- a/engines/storage/postgres/subsystem/subsystem.go
+++ b/engines/storage/postgres/subsystem/subsystem.go
@@ -23,8 +23,8 @@ func (p *PostgresSubsystem) Prepare(dbs []string) error {
 	return nil
 }
 
-func (p *PostgresSubsystem) Run() (*subsystems.SubsystemBackend, error) {
-	pConfig, postgresEngine := postgres_test.BeforeSuite(p.dbs)
+func (p *PostgresSubsystem) Run(exposeAsStandardPort bool) (*subsystems.SubsystemBackend, error) {
+	pConfig, postgresEngine := postgres_test.BeforeSuite(p.dbs, exposeAsStandardPort)
 	configMap, err := config.EncodeStruct(pConfig)
 	if err != nil {
 		return nil, fmt.Errorf("could not encode postgres config: %s", err)

--- a/engines/storage/postgres/test/postgres_test.go
+++ b/engines/storage/postgres/test/postgres_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestEmptyDumpImport(t *testing.T) {
-	cfg, suite := BeforeSuite([]string{"ca"})
+	cfg, suite := BeforeSuite([]string{"ca"}, false)
 
 	defer suite.cleanupDocker()
 
@@ -42,7 +42,7 @@ func TestDumpImport(t *testing.T) {
 
 	pCleanup, cfg, err := RunPostgresDocker(map[string]string{
 		"ca": string(dump),
-	})
+	}, false)
 	if err != nil {
 		t.Fatalf("could not launch Postgres: %s", err)
 	}
@@ -92,7 +92,7 @@ func TestDumpImport(t *testing.T) {
 }
 
 func TestBeforeSuite(t *testing.T) {
-	_, suite := BeforeSuite([]string{"ca"})
+	_, suite := BeforeSuite([]string{"ca"}, false)
 	defer suite.cleanupDocker()
 
 	db := suite.DB["ca"]

--- a/engines/storage/postgres/test/test_suite.go
+++ b/engines/storage/postgres/test/test_suite.go
@@ -18,13 +18,13 @@ type PostgresSuite struct {
 	cleanupDocker func() error
 }
 
-func BeforeSuite(dbNames []string) (config.PostgresPSEConfig, PostgresSuite) {
+func BeforeSuite(dbNames []string, exposeAsStandardPort bool) (config.PostgresPSEConfig, PostgresSuite) {
 	dbs := make(map[string]string)
 	for _, dbName := range dbNames {
 		dbs[dbName] = ""
 	}
 
-	cleaner, conf, err := RunPostgresDocker(dbs)
+	cleaner, conf, err := RunPostgresDocker(dbs, exposeAsStandardPort)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/shared/aws/docker-emulator.go
+++ b/shared/aws/docker-emulator.go
@@ -13,11 +13,22 @@ import (
 	"github.com/ory/dockertest/v3/docker"
 )
 
-func RunAWSEmulationLocalStackDocker() (func() error, func() error, *AWSSDKConfig, error) {
+func RunAWSEmulationLocalStackDocker(exposeAsStandardPort bool) (func() error, func() error, *AWSSDKConfig, error) {
 	containerCleanup, container, dockerHost, err := dockerrunner.RunDocker(dockertest.RunOptions{
 		Repository: "localstack/localstack", // image
 		Tag:        "4.1",                   // version
-	}, func(hc *docker.HostConfig) {})
+	}, func(hc *docker.HostConfig) {
+		if exposeAsStandardPort {
+			hc.PortBindings = map[docker.Port][]docker.PortBinding{
+				"4566/tcp": {
+					{
+						HostIP:   "0.0.0.0",
+						HostPort: "4566", // random port
+					},
+				},
+			}
+		}
+	})
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/shared/subsystems/pkg/test/subsystems/subsystems.go
+++ b/shared/subsystems/pkg/test/subsystems/subsystems.go
@@ -8,7 +8,7 @@ type SubsystemBackend struct {
 }
 
 type Subsystem interface {
-	Run() (*SubsystemBackend, error)
+	Run(exposeAsStandardPort bool) (*SubsystemBackend, error)
 }
 
 type StorageSubsystem interface {

--- a/shared/subsystems/pkg/test/subsystems/subsystems_test.go
+++ b/shared/subsystems/pkg/test/subsystems/subsystems_test.go
@@ -9,7 +9,7 @@ import (
 
 type MockPostgresSubsystem struct{}
 
-func (m *MockPostgresSubsystem) Run() (*SubsystemBackend, error) {
+func (m *MockPostgresSubsystem) Run(bool) (*SubsystemBackend, error) {
 	return &SubsystemBackend{}, nil
 }
 
@@ -39,7 +39,7 @@ func TestPostgresSubsystemRun(t *testing.T) {
 	retrievedSubsystem := GetSubsystemBuilder[Subsystem](Postgres)
 
 	// Run the retrieved subsystem
-	backend, err := retrievedSubsystem.Run()
+	backend, err := retrievedSubsystem.Run(true)
 
 	// Verify the result
 	require.NoError(t, err)


### PR DESCRIPTION
This pull request introduces the `exposeAsStandardPort` parameter across various subsystems and test utilities to allow optional exposure of services on standard ports. The changes improve flexibility in configuring Docker-based service emulation for testing. Below are the most important changes grouped by theme:

### Core Subsystem Updates:
* Added the `exposeAsStandardPort` parameter to the `Run` methods of subsystems like `RabbitMQSubsystem`, `PostgresSubsystem`, `VaultKV2Subsystem`, and `Pkcs11Subsystem`, enabling optional port exposure. [[1]](diffhunk://#diff-02b3a00efc01b28b91993f07235ebe1beebbffabcefea0cbb69f38e1864e079dL18-R19) [[2]](diffhunk://#diff-240aa9a346ca63947e872862d4a6dc2ce1ecc65aaf986ae0e56770f41711c7f7L23-R24) [[3]](diffhunk://#diff-be191c292745bc2fbadc7c3a2d6157c6c06d1d45d4939b629a68850f05e46830L17-R18) [[4]](diffhunk://#diff-85c1b44fe34d8835bf3377cdaf2f34c5214378604ea8ed14bf2f3bbcb957d4b9L16-R17) [[5]](diffhunk://#diff-05af7469ae1cd2bd0e2ddeb5bbb4a0f0c883779b27431ba785b1e91edccc6d4fL26-R27)

### Docker Utilities Enhancements:
* Updated Docker utility functions (e.g., `RunRabbitMQDocker`, `RunPostgresDocker`, `RunHashicorpVaultDocker`, `RunSoftHsmV2Docker`) to support the `exposeAsStandardPort` parameter, adding logic for port bindings when enabled. [[1]](diffhunk://#diff-cb7f550d5413c35a7fd5c31f8643ba1c1ddf095c67043e8903ef6650415338d1L18-R46) [[2]](diffhunk://#diff-0b2f2edb4a49c054ddf9a6ae0298ea39d1829ea8884c96fa1c82dbc4e2bb9a65L21-R21) [[3]](diffhunk://#diff-2eedccf4f541c50289616e46fb1879fd91b53a9af6096b185e119c82d5f607a5L17-R17) [[4]](diffhunk://#diff-529938f8e21d680d8a4b178c27406989efb7feac202c55ac2fbb71683b4eb736L14-R14)

### Test Updates:
* Modified test preparation functions (e.g., `PrepareRabbitMQForTest`, `PreparePostgresForTest`, `prepareKMSCryptoEngine`) to pass `false` as the default value for `exposeAsStandardPort`. This ensures backward compatibility while adopting the new parameter. [[1]](diffhunk://#diff-18ebc66899d0b8ab6716293d7873e75f775fddd50b13fcf5c7b6ceb07a1c0046L196-R196) [[2]](diffhunk://#diff-18ebc66899d0b8ab6716293d7873e75f775fddd50b13fcf5c7b6ceb07a1c0046L213-R213) [[3]](diffhunk://#diff-e11fca5982d3ae109e757d4e96de149c413a76f3a9741f6c4558f716a8131e19L101-R101)

### Labeling and Grouping:
* Added Docker container labels (e.g., `"group": "lamassuiot-monolithic"`) for better organization and identification of test containers. [[1]](diffhunk://#diff-0b2f2edb4a49c054ddf9a6ae0298ea39d1829ea8884c96fa1c82dbc4e2bb9a65R82-R99) [[2]](diffhunk://#diff-2eedccf4f541c50289616e46fb1879fd91b53a9af6096b185e119c82d5f607a5R27-R40) [[3]](diffhunk://#diff-529938f8e21d680d8a4b178c27406989efb7feac202c55ac2fbb71683b4eb736L30-R44) [[4]](diffhunk://#diff-cb7f550d5413c35a7fd5c31f8643ba1c1ddf095c67043e8903ef6650415338d1L18-R46)

### Test Suite Adjustments:
* Updated test suites (e.g., `BeforeSuite` for Postgres and Vault) to include the `exposeAsStandardPort` parameter, ensuring consistent configuration across test cases. [[1]](diffhunk://#diff-fdf1ce4b57361de8dbe8160a390323e7313fae35e83a7cf2d32d73ba7d792215L21-R27) [[2]](diffhunk://#diff-cc154d11784b9a4215e7757261f28238791425dbad7668e6c9c2a335acb17309L15-R16) [[3]](diffhunk://#diff-cb0c9cac0ba8938eda103c9b4503477d15ffd74f51e5d2f58b8f52a69b927101L15-R15)

These changes collectively enhance the configurability and maintainability of the testing framework while preserving existing functionality.