### PR TITLE
feat: add support for filtering CAs based on profile_id

### DIFF
--- a/backend/pkg/assemblers/ca_issuance_profile_crud_test.go
+++ b/backend/pkg/assemblers/ca_issuance_profile_crud_test.go
@@ -2,11 +2,13 @@ package assemblers
 
 import (
 	"context"
+	"crypto/x509"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/resources"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/services"
 )
 
@@ -92,4 +94,167 @@ func TestCAIssuanceProfiles(t *testing.T) {
 	_, err = caSvc.GetIssuanceProfileByID(ctx, getInput)
 	assert.Error(t, err, "expected error when fetching deleted profile, got nil")
 
+}
+
+func TestFilterCAsByProfileID(t *testing.T) {
+	serverTest, err := TestServiceBuilder{}.WithDatabase("ca").Build(t)
+	assert.NoError(t, err, "could not create CA test server")
+
+	caSvc := serverTest.CA.HttpCASDK
+	ctx := context.Background()
+
+	// Create first IssuanceProfile
+	profile1 := &models.IssuanceProfile{
+		Name:        "Profile1",
+		Description: "First test profile",
+		Validity: models.Validity{
+			Type:     "Duration",
+			Duration: models.TimeDuration(365 * 24 * 60 * 60 * 1e9), // 1 year in nanoseconds
+		},
+		SignAsCA: false,
+	}
+	createProfile1Input := services.CreateIssuanceProfileInput{Profile: *profile1}
+	createdProfile1, err := caSvc.CreateIssuanceProfile(ctx, createProfile1Input)
+	assert.NoError(t, err, "failed to create first issuance profile")
+
+	// Create second IssuanceProfile
+	profile2 := &models.IssuanceProfile{
+		Name:        "Profile2",
+		Description: "Second test profile",
+		Validity: models.Validity{
+			Type:     "Duration",
+			Duration: models.TimeDuration(730 * 24 * 60 * 60 * 1e9), // 2 years in nanoseconds
+		},
+		SignAsCA: false,
+	}
+	createProfile2Input := services.CreateIssuanceProfileInput{Profile: *profile2}
+	createdProfile2, err := caSvc.CreateIssuanceProfile(ctx, createProfile2Input)
+	assert.NoError(t, err, "failed to create second issuance profile")
+
+	// Create CAs with different profiles
+	caDuration := models.TimeDuration(24 * 60 * 60 * 1e9) // 1 day in nanoseconds
+
+	// Create CA with profile1
+	ca1, err := caSvc.CreateCA(ctx, services.CreateCAInput{
+		ID:           "ca-with-profile1",
+		KeyMetadata:  models.KeyMetadata{Type: models.KeyType(x509.RSA), Bits: 2048},
+		Subject:      models.Subject{CommonName: "CA with Profile 1"},
+		CAExpiration: models.Validity{Type: "Duration", Duration: caDuration},
+		ProfileID:    createdProfile1.ID,
+	})
+	assert.NoError(t, err, "failed to create CA with profile1")
+	assert.Equal(t, createdProfile1.ID, ca1.ProfileID, "CA should have profile1 ID")
+
+	// Create another CA with profile1
+	ca2, err := caSvc.CreateCA(ctx, services.CreateCAInput{
+		ID:           "ca-with-profile1-2",
+		KeyMetadata:  models.KeyMetadata{Type: models.KeyType(x509.RSA), Bits: 2048},
+		Subject:      models.Subject{CommonName: "Second CA with Profile 1"},
+		CAExpiration: models.Validity{Type: "Duration", Duration: caDuration},
+		ProfileID:    createdProfile1.ID,
+	})
+	assert.NoError(t, err, "failed to create second CA with profile1")
+	assert.Equal(t, createdProfile1.ID, ca2.ProfileID, "Second CA should have profile1 ID")
+
+	// Create CA with profile2
+	ca3, err := caSvc.CreateCA(ctx, services.CreateCAInput{
+		ID:           "ca-with-profile2",
+		KeyMetadata:  models.KeyMetadata{Type: models.KeyType(x509.RSA), Bits: 2048},
+		Subject:      models.Subject{CommonName: "CA with Profile 2"},
+		CAExpiration: models.Validity{Type: "Duration", Duration: caDuration},
+		ProfileID:    createdProfile2.ID,
+	})
+	assert.NoError(t, err, "failed to create CA with profile2")
+	assert.Equal(t, createdProfile2.ID, ca3.ProfileID, "CA should have profile2 ID")
+
+	// Test filtering CAs by profile1 ID
+	var casWithProfile1 []models.CACertificate
+	queryParamsProfile1 := &resources.QueryParameters{
+		Filters: []resources.FilterOption{
+			{
+				Field:           "profile_id",
+				FilterOperation: resources.StringEqual,
+				Value:           createdProfile1.ID,
+			},
+		},
+	}
+
+	getCAsInputProfile1 := services.GetCAsInput{
+		QueryParameters: queryParamsProfile1,
+		ExhaustiveRun:   true,
+		ApplyFunc: func(ca models.CACertificate) {
+			casWithProfile1 = append(casWithProfile1, ca)
+		},
+	}
+
+	_, err = caSvc.GetCAs(ctx, getCAsInputProfile1)
+	assert.NoError(t, err, "failed to get CAs filtered by profile1 ID")
+
+	// Verify that we get exactly 2 CAs with profile1
+	assert.Len(t, casWithProfile1, 2, "should get exactly 2 CAs with profile1")
+
+	// Verify that all returned CAs have profile1 ID
+	for _, ca := range casWithProfile1 {
+		assert.Equal(t, createdProfile1.ID, ca.ProfileID, "all returned CAs should have profile1 ID")
+	}
+
+	// Verify specific CAs are returned
+	caIDs := make([]string, len(casWithProfile1))
+	for i, ca := range casWithProfile1 {
+		caIDs[i] = ca.ID
+	}
+	assert.Contains(t, caIDs, ca1.ID, "should contain first CA with profile1")
+	assert.Contains(t, caIDs, ca2.ID, "should contain second CA with profile1")
+
+	// Test filtering CAs by profile2 ID
+	var casWithProfile2 []models.CACertificate
+	queryParamsProfile2 := &resources.QueryParameters{
+		Filters: []resources.FilterOption{
+			{
+				Field:           "profile_id",
+				FilterOperation: resources.StringEqual,
+				Value:           createdProfile2.ID,
+			},
+		},
+	}
+
+	getCAsInputProfile2 := services.GetCAsInput{
+		QueryParameters: queryParamsProfile2,
+		ExhaustiveRun:   true,
+		ApplyFunc: func(ca models.CACertificate) {
+			casWithProfile2 = append(casWithProfile2, ca)
+		},
+	}
+
+	_, err = caSvc.GetCAs(ctx, getCAsInputProfile2)
+	assert.NoError(t, err, "failed to get CAs filtered by profile2 ID")
+
+	// Verify that we get exactly 1 CA with profile2
+	assert.Len(t, casWithProfile2, 1, "should get exactly 1 CA with profile2")
+	assert.Equal(t, createdProfile2.ID, casWithProfile2[0].ProfileID, "returned CA should have profile2 ID")
+	assert.Equal(t, ca3.ID, casWithProfile2[0].ID, "should return the correct CA with profile2")
+
+	// Test filtering with non-existent profile ID
+	var casWithNonExistentProfile []models.CACertificate
+	queryParamsNonExistent := &resources.QueryParameters{
+		Filters: []resources.FilterOption{
+			{
+				Field:           "profile_id",
+				FilterOperation: resources.StringEqual,
+				Value:           "non-existent-profile-id",
+			},
+		},
+	}
+
+	getCAsInputNonExistent := services.GetCAsInput{
+		QueryParameters: queryParamsNonExistent,
+		ExhaustiveRun:   true,
+		ApplyFunc: func(ca models.CACertificate) {
+			casWithNonExistentProfile = append(casWithNonExistentProfile, ca)
+		},
+	}
+
+	_, err = caSvc.GetCAs(ctx, getCAsInputNonExistent)
+	assert.NoError(t, err, "should not error when filtering by non-existent profile ID")
+	assert.Len(t, casWithNonExistentProfile, 0, "should get no CAs with non-existent profile ID")
 }

