### PR TITLE
fix: add dlq to event bus after 3 retries

### DIFF
--- a/backend/pkg/assemblers/alerts.go
+++ b/backend/pkg/assemblers/alerts.go
@@ -57,7 +57,7 @@ func AssembleAlertsService(conf config.AlertsConfig) (*services.AlertsService, e
 	if conf.SubscriberEventBus.Enabled {
 		log.Infof("Event Bus is enabled")
 
-		publisher, err := eventbus.NewEventBusPublisher(conf.SubscriberEventBus, "alerts", lMessaging)
+		dlqPublisher, err := eventbus.NewEventBusPublisher(conf.SubscriberEventBus, "alerts", lMessaging)
 		if err != nil {
 			return nil, fmt.Errorf("could not create Event Bus publisher: %s", err)
 		}
@@ -69,7 +69,7 @@ func AssembleAlertsService(conf config.AlertsConfig) (*services.AlertsService, e
 		}
 
 		eventHandlers := handlers.NewAlertsEventHandler(lMessaging, svc)
-		subHandler, err := ceventbus.NewEventBusMessageHandler(models.AlertManagerServiceName, []string{"#"}, publisher, subscriber, lMessaging, *eventHandlers)
+		subHandler, err := ceventbus.NewEventBusMessageHandler(models.AlertManagerServiceName, []string{"#"}, dlqPublisher, subscriber, lMessaging, *eventHandlers)
 		if err != nil {
 			return nil, fmt.Errorf("could not create Event Bus Subscription Handler: %s", err)
 		}

--- a/backend/pkg/assemblers/alerts.go
+++ b/backend/pkg/assemblers/alerts.go
@@ -57,6 +57,11 @@ func AssembleAlertsService(conf config.AlertsConfig) (*services.AlertsService, e
 	if conf.SubscriberEventBus.Enabled {
 		log.Infof("Event Bus is enabled")
 
+		publisher, err := eventbus.NewEventBusPublisher(conf.SubscriberEventBus, "alerts", lMessaging)
+		if err != nil {
+			return nil, fmt.Errorf("could not create Event Bus publisher: %s", err)
+		}
+
 		subscriber, err := eventbus.NewEventBusSubscriber(conf.SubscriberEventBus, "alerts", lMessaging)
 		if err != nil {
 			lMessaging.Errorf("could not generate Event Bus Subscriber: %s", err)
@@ -64,7 +69,7 @@ func AssembleAlertsService(conf config.AlertsConfig) (*services.AlertsService, e
 		}
 
 		eventHandlers := handlers.NewAlertsEventHandler(lMessaging, svc)
-		subHandler, err := ceventbus.NewEventBusMessageHandler(models.AlertManagerServiceName, []string{"#"}, subscriber, lMessaging, *eventHandlers)
+		subHandler, err := ceventbus.NewEventBusMessageHandler(models.AlertManagerServiceName, []string{"#"}, publisher, subscriber, lMessaging, *eventHandlers)
 		if err != nil {
 			return nil, fmt.Errorf("could not create Event Bus Subscription Handler: %s", err)
 		}

--- a/backend/pkg/assemblers/device-manager.go
+++ b/backend/pkg/assemblers/device-manager.go
@@ -59,12 +59,13 @@ func AssembleDeviceManagerService(conf config.DeviceManagerConfig, caService ser
 
 	lMessaging := helpers.SetupLogger(conf.PublisherEventBus.LogLevel, "Device Manager", "Event Bus")
 	lMessaging.Infof("Publisher Event Bus is enabled")
-	pub, err := eventbus.NewEventBusPublisher(conf.PublisherEventBus, serviceID, lMessaging)
-	if err != nil {
-		return nil, fmt.Errorf("could not create Event Bus publisher: %s", err)
-	}
 
 	if conf.PublisherEventBus.Enabled {
+		pub, err := eventbus.NewEventBusPublisher(conf.PublisherEventBus, serviceID, lMessaging)
+		if err != nil {
+			return nil, fmt.Errorf("could not create Event Bus publisher: %s", err)
+		}
+
 		svc = eventpub.NewDeviceEventPublisher(&eventpub.CloudEventPublisher{
 			Publisher: pub,
 			ServiceID: serviceID,
@@ -75,6 +76,11 @@ func AssembleDeviceManagerService(conf config.DeviceManagerConfig, caService ser
 	}
 
 	if conf.SubscriberEventBus.Enabled {
+		dlqPublisher, err := eventbus.NewEventBusPublisher(conf.SubscriberEventBus, serviceID, lMessaging)
+		if err != nil {
+			return nil, fmt.Errorf("could not create Event Bus publisher: %s", err)
+		}
+
 		lMessaging := helpers.SetupLogger(conf.SubscriberEventBus.LogLevel, "Device Manager", "Event Bus")
 		lMessaging.Infof("Subscriber Event Bus is enabled")
 
@@ -85,7 +91,7 @@ func AssembleDeviceManagerService(conf config.DeviceManagerConfig, caService ser
 		}
 
 		eventHandlers := handlers.NewDeviceEventHandler(lMessaging, svc)
-		subHandler, err := ceventbus.NewEventBusMessageHandler("DeviceManger-DEFAULT", []string{"certificate.#"}, pub, subscriber, lMessaging, *eventHandlers)
+		subHandler, err := ceventbus.NewEventBusMessageHandler("DeviceManger-DEFAULT", []string{"certificate.#"}, dlqPublisher, subscriber, lMessaging, *eventHandlers)
 		if err != nil {
 			return nil, fmt.Errorf("could not create Event Bus Subscription Handler: %s", err)
 		}

--- a/backend/pkg/assemblers/device-manager.go
+++ b/backend/pkg/assemblers/device-manager.go
@@ -57,14 +57,14 @@ func AssembleDeviceManagerService(conf config.DeviceManagerConfig, caService ser
 
 	deviceSvc := svc.(*lservices.DeviceManagerServiceBackend)
 
-	if conf.PublisherEventBus.Enabled {
-		lMessaging := helpers.SetupLogger(conf.PublisherEventBus.LogLevel, "Device Manager", "Event Bus")
-		lMessaging.Infof("Publisher Event Bus is enabled")
-		pub, err := eventbus.NewEventBusPublisher(conf.PublisherEventBus, serviceID, lMessaging)
-		if err != nil {
-			return nil, fmt.Errorf("could not create Event Bus publisher: %s", err)
-		}
+	lMessaging := helpers.SetupLogger(conf.PublisherEventBus.LogLevel, "Device Manager", "Event Bus")
+	lMessaging.Infof("Publisher Event Bus is enabled")
+	pub, err := eventbus.NewEventBusPublisher(conf.PublisherEventBus, serviceID, lMessaging)
+	if err != nil {
+		return nil, fmt.Errorf("could not create Event Bus publisher: %s", err)
+	}
 
+	if conf.PublisherEventBus.Enabled {
 		svc = eventpub.NewDeviceEventPublisher(&eventpub.CloudEventPublisher{
 			Publisher: pub,
 			ServiceID: serviceID,
@@ -85,7 +85,7 @@ func AssembleDeviceManagerService(conf config.DeviceManagerConfig, caService ser
 		}
 
 		eventHandlers := handlers.NewDeviceEventHandler(lMessaging, svc)
-		subHandler, err := ceventbus.NewEventBusMessageHandler("DeviceManger-DEFAULT", []string{"certificate.#"}, subscriber, lMessaging, *eventHandlers)
+		subHandler, err := ceventbus.NewEventBusMessageHandler("DeviceManger-DEFAULT", []string{"certificate.#"}, pub, subscriber, lMessaging, *eventHandlers)
 		if err != nil {
 			return nil, fmt.Errorf("could not create Event Bus Subscription Handler: %s", err)
 		}

--- a/backend/pkg/assemblers/dms-manager_events_test.go
+++ b/backend/pkg/assemblers/dms-manager_events_test.go
@@ -499,8 +499,18 @@ func TestBindIDEvent(t *testing.T) {
 		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
+			publisher, err := eventbus.NewEventBusPublisher(
+				testServers.EventBus.config,
+				uuid.NewString(),
+				chelpers.SetupLogger(cconfig.Trace, "Test Case", "pub"),
+			)
+			if err != nil {
+				t.Fatalf("could not create publisher: %s", err)
+			}
+
 			router, err := ceventbus.NewMessageRouter(
 				chelpers.SetupLogger(cconfig.Info, "Test Case", "router"),
+				publisher,
 			)
 			if err != nil {
 				t.Fatalf("could not instantiate a messaging router: %s", err)

--- a/backend/pkg/assemblers/va.go
+++ b/backend/pkg/assemblers/va.go
@@ -124,9 +124,13 @@ func createPublisherEventBus(conf config.VAconfig, crl services.CRLService) (ser
 }
 
 func createSubscriberEventBus(conf config.VAconfig, crlSvc *beService.CRLServiceBackend) error {
-
 	lMessaging := helpers.SetupLogger(conf.SubscriberEventBus.LogLevel, "VA", "Event Bus")
 	lMessaging.Infof("Subscriber Event Bus is enabled")
+
+	publisher, err := eventbus.NewEventBusPublisher(conf.SubscriberEventBus, serviceID, lMessaging)
+	if err != nil {
+		return fmt.Errorf("could not create Event Bus publisher: %s", err)
+	}
 
 	subscriber, err := eventbus.NewEventBusSubscriber(conf.SubscriberEventBus, serviceID, lMessaging)
 	if err != nil {
@@ -135,7 +139,7 @@ func createSubscriberEventBus(conf config.VAconfig, crlSvc *beService.CRLService
 	}
 
 	eventHandlers := handlers.NewVAEventHandler(lMessaging, crlSvc)
-	subHandler, err := ceventbus.NewEventBusMessageHandler("VA-CA-DEFAULT", []string{"ca.#", "certificate.#"}, subscriber, lMessaging, *eventHandlers)
+	subHandler, err := ceventbus.NewEventBusMessageHandler("VA-CA-DEFAULT", []string{"ca.#", "certificate.#"}, publisher, subscriber, lMessaging, *eventHandlers)
 	if err != nil {
 		return fmt.Errorf("could not create Event Bus Subscription Handler: %s", err)
 	}

--- a/backend/pkg/assemblers/va.go
+++ b/backend/pkg/assemblers/va.go
@@ -127,7 +127,7 @@ func createSubscriberEventBus(conf config.VAconfig, crlSvc *beService.CRLService
 	lMessaging := helpers.SetupLogger(conf.SubscriberEventBus.LogLevel, "VA", "Event Bus")
 	lMessaging.Infof("Subscriber Event Bus is enabled")
 
-	publisher, err := eventbus.NewEventBusPublisher(conf.SubscriberEventBus, serviceID, lMessaging)
+	dlqPublisher, err := eventbus.NewEventBusPublisher(conf.SubscriberEventBus, serviceID, lMessaging)
 	if err != nil {
 		return fmt.Errorf("could not create Event Bus publisher: %s", err)
 	}
@@ -139,7 +139,7 @@ func createSubscriberEventBus(conf config.VAconfig, crlSvc *beService.CRLService
 	}
 
 	eventHandlers := handlers.NewVAEventHandler(lMessaging, crlSvc)
-	subHandler, err := ceventbus.NewEventBusMessageHandler("VA-CA-DEFAULT", []string{"ca.#", "certificate.#"}, publisher, subscriber, lMessaging, *eventHandlers)
+	subHandler, err := ceventbus.NewEventBusMessageHandler("VA-CA-DEFAULT", []string{"ca.#", "certificate.#"}, dlqPublisher, subscriber, lMessaging, *eventHandlers)
 	if err != nil {
 		return fmt.Errorf("could not create Event Bus Subscription Handler: %s", err)
 	}

--- a/connectors/awsiot/pkg/assembler.go
+++ b/connectors/awsiot/pkg/assembler.go
@@ -38,7 +38,7 @@ func AssembleAWSIoTManagerService(conf ConnectorServiceConfig, caService service
 	serviceID := fmt.Sprintf("aws-connector-%s", strings.ReplaceAll(conf.ConnectorID, "aws.", "-"))
 	eventHandlers := NewAWSIoTEventHandler(lMessaging, awsConnectorSvc)
 
-	publisher, err := eventbus.NewEventBusPublisher(conf.SubscriberEventBus, serviceID, lMessaging)
+	dlqPublisher, err := eventbus.NewEventBusPublisher(conf.SubscriberEventBus, serviceID, lMessaging)
 	if err != nil {
 		lMessaging.Errorf("could not generate Event Bus Publisher: %s", err)
 		return nil, err
@@ -50,7 +50,7 @@ func AssembleAWSIoTManagerService(conf ConnectorServiceConfig, caService service
 		return nil, err
 	}
 
-	routerHandler, err := ceventbus.NewEventBusMessageHandler("AWSConnector-DEFAULT", []string{"#"}, publisher, subscriber, lMessaging, *eventHandlers)
+	routerHandler, err := ceventbus.NewEventBusMessageHandler("AWSConnector-DEFAULT", []string{"#"}, dlqPublisher, subscriber, lMessaging, *eventHandlers)
 	if err != nil {
 		lMessaging.Errorf("could not generate Event Bus Subscription Handler: %s", err)
 	}

--- a/connectors/awsiot/pkg/assembler.go
+++ b/connectors/awsiot/pkg/assembler.go
@@ -37,13 +37,20 @@ func AssembleAWSIoTManagerService(conf ConnectorServiceConfig, caService service
 
 	serviceID := fmt.Sprintf("aws-connector-%s", strings.ReplaceAll(conf.ConnectorID, "aws.", "-"))
 	eventHandlers := NewAWSIoTEventHandler(lMessaging, awsConnectorSvc)
+
+	publisher, err := eventbus.NewEventBusPublisher(conf.SubscriberEventBus, serviceID, lMessaging)
+	if err != nil {
+		lMessaging.Errorf("could not generate Event Bus Publisher: %s", err)
+		return nil, err
+	}
+
 	subscriber, err := eventbus.NewEventBusSubscriber(conf.SubscriberEventBus, serviceID, lMessaging)
 	if err != nil {
 		lMessaging.Errorf("could not generate Event Bus Subscriber: %s", err)
 		return nil, err
 	}
 
-	routerHandler, err := ceventbus.NewEventBusMessageHandler("AWSConnector-DEFAULT", []string{"#"}, subscriber, lMessaging, *eventHandlers)
+	routerHandler, err := ceventbus.NewEventBusMessageHandler("AWSConnector-DEFAULT", []string{"#"}, publisher, subscriber, lMessaging, *eventHandlers)
 	if err != nil {
 		lMessaging.Errorf("could not generate Event Bus Subscription Handler: %s", err)
 	}

--- a/core/pkg/engines/eventbus/messaging.go
+++ b/core/pkg/engines/eventbus/messaging.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func NewMessageRouter(logger *logrus.Entry) (*message.Router, error) {
+func NewMessageRouter(logger *logrus.Entry, poisonPub message.Publisher) (*message.Router, error) {
 	lEventBus := NewLoggerAdapter(logger.WithField("subsystem-provider", "EventBus - Router"))
 
 	router, err := message.NewRouter(message.RouterConfig{}, lEventBus)
@@ -18,8 +18,20 @@ func NewMessageRouter(logger *logrus.Entry) (*message.Router, error) {
 		return nil, fmt.Errorf("could not create event bus router: %s", err)
 	}
 
+	posionMw, err := middleware.PoisonQueue(poisonPub, "lamassu-dlq")
+	if err != nil {
+		return nil, fmt.Errorf("could not create poison queue middleware: %s", err)
+	}
+
 	router.AddPlugin(plugin.SignalsHandler)
+
+	//mw are applied in order they are added. So the first one is the outermost one (recovery wraps all the others for example)
 	router.AddMiddleware(
+		middleware.Recoverer,
+
+		// // Poision queue middleware will move messages that have been Nacked more than MaxRetries to a separate topic.
+		posionMw,
+
 		// CorrelationID will copy the correlation id from the incoming message's metadata to the produced messages
 		middleware.CorrelationID,
 
@@ -36,8 +48,6 @@ func NewMessageRouter(logger *logrus.Entry) (*message.Router, error) {
 			Multiplier:      3,
 			Logger:          lEventBus,
 		}.Middleware,
-
-		middleware.Recoverer,
 	)
 
 	return router, nil

--- a/core/pkg/engines/eventbus/subscriber.go
+++ b/core/pkg/engines/eventbus/subscriber.go
@@ -16,8 +16,8 @@ type EventSubscriptionHandler struct {
 	handlers   []*message.Handler
 }
 
-func NewEventBusMessageHandler(service models.ServiceName, topics []string, sub message.Subscriber, lMessaging *logrus.Entry, handler eventhandling.EventHandler) (*EventSubscriptionHandler, error) {
-	router, err := NewMessageRouter(lMessaging)
+func NewEventBusMessageHandler(service models.ServiceName, topics []string, poisonPub message.Publisher, sub message.Subscriber, lMessaging *logrus.Entry, handler eventhandling.EventHandler) (*EventSubscriptionHandler, error) {
+	router, err := NewMessageRouter(lMessaging, poisonPub)
 	if err != nil {
 		return nil, err
 	}

--- a/engines/eventbus/amqp/engine_test.go
+++ b/engines/eventbus/amqp/engine_test.go
@@ -63,3 +63,12 @@ func TestWildcardSubscribe(t *testing.T) {
 		},
 	})
 }
+
+func TestErrorHandling(t *testing.T) {
+	eventbus.TestErrorHandling(t, eventbus.EventBusTestInput{
+		SetupEventBus: func() (func() error, message.Publisher, func(serviceID string) message.Subscriber) {
+			cleanup, publisher, subFunc := prepareEventBusForTest(t)
+			return cleanup, publisher, subFunc
+		},
+	})
+}

--- a/engines/eventbus/aws/engine_test.go
+++ b/engines/eventbus/aws/engine_test.go
@@ -63,3 +63,12 @@ func TestWildcardSubscribe(t *testing.T) {
 		},
 	})
 }
+
+func TestErrorHandling(t *testing.T) {
+	eventbus.TestErrorHandling(t, eventbus.EventBusTestInput{
+		SetupEventBus: func() (func() error, message.Publisher, func(serviceID string) message.Subscriber) {
+			cleanup, publisher, subFunc := prepareEventBusForTest(t)
+			return cleanup, publisher, subFunc
+		},
+	})
+}


### PR DESCRIPTION
This pull request introduces significant improvements to the event bus system, primarily by adding support for poison queue handling and enhancing error handling in event-driven services. The changes ensure that messages which repeatedly fail processing are moved to a dead-letter queue (DLQ) for further inspection, improving system reliability and observability. Additionally, the event bus message handler and its usage across the codebase have been updated to support the new publisher parameter required for poison queue functionality. Comprehensive tests have been added to validate error handling and DLQ behavior.

**Event Bus Poison Queue and Middleware Enhancements:**

* Refactored `NewMessageRouter` in `messaging.go` to accept a poison queue publisher, add poison queue middleware, and ensure messages that exceed the retry limit are sent to a DLQ (`lamassu-dlq`). Also adjusted middleware application order for correct error handling. [[1]](diffhunk://#diff-81e9b1a4692eb0f1d35d22c50e758c1fa11e4116e430b312e30c6fe3e2fe4aedL13-R34) [[2]](diffhunk://#diff-81e9b1a4692eb0f1d35d22c50e758c1fa11e4116e430b312e30c6fe3e2fe4aedL39-L40)

**Event Bus Handler API Changes:**

* Updated `NewEventBusMessageHandler` in `subscriber.go` to require a poison queue publisher as a parameter, and refactored all usages throughout the codebase to provide this publisher when constructing message handlers. [[1]](diffhunk://#diff-81a947d823d8b9da7d93e9933ec6c24d2ee53ff2ea004fdeaa4f23a285411a81L19-R20) [[2]](diffhunk://#diff-e0488f21e2d46e56fa26c644921d4dbb4c5321e466fb3c37f2e6c31e98e9b864R60-R72) [[3]](diffhunk://#diff-9ba6840212bfa0dec6d05be4b7cbad7b8e17cf25620dc8f41e104c7cf8e384e9L88-R88) [[4]](diffhunk://#diff-8fe0cfe52a16a3428bd5e2d7acc13d21907c0208a6c3195e4942df5de462af8cL127-R142) [[5]](diffhunk://#diff-4a2aed18ccdd0b397ad4959ac279e843e333c53aaf19aefb57369bb52d3d9e81R40-R53) [[6]](diffhunk://#diff-0ad2f98e99fa9ab1fb5a139859bf6f548af607df0975e435e9d5ef59c77f2168L63-R63) [[7]](diffhunk://#diff-0ad2f98e99fa9ab1fb5a139859bf6f548af607df0975e435e9d5ef59c77f2168L186-R186) [[8]](diffhunk://#diff-0ad2f98e99fa9ab1fb5a139859bf6f548af607df0975e435e9d5ef59c77f2168L326-R326)

**Error Handling and Testing Improvements:**

* Added a new `TestErrorHandling` function in `eventbus_testset.go` to ensure that messages are retried and then sent to the DLQ after exceeding the retry limit, and integrated this test into both AMQP and AWS event bus engine tests. [[1]](diffhunk://#diff-0ad2f98e99fa9ab1fb5a139859bf6f548af607df0975e435e9d5ef59c77f2168R405-R449) [[2]](diffhunk://#diff-43b520f1304a6ea1a813805f6ee1d25d7d1aa362239d9619e6fe31e27271a666R66-R74) [[3]](diffhunk://#diff-b4334432c5f56e3aff5de00d5effcedb5d9f9373965939a76e45a037a62fd57eR66-R74)

**Service Assembler Updates:**

* Updated service assemblers (`alerts.go`, `device-manager.go`, `va.go`, `assembler.go`) to instantiate and pass event bus publishers to message handlers, ensuring all event-driven services are DLQ-capable. [[1]](diffhunk://#diff-e0488f21e2d46e56fa26c644921d4dbb4c5321e466fb3c37f2e6c31e98e9b864R60-R72) [[2]](diffhunk://#diff-9ba6840212bfa0dec6d05be4b7cbad7b8e17cf25620dc8f41e104c7cf8e384e9L60-R67) [[3]](diffhunk://#diff-8fe0cfe52a16a3428bd5e2d7acc13d21907c0208a6c3195e4942df5de462af8cL127-R142) [[4]](diffhunk://#diff-4a2aed18ccdd0b397ad4959ac279e843e333c53aaf19aefb57369bb52d3d9e81R40-R53)

**Test Infrastructure Updates:**

* Modified test setup in `dms-manager_events_test.go` to create and pass a publisher to the message router, aligning with the new poison queue requirements.

These changes collectively improve the robustness and maintainability of the event bus system, making error handling more resilient and observable.