### PR TITLE
chore: update CONTRIBUTING.md to clarify setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,89 @@ Before contributing to LamassuIot, make sure you have the following tools instal
    - Download and install the latest version of Go from:  
      [Install Go](https://go.dev/doc/install)
 
+   ### PKCS#11 / CGO (C compiler) requirement
+
+   LamassuIoT includes a PKCS#11 crypto engine that depends on native C libraries. Building or running parts of the project that use the PKCS#11 engine requires CGO to be enabled so the Go toolchain can link with C code.
+
+   To enable CGO when building or testing, set the `CGO_ENABLED` environment variable to `1` and ensure a C compiler and build tools are installed on your system. Example commands:
+
+   ```sh
+   # enable CGO for a single command
+   CGO_ENABLED=1 go build ./...
+
+   # enable CGO for running tests
+   CGO_ENABLED=1 go test ./...
+
+   # or export it for the current shell session
+   export CGO_ENABLED=1
+   ```
+
+   Install a C compiler / build tools (examples):
+
+   - Ubuntu / Debian:
+
+   ```sh
+   sudo apt update
+   sudo apt install -y build-essential
+   ```
+
+   - Fedora:
+
+   ```sh
+   sudo dnf install -y gcc make pkgconfig
+   ```
+
+   - CentOS / RHEL:
+
+   ```sh
+   sudo yum groupinstall -y "Development Tools"
+   ```
+
+   - Arch Linux:
+
+   ```sh
+   sudo pacman -S --needed base-devel
+   ```
+
+   - macOS (Xcode command line tools):
+
+   ```sh
+   xcode-select --install
+   ```
+
+   Notes:
+
+   - CGO complicates cross-compilation. If you need to build for a different target architecture, prefer building on the target platform or use a container image that includes the required C toolchain.
+   - If you build Docker images for the project that require PKCS#11 support, ensure the image includes a C compiler and the necessary headers (for example by using a `build-essential`-equipped base image during the build stage or installing packages inside the Dockerfile).
+
+   ## Go build tags used in this repository
+
+   This repository uses Go build tags to optionally include or exclude features at compile time. Below is a list of the common build tags found in the codebase and what they control:
+
+   - `noaws` — when present (build with `-tags noaws`), AWS-related components (AWS Connector, S3 fs-storage registration, etc.) are excluded. Default build includes AWS components.
+   - `noamqp` — when present, AMQP/RabbitMQ eventbus registration is excluded.
+   - `novault` — when present, Vault crypto engine registration is excluded.
+   - `nopkcs11` — when present, PKCS#11 crypto engine registration is excluded.
+   - `nojs` — when present, the JavaScript-based alert/event filter registrar is excluded.
+   - `windows` / `!windows` — platform-specific files use the `windows` tag to include Windows-only implementations (for example PKCS#11 has a Windows stub). Most PKCS#11 code is excluded on Windows builds.
+
+   Examples:
+
+   ```sh
+   # Build excluding PKCS#11 and AWS components
+   go build -tags "nopkcs11 noaws" ./...
+
+   # Build with no extra tags (default includes components guarded by !no* build tags)
+   go build ./...
+   ```
+
+   Notes on build tags:
+
+   - Files that use `//go:build !noaws` are compiled unless you explicitly pass the `noaws` tag.
+   - The `-tags` flag accepts a space-separated list of tags. Use quotes to prevent shell splitting when needed.
+   - Some files use platform build tags like `windows` or `!windows` — these are handled automatically by the Go toolchain based on the target OS.
+
+
 ## Cloning and Setup
 
 To set up the project locally, follow these steps:


### PR DESCRIPTION
This pull request adds detailed instructions to the `CONTRIBUTING.md` file regarding the PKCS#11 crypto engine's dependency on CGO and native C libraries. The new section explains how to enable CGO, install required build tools for various operating systems, and provides important notes about cross-compilation and Docker builds.

PKCS#11 / CGO requirements:

* Added a new section explaining that LamassuIoT's PKCS#11 crypto engine requires CGO to be enabled and a C compiler installed, with example commands for building and testing (`CONTRIBUTING.md`).
* Provided installation instructions for C build tools on major Linux distributions and macOS (`CONTRIBUTING.md`).
* Included notes about cross-compilation challenges and Docker image requirements when PKCS#11 support is needed (`CONTRIBUTING.md`).