### PR TITLE
fix: ca: import ca without key when profileid not supplied

### DIFF
--- a/backend/pkg/assemblers/ca_test.go
+++ b/backend/pkg/assemblers/ca_test.go
@@ -3114,28 +3114,17 @@ func TestImportCA(t *testing.T) {
 		resultCheck func(*models.CACertificate, error) error
 	}{
 		{
-			name:   "OK/ImportingExternalCA",
+			name:   "OK/ImportingCAWithoutKey",
 			before: func(svc services.CAService) error { return nil },
 			run: func(caSDK services.CAService) (*models.CACertificate, error) {
 				ca, _, err := generateSelfSignedCA(x509.RSA)
-				var duration time.Duration = 100
 				if err != nil {
 					return nil, fmt.Errorf("Failed creating the certificate %s", err)
-				}
-
-				profile, err := caSDK.CreateIssuanceProfile(context.Background(), services.CreateIssuanceProfileInput{
-					Profile: models.IssuanceProfile{
-						Validity: models.Validity{Type: models.Duration, Duration: (models.TimeDuration)(duration)},
-					},
-				})
-				if err != nil {
-					t.Fatalf("failed creating issuance profile: %s", err)
 				}
 
 				importedCA, err := caSDK.ImportCA(context.Background(), services.ImportCAInput{
 					ID:            "id-1234",
 					CAType:        models.CertificateTypeExternal,
-					ProfileID:     profile.ID,
 					CACertificate: (*models.X509Certificate)(ca),
 				})
 
@@ -3150,7 +3139,7 @@ func TestImportCA(t *testing.T) {
 			},
 		},
 		{
-			name:   "OK/ImportingExternalCA",
+			name:   "OK/ImportingCAWithKey",
 			before: func(svc services.CAService) error { return nil },
 			run: func(caSDK services.CAService) (*models.CACertificate, error) {
 				ca, key, err := generateSelfSignedCA(x509.RSA)

--- a/backend/pkg/services/ca.go
+++ b/backend/pkg/services/ca.go
@@ -1662,6 +1662,10 @@ func importCAValidation(sl validator.StructLevel) {
 			sl.ReportError(ca.CARSAKey, "CARSAKey", "CARSAKey", "PrivateKeyAndCertificateNotMatch", "")
 			sl.ReportError(ca.CAECKey, "CAECKey", "CAECKey", "PrivateKeyAndCertificateNotMatch", "")
 		}
+
+		if ca.ProfileID == "" {
+			sl.ReportError(ca.ProfileID, "ProfileID", "ProfileID", "ProfileIDRequiredForImportedWithKey", "")
+		}
 	}
 }
 

--- a/core/pkg/services/ca.go
+++ b/core/pkg/services/ca.go
@@ -99,8 +99,8 @@ type IssueCACSROutput struct {
 
 type ImportCAInput struct {
 	ID            string
-	CAType        models.CertificateType    `validate:"required,ne=MANAGED"`
-	ProfileID     string                    `validate:"required"`
+	CAType        models.CertificateType `validate:"required,ne=MANAGED"`
+	ProfileID     string
 	CACertificate *models.X509Certificate   `validate:"required"`
 	CAChain       []*models.X509Certificate //Parent CAs. They MUST be sorted as follows. 0: Root-CA; 1: Subordinate CA from Root-CA; ...
 	CARSAKey      *rsa.PrivateKey


### PR DESCRIPTION
This pull request updates the CA import logic and its associated validation and tests to better distinguish between importing a CA with or without a private key. The changes clarify when a `ProfileID` is required and update the test cases to reflect the new import scenarios.

**Validation logic improvements:**

* In `backend/pkg/services/ca.go`, added a check to require `ProfileID` when importing a CA with a private key, ensuring proper validation for different import scenarios.

**Test case updates:**

* In `backend/pkg/assemblers/ca_test.go`, renamed and updated the test case to `OK/ImportingCAWithoutKey`, removing the issuance profile creation and `ProfileID` assignment for external CA imports without a private key.
* Renamed the test case to `OK/ImportingCAWithKey` to clarify the scenario where a CA is imported with a private key.

**Input struct changes:**

* In `core/pkg/services/ca.go`, removed the unconditional `required` validation for `ProfileID` in `ImportCAInput`, allowing imports without a profile when no private key is present.