### PR TITLE
feat: va: add support for CRL certificate reactivation from hold 

### DIFF
--- a/backend/pkg/services/handlers/va-handlers.go
+++ b/backend/pkg/services/handlers/va-handlers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/services"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/services/eventhandling"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/crypto/ocsp"
 )
 
 func NewVAEventHandler(l *logrus.Entry, crlSvc services.CRLService) *eventhandling.CloudEventHandler {
@@ -61,7 +62,23 @@ func updateCertificateStatus(event *event.Event, crlSvc services.CRLService, lMe
 	cn := cert.Updated.Certificate.Subject.CommonName
 	icn := cert.Updated.Certificate.Issuer.CommonName
 
-	if cert.Updated.Status == models.StatusRevoked {
+	// Check if this is a certificate being reactivated from CertificateHold
+	isReactivationFromHold := cert.Previous.Status == models.StatusRevoked &&
+		cert.Previous.RevocationReason == ocsp.CertificateHold &&
+		cert.Updated.Status == models.StatusActive
+
+	// Check if this is a normal revocation
+	isRevocation := cert.Updated.Status == models.StatusRevoked
+
+	// Regenerate CRL if certificate is revoked OR reactivated from CertificateHold
+	if isRevocation || isReactivationFromHold {
+		action := "revocation"
+		if isReactivationFromHold {
+			action = "reactivation from CertificateHold"
+		}
+
+		lMessaging.Infof("Certificate %s %s - %s %s is being processed for CRL update due to %s", cn, ski, icn, aki, action)
+
 		role, err := crlSvc.GetVARole(ctx, services.GetVARoleInput{
 			CASubjectKeyID: aki,
 		})
@@ -80,6 +97,9 @@ func updateCertificateStatus(event *event.Event, crlSvc services.CRLService, lMe
 				lMessaging.Error(err)
 				return err
 			}
+			lMessaging.Infof("CRL regenerated for CA %s due to certificate %s", aki, action)
+		} else {
+			lMessaging.Infof("CRL regeneration disabled for CA %s, skipping CRL update", aki)
 		}
 	}
 


### PR DESCRIPTION
This pull request adds support for regenerating the Certificate Revocation List (CRL) when a certificate is reactivated from a CertificateHold status, ensuring that the CRL is properly updated both for revocation and reactivation events. The changes include updates to the event handling logic and a new test to verify correct CRL behavior.

**CRL Regeneration Logic Improvements:**

* Updated `updateCertificateStatus` in `va-handlers.go` to regenerate the CRL not only when a certificate is revoked, but also when it is reactivated from CertificateHold status. This ensures that certificates are correctly removed from the CRL upon reactivation.
* Added logging to clarify when CRL regeneration occurs due to either revocation or reactivation from CertificateHold, and when regeneration is skipped because it is disabled.

**Testing Enhancements:**

* Added a comprehensive test `TestCRLCertificateReactivationFromHold` in `va_test.go` to verify that the CRL is updated correctly when a certificate is revoked with CertificateHold and then reactivated, including checks for CRL version and entries.

**Dependency Updates:**

* Imported the `ocsp` package in `va-handlers.go` to support handling of CertificateHold revocation reason.
 
** Note **
The RemovefromCrl status is intended for use in delta CRLs. it does not apply to the current implementation, as only full CRLs are offered.

Fixes #231