--- a/core/pkg/resources/careq.go
+++ b/core/pkg/resources/careq.go
@@ -19,6 +19,7 @@ var CAFiltrableFields = map[string]FilterFieldType{
 	"revocation_reason":    EnumFilterFieldType,
 	"subject.common_name":  StringFilterFieldType,
 	"subject_key_id":       StringFilterFieldType,
+	"profile_id":           StringFilterFieldType,
 }
 
 var CARequestFiltrableFields = map[string]FilterFieldType{


### PR DESCRIPTION
This pull request introduces and tests the ability to filter Certificate Authorities (CAs) by their associated Issuance Profile ID. The main changes include adding support for filtering by `profile_id` in the CA resource and a comprehensive test to validate this filtering logic.

**CA Filtering Enhancements:**

* Added `profile_id` as a filterable field in the CA resource, enabling queries to retrieve CAs by their associated issuance profile (`core/pkg/resources/careq.go`).

**Testing Improvements:**

* Added a new test `TestFilterCAsByProfileID` to `ca_issuance_profile_crud_test.go` that:
  - Creates multiple issuance profiles and CAs associated with them.
  - Verifies filtering CAs by `profile_id` returns the correct CAs.
  - Tests filtering with a non-existent profile ID returns no results.
* Updated imports to include dependencies required for new test logic in `ca_issuance_profile_crud_test.go`.