### PR TITLE
fix: ca: add migration for profile_id with null in validity_time column in ca_certificates table

### DIFF
--- a/engines/storage/postgres/migrations/ca/20250908074250_add_profile_id.go
+++ b/engines/storage/postgres/migrations/ca/20250908074250_add_profile_id.go
@@ -39,7 +39,12 @@ func upAddProfileId(ctx context.Context, tx *sql.Tx) error {
 		caID := row["id"].(string)
 		validityType := row["validity_type"].(string)
 		validityDurationStr := row["validity_duration"].(string)
-		validityTimeStr := row["validity_time"].(time.Time)
+		var validityTimeStr time.Time
+		if v, ok := row["validity_time"]; ok && v != nil {
+			if t, ok := v.(time.Time); ok {
+				validityTimeStr = t
+			}
+		}
 
 		// Check if a profile with the same characteristics already exists
 		profileRow := tx.QueryRowContext(ctx, `

--- a/engines/storage/postgres/migrations_test/ca_test.go
+++ b/engines/storage/postgres/migrations_test/ca_test.go
@@ -328,6 +328,15 @@ func MigrationTest_CA_20250704101200_add_version_schema(t *testing.T, logger *lo
 }
 
 func MigrationTest_CA_20250908074250_add_profile_id(t *testing.T, logger *logrus.Entry, con *gorm.DB) {
+	// Insert CA certificate with validity_time as NULL (should be handled gracefully by migration)
+	con.Exec(`INSERT INTO public.certificates 
+		(serial_number, metadata, issuer_meta_serial_number, issuer_meta_id, issuer_meta_level, status, certificate, key_meta_type, key_meta_bits, key_meta_strength, subject_common_name, subject_organization, subject_organization_unit, subject_country, subject_state, subject_locality, valid_from, valid_to, revocation_timestamp, revocation_reason, type, engine_id, subject_key_id, is_ca) 
+		VALUES ('00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00', '{}', '37-65-cd-86-f0-bf-c5-c8-1b-7f-10-f8-15-4e-4e-35-81-4c-d8-79', '8b600c60-9eb3-4251-b6ce-c92d1beccc63', 0, 'ACTIVE', 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURsRENDQW55Z0F3SUJBZ0lVTjJYTmh2Qy94Y2diZnhENEZVNU9OWUZNMkhrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1hERUxNQWtHQTFVRUJoTUNWVk14RlRBVEJnTlZCQWdNREVWNFlXMXdiR1ZUZEdGMFpURVVNQklHQTFVRQpCd3dMUlhoaGJYQnNaVU5wZEhreER6QU5CZ05WQkFvTUJsSnZiM1JEUVRFUU1BNEdBMVVFQXd3SFVtOXZkQ0JEClFUQWVGdzB5TlRBeU1qVXhNelUwTVRoYUZ3MHpOVEF5TWpNeE16VTBNVGhhTUVZeEN6QUpCZ05WQkFZVEFsVlQKTVJVd0V3WURWUVFJREF4RmVHRnRjR3hsVTNSaGRHVXhEekFOQmdOVkJBb01CbEp2YjNSRFFURVBNQTBHQTFVRQpBd3dHVTNWaUlFTkJNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQTJIay91Ri9VClJNdHAzengyYmltUllvSEFxMXJ6OUgyL1F3S2d0RTRkTkk1R01ISUh4ZWVJZk9sYnh4T2hyMVBhTUtTb3hJdjEKM1NqMWFycEloUUVGc2V0NDJ0WU9FS2dUTzB4NUtRSFFSbnNYOUY1dXVjNURyajZFNFUxcUF2MGtxQlMvN2NobQpqc3pwc1oyK1ExOWordjNHM0NNa2twT09ZWmFUQW8wWlBFdFJCYU5HM3hYMlg0akdidmlNMWFDeDZ2MmNDM0s4CnJmYXVoNzR4T3lLaldNME1PVm5kS2N0VUFzNW9VckZjTkM2c3BwOGtqQk1XcFhjQ3RjWStZTm5ISDVhRDcvTEIKakdaSmxaTkROS0NDdFIwR050d2xxUHZiQ3pUYnV2UHZqVkY2aFdQaEIwZFdYUDVqRTFuc05BUkxnWW51RTJXTQpoQWx5cU92bWdlaGZVUUlEQVFBQm8yTXdZVEFQQmdOVkhSTUJBZjhFQlRBREFRSC9NQTRHQTFVZER3RUIvd1FFCkF3SUJCakFkQmdOVkhRNEVGZ1FVSHV1UElDL2tVWVA2MHlzSGlMMTl2NTFyMUtFd0h3WURWUjBqQkJnd0ZvQVUKNUZpMVFQOFc5KzRSaS8wdFZFNENhaVg1cHY0d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFJdTFsQVp0ZVUrbgorNmwvd3VFb2V2K0FkOEQzVHZIREVqeHlIbll0RTRNZitITGsyU2d1WXZYSkpSRkZjOXVzRzNGbW1CMGhUUG14CktEck1rOVFPYmdIc1pIY05hZ3doQjZVcm4rRUtyai9ZVW5JSkUyVHJYL2JsRllvTUJQYXhiV3J3cm1GQWpLc2wKOHV1Sm9OWTY0RzZzT016SEJwZUVMaGRaVS94Z0Rzck5rK2RHeVZ0WUFqbWZrc1FMT1NnRjE0WFpuWEw5K3dQYwpqU200bjhXNVlRMHpzS0FaNVRtQjBWcFRDa3ZWUy9nR0RIb1pmZE8zOENTcnk0ejhuTTNXNHpka212bzc2RzhVCjJmdkMxMUZTWHh6UlZRcmJ4ZmFPTUVjZHpUMHUxd2NzUVF6TTQrdjBOanQzdlZ5K2dSbGptK0dtdDBEYzkvTGIKTzN2MkFmbWhQaVU9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K', 'RSA', 2048, 'MEDIUM', 'Sub CA', 'RootCA', '', 'US', 'ExampleState', '', '2025-02-25 13:54:18+00', '2035-02-23 13:54:18+00', '0001-01-01 00:00:00+00', 'Unspecified', 'EXTERNAL', '', '1E:EB:8F:20:2F:E4:51:83:FA:D3:2B:07:88:BD:7D:BF:9D:6B:D4:A1', true);
+	`)
+	con.Exec(`INSERT INTO ca_certificates
+	       (serial_number, metadata, id, creation_ts, "level", validity_type, validity_time, validity_duration)
+	       VALUES('00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00', '{}', 'ca-nil-validity-time', '2025-01-07 15:53:00.000', 2, 'Duration', NULL, '14w2d');
+       `)
 	// Insert first CA certificate
 	con.Exec(`INSERT INTO public.certificates 
 		(serial_number, metadata, issuer_meta_serial_number, issuer_meta_id, issuer_meta_level, status, certificate, key_meta_type, key_meta_bits, key_meta_strength, subject_common_name, subject_organization, subject_organization_unit, subject_country, subject_state, subject_locality, valid_from, valid_to, revocation_timestamp, revocation_reason, type, engine_id, subject_key_id, is_ca) 
@@ -371,6 +380,14 @@ func MigrationTest_CA_20250908074250_add_profile_id(t *testing.T, logger *logrus
 	// Verify both profile IDs are assigned
 	assert.NotEmpty(t, ca1ProfileID, "First CA should have a profile ID assigned")
 	assert.NotEmpty(t, ca2ProfileID, "Second CA should have a profile ID assigned")
+
+	// Check that the CA with nil validity_time still gets a profile_id assigned (should not panic)
+	var caNilProfileID string
+	tx = con.Raw("SELECT profile_id FROM ca_certificates WHERE id = ?", "ca-nil-validity-time").Scan(&caNilProfileID)
+	if tx.Error != nil {
+		t.Fatalf("failed to get profile ID for CA with nil validity_time: %v", tx.Error)
+	}
+	assert.NotEmpty(t, caNilProfileID, "CA with nil validity_time should have a profile ID assigned (or at least not panic)")
 
 	// Both CAs should share the same profile since they have identical validity settings
 	assert.Equal(t, ca1ProfileID, ca2ProfileID, "Both CAs should reference the same profile ID since they have identical validity settings")


### PR DESCRIPTION
This pull request improves the robustness of the CA certificate migration by ensuring that certificates with a NULL `validity_time` are handled gracefully. It also adds comprehensive test coverage to verify this behavior during migration.

**Migration robustness improvements:**

* Updated the migration code in `add_profile_id.go` to safely handle cases where `validity_time` is NULL, preventing panics by checking for nil values before type assertion.

**Test coverage enhancements:**

* Added a test case in `ca_test.go` that inserts a CA certificate with a NULL `validity_time` and verifies that the migration does not panic and still assigns a `profile_id`. [[1]](diffhunk://#diff-c31198a41b6d18cab90da8de04c6806c3d98c9f234db593d000602b5a18daa6eR331-R339) [[2]](diffhunk://#diff-c31198a41b6d18cab90da8de04c6806c3d98c9f234db593d000602b5a18daa6eR384-R391)

Fixes #315