### PR TITLE
refactor: CA: homogenize certificate SN format

### DIFF
--- a/backend/pkg/assemblers/dms-manager_test.go
+++ b/backend/pkg/assemblers/dms-manager_test.go
@@ -2904,7 +2904,7 @@ func TestESTReEnroll(t *testing.T) {
 				}
 
 				_, err = testServers.CA.Service.UpdateCertificateStatus(context.Background(), services.UpdateCertificateStatusInput{
-					SerialNumber:     helpers.SerialNumberToString(deviceCrt.SerialNumber),
+					SerialNumber:     helpers.SerialNumberToHexString(deviceCrt.SerialNumber),
 					NewStatus:        models.StatusRevoked,
 					RevocationReason: ocsp.Superseded,
 				})
@@ -3066,7 +3066,7 @@ func TestESTReEnroll(t *testing.T) {
 				}
 
 				crt1, err := testServers.CA.Service.GetCertificateBySerialNumber(context.Background(), services.GetCertificatesBySerialNumberInput{
-					SerialNumber: helpers.SerialNumberToString(deviceCrt1.SerialNumber),
+					SerialNumber: helpers.SerialNumberToHexString(deviceCrt1.SerialNumber),
 				})
 				if err != nil {
 					t.Fatalf("could not get certificate: %s", err)
@@ -3102,7 +3102,7 @@ func TestESTReEnroll(t *testing.T) {
 				}
 
 				crt2, err := testServers.CA.Service.GetCertificateBySerialNumber(context.Background(), services.GetCertificatesBySerialNumberInput{
-					SerialNumber: helpers.SerialNumberToString(deviceCrt2.SerialNumber),
+					SerialNumber: helpers.SerialNumberToHexString(deviceCrt2.SerialNumber),
 				})
 				if err != nil {
 					t.Fatalf("could not get certificate: %s", err)

--- a/backend/pkg/assemblers/va_test.go
+++ b/backend/pkg/assemblers/va_test.go
@@ -264,8 +264,8 @@ func TestPostOCSP(t *testing.T) {
 					return fmt.Errorf("should've got OCSP Response, but got error: %s", err)
 				}
 
-				if helpers.SerialNumberToString(response.SerialNumber) != crt.SerialNumber {
-					return fmt.Errorf("ocsp response has different serial number than the certificate. Got %s, should've got %s", helpers.SerialNumberToString(response.SerialNumber), crt.SerialNumber)
+				if helpers.SerialNumberToHexString(response.SerialNumber) != crt.SerialNumber {
+					return fmt.Errorf("ocsp response has different serial number than the certificate. Got %s, should've got %s", helpers.SerialNumberToHexString(response.SerialNumber), crt.SerialNumber)
 				}
 
 				if err = response.CheckSignatureFrom((*x509.Certificate)(issuer.Certificate.Certificate)); err != nil {

--- a/backend/pkg/helpers/serialnumber.go
+++ b/backend/pkg/helpers/serialnumber.go
@@ -1,31 +1,16 @@
 package helpers
 
 import (
-	"bytes"
-	"fmt"
+	"encoding/hex"
 	"math/big"
 )
 
-func insertNth(s string, n int, sep rune) string {
-	if len(s)%2 != 0 {
-		s = "0" + s
+// SerialNumberToHexString converts a big.Int serial number to its hexadecimal string representation.
+// It ensures that the output is in lowercase and has an even length by padding with a leading zero if necessary.
+func SerialNumberToHexString(n *big.Int) string {
+	n = new(big.Int).Abs(n)
+	if n.Sign() == 0 {
+		return "00"
 	}
-	var buffer bytes.Buffer
-	var n1 = n - 1
-	var l1 = len(s) - 1
-	for i, rune := range s {
-		buffer.WriteRune(rune)
-		if i%n == n1 && i != l1 {
-			buffer.WriteRune(sep)
-		}
-	}
-	return buffer.String()
-}
-
-func toHexInt(n *big.Int) string {
-	return fmt.Sprintf("%x", n) // or %X or upper case
-}
-
-func SerialNumberToString(n *big.Int) string {
-	return insertNth(toHexInt(new(big.Int).Abs(n)), 2, '-')
+	return hex.EncodeToString(n.Bytes())
 }

--- a/backend/pkg/helpers/serialnumber_test.go
+++ b/backend/pkg/helpers/serialnumber_test.go
@@ -5,69 +5,11 @@ import (
 	"testing"
 )
 
-func TestInsertNth(t *testing.T) {
-	// Caso de prueba 1: cadena vacía
-	s1 := ""
-	n1 := 2
-	sep1 := '-'
-	expected1 := ""
-	result1 := insertNth(s1, n1, sep1)
-	if result1 != expected1 {
-		t.Errorf("Expected %v, but got %v", expected1, result1)
-	}
-
-	// Caso de prueba 2: cadena con longitud impar
-	s2 := "123"
-	n2 := 2
-	sep2 := '-'
-	expected2 := "01-23"
-	result2 := insertNth(s2, n2, sep2)
-	if result2 != expected2 {
-		t.Errorf("Expected %v, but got %v", expected2, result2)
-	}
-
-	// Caso de prueba 3: cadena con longitud par
-	s3 := "1234"
-	n3 := 2
-	sep3 := '-'
-	expected3 := "12-34"
-	result3 := insertNth(s3, n3, sep3)
-	if result3 != expected3 {
-		t.Errorf("Expected %v, but got %v", expected3, result3)
-	}
-}
-
-func TestToHexInt(t *testing.T) {
-	// Caso de prueba 1: número cero
-	n1 := big.NewInt(0)
-	expected1 := "0"
-	result1 := toHexInt(n1)
-	if result1 != expected1 {
-		t.Errorf("Expected %v, but got %v", expected1, result1)
-	}
-
-	// Caso de prueba 2: número positivo
-	n2 := big.NewInt(255)
-	expected2 := "ff"
-	result2 := toHexInt(n2)
-	if result2 != expected2 {
-		t.Errorf("Expected %v, but got %v", expected2, result2)
-	}
-
-	// Caso de prueba 3: número negativo
-	n3 := big.NewInt(-255)
-	expected3 := "-ff"
-	result3 := toHexInt(n3)
-	if result3 != expected3 {
-		t.Errorf("Expected %v, but got %v", expected3, result3)
-	}
-}
-
 func TestSerialNumberToString(t *testing.T) {
 	// Caso de prueba 1: número cero
 	n1 := big.NewInt(0)
 	expected1 := "00"
-	result1 := SerialNumberToString(n1)
+	result1 := SerialNumberToHexString(n1)
 	if result1 != expected1 {
 		t.Errorf("Expected %v, but got %v", expected1, result1)
 	}
@@ -75,7 +17,7 @@ func TestSerialNumberToString(t *testing.T) {
 	// Caso de prueba 2: número positivo
 	n2 := big.NewInt(255)
 	expected2 := "ff"
-	result2 := SerialNumberToString(n2)
+	result2 := SerialNumberToHexString(n2)
 	if result2 != expected2 {
 		t.Errorf("Expected %v, but got %v", expected2, result2)
 	}
@@ -83,31 +25,31 @@ func TestSerialNumberToString(t *testing.T) {
 	// Caso de prueba 3: número negativo
 	n3 := big.NewInt(-255)
 	expected3 := "ff"
-	result3 := SerialNumberToString(n3)
+	result3 := SerialNumberToHexString(n3)
 	if result3 != expected3 {
 		t.Errorf("Expected %v, but got %v", expected3, result3)
 	}
 
 	// Caso de prueba 4: > 255, longitud impar
 	n4 := big.NewInt(256)
-	expected4 := "01-00"
-	result4 := SerialNumberToString(n4)
+	expected4 := "0100"
+	result4 := SerialNumberToHexString(n4)
 	if result4 != expected4 {
 		t.Errorf("Expected %v, but got %v", expected4, result4)
 	}
 
 	// Caso de prueba 5: > 255, longitud par
 	n5 := big.NewInt(1024 * 4)
-	expected5 := "10-00"
-	result5 := SerialNumberToString(n5)
+	expected5 := "1000"
+	result5 := SerialNumberToHexString(n5)
 	if result5 != expected5 {
 		t.Errorf("Expected %v, but got %v", expected5, result5)
 	}
 
 	// Caso de prueba 6: long number
 	n6 := new(big.Int).Exp(big.NewInt(2), big.NewInt(1024), nil)
-	expected6 := "01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00"
-	result6 := SerialNumberToString(n6)
+	expected6 := "010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+	result6 := SerialNumberToHexString(n6)
 	if result6 != expected6 {
 		t.Errorf("Expected %v, but got %v", expected6, result6)
 	}

--- a/backend/pkg/services/dmsmanager.go
+++ b/backend/pkg/services/dmsmanager.go
@@ -348,7 +348,7 @@ func (svc DMSManagerServiceBackend) Enroll(ctx context.Context, csr *x509.Certif
 		}
 
 		lFunc = lFunc.WithField("auth-status", "verifying")
-		lFunc = lFunc.WithField("auth-uri", fmt.Sprintf("CN=%s, SN=%s, Issuer=%s", clientCert.Subject.CommonName, helpers.SerialNumberToString(clientCert.SerialNumber), clientCert.Issuer.CommonName))
+		lFunc = lFunc.WithField("auth-uri", fmt.Sprintf("CN=%s, SN=%s, Issuer=%s", clientCert.Subject.CommonName, helpers.SerialNumberToHexString(clientCert.SerialNumber), clientCert.Issuer.CommonName))
 		lFunc.Debugf("presented client certificate")
 
 		//check if certificate is a certificate issued by bootstrap CA
@@ -667,7 +667,7 @@ func (svc DMSManagerServiceBackend) Reenroll(ctx context.Context, csr *x509.Cert
 		}
 
 		lFunc = lFunc.WithField("auth-status", "verifying")
-		lFunc = lFunc.WithField("auth-uri", fmt.Sprintf("CN=%s, SN=%s, Issuer=%s", clientCert.Subject.CommonName, helpers.SerialNumberToString(clientCert.SerialNumber), clientCert.Issuer.CommonName))
+		lFunc = lFunc.WithField("auth-uri", fmt.Sprintf("CN=%s, SN=%s, Issuer=%s", clientCert.Subject.CommonName, helpers.SerialNumberToHexString(clientCert.SerialNumber), clientCert.Issuer.CommonName))
 		lFunc.Debugf("presented client certificate")
 
 		validCertificate := false
@@ -1016,7 +1016,7 @@ func (svc DMSManagerServiceBackend) checkCertificateRevocation(ctx context.Conte
 
 	revocationChecked := false
 	revoked := true
-	clientSN := helpers.SerialNumberToString(cert.SerialNumber)
+	clientSN := helpers.SerialNumberToHexString(cert.SerialNumber)
 	//check if revoked
 	//  If cert is in Lamassu: check status
 	//  If cert NOT in Lamassu (i.e. Issued Offline/Outside Lamassu), check if the certificate has CRL/OCSP in presented CRT.

--- a/backend/pkg/services/ocsp.go
+++ b/backend/pkg/services/ocsp.go
@@ -30,7 +30,7 @@ func NewOCSPService(builder OCSPServiceBuilder) services.OCSPService {
 }
 
 func (svc ocspResponder) Verify(ctx context.Context, req *ocsp.Request) ([]byte, error) {
-	ocspCrtSN := helpers.SerialNumberToString(req.SerialNumber)
+	ocspCrtSN := helpers.SerialNumberToHexString(req.SerialNumber)
 	crt, err := svc.caSDK.GetCertificateBySerialNumber(ctx, services.GetCertificatesBySerialNumberInput{
 		SerialNumber: ocspCrtSN,
 	})

--- a/backend/pkg/x509engines/x509engine.go
+++ b/backend/pkg/x509engines/x509engine.go
@@ -103,7 +103,7 @@ func (engine X509Engine) CreateRootCA(ctx context.Context, signer crypto.Signer,
 		caExpiration = validity.Time
 	}
 
-	lFunc.Debugf("generated serial number for root CA: %s", helpers.SerialNumberToString(sn))
+	lFunc.Debugf("generated serial number for root CA: %s", helpers.SerialNumberToHexString(sn))
 	lFunc.Debugf("validity of root CA: %s", caExpiration)
 	lFunc.Debugf("key ID of root CA: %s", keyID)
 	lFunc.Debugf("subject of root CA: %s", subject)

--- a/connectors/awsiot/pkg/service.go
+++ b/connectors/awsiot/pkg/service.go
@@ -341,7 +341,7 @@ func (svc *AWSCloudConnectorServiceBackend) RegisterAndAttachThing(ctx context.C
 
 	params := map[string]string{
 		"ThingName":               input.DeviceID,
-		"SerialNumber":            helpers.SerialNumberToString(input.BindedIdentity.Certificate.Certificate.SerialNumber),
+		"SerialNumber":            helpers.SerialNumberToHexString(input.BindedIdentity.Certificate.Certificate.SerialNumber),
 		"DMS":                     input.BindedIdentity.DMS.ID,
 		"LamassuCertificate":      chelpers.CertificateToPEM((*x509.Certificate)(input.BindedIdentity.Certificate.Certificate)),
 		"LamassuCACertificatePem": chelpers.CertificateToPEM((*x509.Certificate)(ca.Certificate.Certificate)),
@@ -662,7 +662,7 @@ func (svc *AWSCloudConnectorServiceBackend) GetRegisteredCAs(ctx context.Context
 				return cas, err
 			}
 
-			lFunc.Debugf("requesting CA with ID '%s' which has SN '%s' to CA service", *caMeta.CertificateId, helpers.SerialNumberToString(descCrt.SerialNumber))
+			lFunc.Debugf("requesting CA with ID '%s' which has SN '%s' to CA service", *caMeta.CertificateId, helpers.SerialNumberToHexString(descCrt.SerialNumber))
 			if res.NextMarker != nil && *res.NextMarker != "" {
 				lFunc.Debugf("Next marker: %s", *res.NextMarker)
 				nextMarker = *res.NextMarker

--- a/engines/crypto/software/software.go
+++ b/engines/crypto/software/software.go
@@ -97,11 +97,6 @@ func (p *SoftwareCryptoEngine) EncodePKIXPublicKeyDigest(key interface{}) (strin
 		return "", err
 	}
 
-	if err != nil {
-		p.logger.Errorf("could not marshal public key: %s", err)
-		return "", err
-	}
-
 	hash := sha256.New()
 	hash.Write(pubkeyBytes)
 	digest := hash.Sum(nil)

--- a/engines/storage/postgres/migrations/ca/20250904183000_update_serial_numbers.sql
+++ b/engines/storage/postgres/migrations/ca/20250904183000_update_serial_numbers.sql
@@ -1,0 +1,33 @@
+-- +goose Up
+-- +goose StatementBegin
+
+    -- BEGIN;
+
+    -- 1. Drop the foreign key constraint from ca_certificates
+    ALTER TABLE ca_certificates DROP CONSTRAINT fk_serial_number;
+
+    -- 2. Update certificates and ca_certificates tables: remove dashes
+
+    UPDATE certificates
+    SET serial_number = REPLACE(serial_number, '-', '')
+    WHERE POSITION('-' IN serial_number) > 0;
+
+    -- Update the child table
+    UPDATE ca_certificates
+    SET serial_number = REPLACE(serial_number, '-', '')
+    WHERE POSITION('-' IN serial_number) > 0;
+
+    -- 3. Restore foreign key constraint to certificates table for certificate_serial_number
+    ALTER TABLE ca_certificates
+        ADD CONSTRAINT fk_serial_number
+        FOREIGN KEY (serial_number) REFERENCES certificates (serial_number)
+        ON DELETE CASCADE;
+    
+    -- COMMIT;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'down SQL query';
+-- +goose StatementEnd

--- a/engines/storage/postgres/migrations_test/ca_test.go
+++ b/engines/storage/postgres/migrations_test/ca_test.go
@@ -28,7 +28,7 @@ func MigrationTest_CA_00000000000001_create_table(t *testing.T, logger *logrus.E
 			VALUES('ef-6d-47-f4-e5-bd-c8-e3-81-67-74-60-12-c1-0f-47', '{}', 'ef-6d-47-f4-e5-bd-c8-e3-81-67-74-60-12-c1-0f-47', '9beebc5b-ba8d-4fc0-9e97-58299d30ae9f', 0, 'ACTIVE', 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUY5RENDQTl5Z0F3SUJBZ0lSQU85dFIvVGx2Y2pqZ1dkMFlCTEJEMGN3RFFZSktvWklodmNOQVFFTEJRQXcKSERFYU1CZ0dBMVVFQXhNUlJVTlRMVTFoYm5WbVlXTjBkWEpwYm1jd0hoY05NalF4TVRJMU1EazBOVFE0V2hjTgpNalV3T1RJeE1EazBOVFEwV2pBY01Sb3dHQVlEVlFRREV4RkZRMU10VFdGdWRXWmhZM1IxY21sdVp6Q0NBaUl3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dJUEFEQ0NBZ29DZ2dJQkFOQllQKytacmZNY2MzL1BiTXVVYjBVcklMMVEKb2Jtbm41TllWdXJkU1c2ZEhZMEF3ajQzbmhlTndtV3NPbGt5bmR3UGNmVWdpWnlsS1dpVzcxUlFsMGF1bWFZLworczFVcnhjQXhidFFCOGQ3c3dBd2xYZ0xoMk1XR3ppUm4wUjBuNDJkRDdxVFdZWXIwcFRnbkc1WG82LzV1ak5iCmlSVzZaWXA4ZzNuM1BCbWFhbFRRVmxmRWgzNHBIbFU5SThFUExUdmFvMnFXU01RSlY4WDM5Y1VDdjBib0RKVEwKa0daaWpxTVM0dEoyR3NRWHo4UE8yTk83UHlXVndLWlgvSE5tYTA1NWlZV0tzNi9GN2I3bEY3YkNEQVFMalVCdwphWldWOW00VmpwRWpCMEc0WTkzTm5VMFNqVUxzR2ZFYVRlblovVk5zMXBZZ3hJcHRXWFdtZUdBT3RJWi90bFJ0CmwyTitweTVZenFtQ2tYbjZxRlRpb3ZyN1huTjFWSkxRblJKMkhSZUxWVUJ6K21TWmMzSmRXOHd6QmgvWTVtYUgKK1RpZ0dyTnIrcFZVZi9vNTZ6ZS9pblAzWUUvdERoUG5FRk1PSVBCbGdyZktlcFRKOVd6dmtPWHNkb1hwR2RHYQp6QlIwNTl1N05uVFpEQzBsc3ByKzJWMTVGVVhIMXRyelg3Nmk4QSt5bVJRak45U2NhTWlhemlzWUdSU09XNVRTClhJZ0VkSVM0YXg4TWQ1Skd5TStFVVdyQ2pwaHRaamVlQzNvdjY0R25mSWdiL1lOTFNQUi9FeHhwekJwNjN4d3AKdS8wWnZaRTZVNVBNTExwNkF0RzkzY2h2NTFVdE1lVVAzYXlQaUF4OEhZTmp3L0djN2VHKzZ1cnhYMVFnakpHSQp1MWNqU3djTE00dFA4aXdMQWdNQkFBR2pnZ0V2TUlJQkt6QU9CZ05WSFE4QkFmOEVCQU1DQVpZd0hRWURWUjBsCkJCWXdGQVlJS3dZQkJRVUhBd0lHQ0NzR0FRVUZCd01CTUE4R0ExVWRFd0VCL3dRRk1BTUJBZjh3TFFZRFZSME8KQkNZRUpEbGlaV1ZpWXpWaUxXSmhPR1F0Tkdaak1DMDVaVGszTFRVNE1qazVaRE13WVdVNVpqQXZCZ05WSFNNRQpLREFtZ0NRNVltVmxZbU0xWWkxaVlUaGtMVFJtWXpBdE9XVTVOeTAxT0RJNU9XUXpNR0ZsT1dZd053WUlLd1lCCkJRVUhBUUVFS3pBcE1DY0dDQ3NHQVFVRkJ6QUJoaHRvZEhSd2N6b3ZMMnhoWWk1c1lXMWhjM04xTG1sdkwyOWoKYzNBd1VBWURWUjBmQkVrd1J6QkZvRU9nUVlZL2FIUjBjSE02THk5c1lXSXViR0Z0WVhOemRTNXBieTlqY213dgpPV0psWldKak5XSXRZbUU0WkMwMFptTXdMVGxsT1RjdE5UZ3lPVGxrTXpCaFpUbG1NQTBHQ1NxR1NJYjNEUUVCCkN3VUFBNElDQVFDQ1pTOG5pRStxeEdBYjJjSVhVWW4rRHNJVGRwZXFnM3BQRU1EZU5DR29rUUY4cGcwbkpOdjcKZURmaTR3TEp2ZlBRK0lzNjNLYnU4dVBoanpYcnVrWUE3VWgyTmJRZnJHM1d3L3JDUGlJTkVZNktjNmltdnk1RApyK2NIbFJKYkEyaE9yNTd3Tnc0b2RrMERsdkdIbVN6M2hOWXFxcWZJcEYxMEYwdUNTNllOV1AvUHU1VFVaN2V4CkFPTjF2aWZMdFBGcGFnYkxPd3k5K3JicStHUkZET0ZSRjlzYzdBUHdoWVpUZTdHSnFNblZKbklPOU1Qd01idDEKMW1KRHNJTzlqTkhNVkVMbzBGWVRhOE05K29EWE1CaThzRWN5aER0ZlN1ZUU5bU9wWkhFck1Wb2s5aTd6Y2FObwp4OEFBZTNHRFU5MDB1SlB1Y0t3TmprVjZpL21FMk1maXBCYTMxV3NHcUdNbjY3MDBoSjJhS00wcjVIRnhhK3l4CnMzMVArQ1hCZjF4THBaYTBPY3ZTTFJuTzJtSFhnTTlzRGRsdW5WZkEzOGFoU2Zna1ZBK1BQU1EvTTFZTVUxT1YKRTIvdlNvUjR0elF4QU9wU3RjaUxGUFpxczcrY0ZJbzlKSk5aZnNNR2ZKempDbFBlRU91VFJ0YklmR0FEc1VzeQp0MmdtdDZMeDhSc2M1V0NXanNGMjFjR3FKZjB3TlJHcloyb20xTnlRcjhDZTdmQ1Y1dWY0dlNJMEZkVGU3cE5WCjNKKzJwa3ZDV05TVUdyNktmUEw2OGw1YnhiVWl0d294N0doV0dZT2IwaEp5b2V4VC92MmNiQys2WWNDUXZCSFUKeUR6bU1EZVFVQkVJeXhFRk96bE5uZlZxRnNQbmVJT2ZhbWNNaHd1VkdRSUhMdWhIK0gwdDVBPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=', 1, 4096, 'HIGH', 'ECS-Manufacturing', '', '', '', '', '', '2024-11-25 9:45:48.000', '2025-09-21 11:45:44.000', '0001-01-01 01:00:00.000', 0, 'MANAGED', 'filesystem-1', '9beebc5b-ba8d-4fc0-9e97-58299d30ae9f', '{"type":"Duration","duration":"14w2d","time":""}', '2024-11-25 11:45:48.620', 0);
 	`)
 
-	var result map[string]interface{}
+	var result map[string]any
 	tx := con.Raw("SELECT * FROM ca_certificates").Scan(&result)
 	if tx.RowsAffected != 1 {
 		t.Fatalf("expected 1 row, got %d", tx.RowsAffected)
@@ -62,7 +62,7 @@ func MigrationTest_CA_00000000000001_create_table(t *testing.T, logger *logrus.E
 func MigrationTest_CA_20241215165048_add_key_id(t *testing.T, logger *logrus.Entry, con *gorm.DB) {
 	ApplyMigration(t, logger, con, CADBName)
 
-	var result map[string]interface{}
+	var result map[string]any
 	tx := con.Raw("SELECT * FROM ca_certificates").Scan(&result)
 	if tx.RowsAffected != 1 {
 		t.Fatalf("expected 1 row, got %d", tx.RowsAffected)
@@ -249,7 +249,7 @@ func MigrationTest_CA_20250115095852_create_requests_table(t *testing.T, logger 
 			Strength: models.KeyStrengthHigh,
 		},
 		CSR:        models.X509CertificateRequest(*csr),
-		Metadata:   map[string]interface{}{},
+		Metadata:   map[string]any{},
 		CreationTS: time.Date(2024, time.November, 25, 9, 45, 48, 0, time.UTC),
 	})
 
@@ -302,7 +302,7 @@ func MigrationTest_CA_20250226114600_ca_add_kids(t *testing.T, logger *logrus.En
 
 	ApplyMigration(t, logger, con, CADBName)
 
-	var result map[string]interface{}
+	var result map[string]any
 	tx := con.Raw("SELECT * FROM certificates").Scan(&result)
 	if tx.RowsAffected != 1 {
 		t.Fatalf("expected 1 row, got %d", tx.RowsAffected)
@@ -339,6 +339,43 @@ func MigrationTest_CA_20250908074250_add_profile_id(t *testing.T, logger *logrus
 	`)
 
 	ApplyMigration(t, logger, con, CADBName)
+}
+
+func MigrationTest_CA_20250904183000_update_serial_numbers(t *testing.T, logger *logrus.Entry, con *gorm.DB) {
+
+	serialWithDashes := "37-65-cd-86-f0-bf-c5-c8-1b-7f-10-f8-15-4e-4e-35-81-4c-d8-79"
+	expected := "3765cd86f0bfc5c81b7f10f8154e4e35814cd879"
+
+	// 1. Insert certificate with dashed serial number
+	con.Exec(`INSERT INTO certificates
+        (serial_number, metadata, issuer_meta_serial_number, issuer_meta_id, issuer_meta_level, status, certificate, key_meta_type, key_meta_bits, key_meta_strength, subject_common_name, subject_organization, subject_organization_unit, subject_country, subject_state, subject_locality, valid_from, valid_to, revocation_timestamp, revocation_reason, type, engine_id)
+        VALUES (?, '{}', ?, 'test-id', 0, 'ACTIVE', 'test-cert', 'RSA', 2048, 'MEDIUM', 'TestCN', 'TestOrg', '', 'US', '', '', '2025-01-01 00:00:00', '2026-01-01 00:00:00', '0001-01-01 01:00:00.000', 'Unspecified', 'EXTERNAL', 'test-engine');`,
+		serialWithDashes, serialWithDashes)
+
+	// 2. Insert ca_certificates referencing the certificate
+	con.Exec(`INSERT INTO ca_certificates
+		(serial_number, metadata, id, creation_ts, "level", validity_type, validity_time, validity_duration)
+		VALUES(?, '{}', '8b600c60-9eb3-4251-b6ce-c92d1beccc63', '2025-01-07 15:51:59.774', 0, 'Duration', '2025-11-03 15:51:41.000', '14w2d');
+	`, serialWithDashes)
+
+	// 3. Apply migration
+	ApplyMigration(t, logger, con, CADBName)
+
+	// 4. Check serial numbers updated correctly in certificates
+	var certSerial string
+	tx := con.Raw("SELECT serial_number FROM certificates WHERE serial_number = ?", expected).Scan(&certSerial)
+	if tx.Error != nil {
+		t.Fatalf("failed to select updated certificate serial_number: %v", tx.Error)
+	}
+	assert.Equal(t, expected, certSerial)
+
+	// Check serial numbers updated correctly in ca_certificates
+	var caCertSerial string
+	tx = con.Raw("SELECT serial_number FROM ca_certificates WHERE serial_number = ?", expected).Scan(&caCertSerial)
+	if tx.Error != nil {
+		t.Fatalf("failed to select updated ca_certificate serial_number: %v", tx.Error)
+	}
+	assert.Equal(t, expected, caCertSerial)
 }
 
 func TestMigrations(t *testing.T) {
@@ -403,5 +440,10 @@ func TestMigrations(t *testing.T) {
 	MigrationTest_CA_20250908074250_add_profile_id(t, logger, con)
 	if t.Failed() {
 		t.Fatalf("failed while running migration v20250908074250_add_profile_id")
+	}
+
+	MigrationTest_CA_20250904183000_update_serial_numbers(t, logger, con)
+	if t.Failed() {
+		t.Fatalf("failed while running migration v20250904183000_update_serial_numbers")
 	}
 }


### PR DESCRIPTION
This PR standardizes the handling and storage of certificate **serial numbers** across the backend, connectors, and database migrations. The new format is a plain, **lowercase hexadecimal string without dashes,** ensuring consistency and simplifying queries and integrations.

Closes #288

### Key Changes

**Helpers Refactor:**

- Replaced `SerialNumberToString` (which used dashed hex) with `SerialNumberToHexString`, producing lowercase hex strings.
- Updated all usages and tests to expect the new format.

**Backend & Connectors Update:**

- Refactored all backend services, logging, and connector logic to use the normalized serial number format.
- Ensured all certificate-related operations use lowercase hex serial numbers.

**Database Migration:**

- Added a migration to update existing certificate and CA certificate serial numbers in the database, removing dashes and enforcing the new format.
- Updated foreign key constraints to match the new format.
