### PR TITLE
fix: monolithic: deploy v4 ui in monolithic with correct port mapping

### DIFF
--- a/monolithic/cmd/development/main.go
+++ b/monolithic/cmd/development/main.go
@@ -316,14 +316,14 @@ func main() {
 
 	cloudConnectors := "[]"
 	if *awsIoTManagerID != "" {
-		cloudConnectors = fmt.Sprintf("aws.%s", *awsIoTManagerID)
+		cloudConnectors = fmt.Sprintf("[\"aws.%s\"]", *awsIoTManagerID)
 	}
 
 	if !*disableUI {
 		containerCleanup, container, _, err := dockerrunner.RunDocker(dockertest.RunOptions{
 			Repository: "ghcr.io/lamassuiot/lamassu-ui", // image
 			Tag:        "latest",                        // version
-			Env:        []string{"OIDC_ENABLED=false", "DOMAIN=localhost:8443", "COGNITO_ENABLED=false", "CLOUD_CONNECTORS=" + cloudConnectors},
+			Env:        []string{"OIDC_ENABLED=false", "UI_FOOTER_ENABLED=false", "LAMASSU_API=https://localhost:8443/api", "CLOUD_CONNECTORS=" + cloudConnectors},
 			Labels: map[string]string{
 				"group": "lamassuiot-monolithic",
 			},
@@ -331,7 +331,7 @@ func main() {
 			hc.AutoRemove = true
 		})
 
-		uiPort, _ = strconv.Atoi(container.GetPort("8080/tcp"))
+		uiPort, _ = strconv.Atoi(container.GetPort("80/tcp"))
 
 		if err != nil {
 			containerCleanup()


### PR DESCRIPTION
This pull request updates the configuration for running the UI container in development mode, focusing on how environment variables are set and which port is mapped. The changes improve the integration with the API and cloud connectors, and adjust the UI's runtime settings.

UI container environment configuration:

* Updated the `CLOUD_CONNECTORS` environment variable to use a JSON array format when AWS IoT Manager is specified, ensuring correct parsing by the UI.
* Added new environment variables: `UI_FOOTER_ENABLED=false` and `LAMASSU_API=https://localhost:8443/api`, and removed `DOMAIN` and `COGNITO_ENABLED` from the UI container setup for more accurate local development configuration.

Port mapping adjustment:

* Changed the UI container port mapping from `8080/tcp` to `80/tcp` to match the expected default port for the UI service.