### PR TITLE
fix: devicemanager: normalize device certificate serial numbers

### DIFF
--- a/engines/storage/postgres/migrations/devicemanager/20250925120000_remove_serial_hyphens.go
+++ b/engines/storage/postgres/migrations/devicemanager/20250925120000_remove_serial_hyphens.go
@@ -1,0 +1,104 @@
+package devicemanager
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	mhelper "github.com/lamassuiot/lamassuiot/engines/storage/postgres/v3/migrations/helpers"
+	"github.com/pressly/goose/v3"
+)
+
+func Register20250925120000RemoveSerialHyphens() {
+	goose.AddMigrationContext(upRemoveSerialHyphens, downRemoveSerialHyphens)
+}
+
+func upRemoveSerialHyphens(ctx context.Context, tx *sql.Tx) error {
+	// Query all devices that have identity_slot data
+	rows, err := tx.QueryContext(ctx, "SELECT id, identity_slot FROM devices WHERE identity_slot IS NOT NULL AND identity_slot != ''")
+	if err != nil {
+		return err
+	}
+
+	result, err := mhelper.RowsToMap(rows)
+	if err != nil {
+		return err
+	}
+
+	for _, r := range result {
+		deviceID := r["id"].(string)
+		identitySlotStr := r["identity_slot"].(string)
+
+		updatedIdentitySlotStr, shouldUpdate, err := processIdentitySlot(deviceID, identitySlotStr)
+		if err != nil {
+			fmt.Printf("Warning: %v\n", err)
+			continue
+		}
+
+		if shouldUpdate {
+			_, err = tx.ExecContext(ctx, "UPDATE devices SET identity_slot = $1 WHERE id = $2", updatedIdentitySlotStr, deviceID)
+			if err != nil {
+				return fmt.Errorf("failed to update device %s: %v", deviceID, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// processIdentitySlot processes the identity_slot JSON, removes hyphens from serials, and returns the updated JSON string, a bool indicating if update is needed, and error if any.
+func processIdentitySlot(deviceID, identitySlotStr string) (string, bool, error) {
+	if identitySlotStr == "" {
+		return "", false, nil
+	}
+
+	var identitySlot map[string]any
+	if err := json.Unmarshal([]byte(identitySlotStr), &identitySlot); err != nil {
+		return "", false, fmt.Errorf("failed to unmarshal identity_slot JSON for device %s: %v", deviceID, err)
+	}
+
+	shouldUpdate := false
+	versions, ok := identitySlot["versions"]
+	if !ok {
+		return "", false, nil
+	}
+
+	versionsMap, ok := versions.(map[string]any)
+	if !ok {
+		return "", false, nil
+	}
+
+	for versionKey, serialNumber := range versionsMap {
+		serialStr, ok := serialNumber.(string)
+		if !ok {
+			continue
+		}
+		newSerial := strings.ToLower(strings.ReplaceAll(serialStr, "-", ""))
+		if newSerial != serialStr {
+			versionsMap[versionKey] = newSerial
+			shouldUpdate = true
+			fmt.Printf("Updating serial number for device %s, version %s: %s -> %s\n",
+				deviceID, versionKey, serialStr, newSerial)
+		}
+	}
+	identitySlot["versions"] = versionsMap
+
+	if shouldUpdate {
+		updatedIdentitySlotStr, err := json.Marshal(identitySlot)
+		if err != nil {
+			return "", false, fmt.Errorf("failed to marshal identity_slot JSON for device %s: %v", deviceID, err)
+		}
+		return string(updatedIdentitySlotStr), true, nil
+	}
+	return "", false, nil
+}
+
+func downRemoveSerialHyphens(ctx context.Context, tx *sql.Tx) error {
+	// This migration cannot be easily reversed since we don't know the original hyphen positions
+	// The down migration would require storing the original format or implementing logic to guess hyphen positions
+	// For now, we'll just log that this migration cannot be reversed
+	fmt.Println("Warning: Cannot reverse serial number hyphen removal migration. Original hyphen positions are lost.")
+	return nil
+}

--- a/engines/storage/postgres/migrations/gomigrations.go
+++ b/engines/storage/postgres/migrations/gomigrations.go
@@ -2,6 +2,7 @@ package migrations
 
 import (
 	"github.com/lamassuiot/lamassuiot/engines/storage/postgres/v3/migrations/ca"
+	"github.com/lamassuiot/lamassuiot/engines/storage/postgres/v3/migrations/devicemanager"
 	"github.com/lamassuiot/lamassuiot/engines/storage/postgres/v3/migrations/dmsmanager"
 )
 
@@ -13,6 +14,8 @@ func RegisterGoMigrations(dbname string) {
 		ca.Register20250226114600CaAddKids()
 		ca.Register20250908074250AddProfileId()
 		ca.Register20250915090500UpdateSkiAki()
+	case "devicemanager":
+		devicemanager.Register20250925120000RemoveSerialHyphens()
 	case "dmsmanager":
 		dmsmanager.Register20241230124809ServerkeygenRevokereenroll()
 		dmsmanager.Register20250612100530ESTVerifyCSRSignature()

--- a/engines/storage/postgres/migrations/helpers/rows_iterator.go
+++ b/engines/storage/postgres/migrations/helpers/rows_iterator.go
@@ -6,21 +6,21 @@ import (
 	"log"
 )
 
-func RowsToMap(rows *sql.Rows) ([]map[string]interface{}, error) {
+func RowsToMap(rows *sql.Rows) ([]map[string]any, error) {
 	// Fetch column names
 	columns, err := rows.Columns()
 	if err != nil {
 		log.Fatalf("Failed to fetch column names: %v", err)
 	}
 
-	result := make([]map[string]interface{}, 0)
+	result := make([]map[string]any, 0)
 
 	// Iterate over the rows
 	for rows.Next() {
 		// Create a slice of interface{} to hold values for each column
-		values := make([]interface{}, len(columns))
+		values := make([]any, len(columns))
 		// Create a slice of pointers to hold references to the values
-		valuePtrs := make([]interface{}, len(columns))
+		valuePtrs := make([]any, len(columns))
 		for i := range values {
 			valuePtrs[i] = &values[i]
 		}
@@ -31,7 +31,7 @@ func RowsToMap(rows *sql.Rows) ([]map[string]interface{}, error) {
 		}
 
 		// Create a map to store column name and value
-		rowMap := make(map[string]interface{})
+		rowMap := make(map[string]any)
 		for i, col := range columns {
 			val := values[i]
 

--- a/engines/storage/postgres/migrations_test/devicemanager_test.go
+++ b/engines/storage/postgres/migrations_test/devicemanager_test.go
@@ -1,0 +1,216 @@
+package migrationstest
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/config"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/helpers"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+)
+
+var DeviceManagerDBName = "devicemanager"
+
+func MigrationTest_DeviceManager_00000000000001_create_table(t *testing.T, logger *logrus.Entry, con *gorm.DB) {
+	ApplyMigration(t, logger, con, DeviceManagerDBName)
+
+	// Insert test device data
+	con.Exec(`INSERT INTO devices
+		(id, tags, status, icon, icon_color, creation_timestamp, metadata, dms_owner, identity_slot, extra_slots, events)
+		VALUES('test-device-1', '{}', 'ACTIVE', 'device', '#FF0000', '2024-11-25 11:45:48.620', '{}', 'test-dms', '{}', '{}', '{}');
+	`)
+
+	var result map[string]any
+	tx := con.Raw("SELECT * FROM devices WHERE id = 'test-device-1'").Scan(&result)
+	if tx.RowsAffected != 1 {
+		t.Fatalf("expected 1 row, got %d", tx.RowsAffected)
+	}
+
+	assert.Equal(t, "test-device-1", result["id"])
+	assert.Equal(t, "ACTIVE", result["status"])
+	assert.Equal(t, "test-dms", result["dms_owner"])
+}
+
+func MigrationTest_DeviceManager_20250925120000_remove_serial_hyphens(t *testing.T, logger *logrus.Entry, con *gorm.DB) {
+	// Clean the table first to avoid counting the test device from the previous test
+	CleanAllTables(t, logger, con)
+
+	// Test data with various scenarios
+	testCases := []struct {
+		name                 string
+		deviceID             string
+		inputIdentitySlot    string
+		expectedIdentitySlot string
+		shouldUpdate         bool
+	}{
+		{
+			name:     "Device with hyphenated serial numbers",
+			deviceID: "device-with-hyphens",
+			inputIdentitySlot: `{
+				"status": "EXPIRED",
+				"active_version": 2,
+				"type": "x509",
+				"versions": {
+					"0": "02-F4-D5-4B-50-BF-26-BA-75-27-68-20-55-51-A9-25",
+					"1": "42-BD-E9-FC-7A-CC-25-20-EB-91-3E-DE-21-50-F4-1D",
+					"2": "77-70-B4-07-8C-A0-4C-52-EE-0B-37-DE-98-22-95-7B"
+				},
+				"events": {}
+			}`,
+			expectedIdentitySlot: `{
+				"status": "EXPIRED",
+				"active_version": 2,
+				"type": "x509",
+				"versions": {
+					"0": "02f4d54b50bf26ba752768205551a925",
+					"1": "42bde9fc7acc2520eb913ede2150f41d",
+					"2": "7770b4078ca04c52ee0b37de9822957b"
+				},
+				"events": {}
+			}`,
+			shouldUpdate: true,
+		},
+		{
+			name:     "Device with already clean serial numbers",
+			deviceID: "device-clean-serials",
+			inputIdentitySlot: `{
+				"status": "ACTIVE",
+				"active_version": 1,
+				"type": "x509",
+				"versions": {
+					"0": "02f4d54b50bf26ba75276820555a925",
+					"1": "42bde9fc7acc2520eb913ede2150f41d"
+				},
+				"events": {}
+			}`,
+			expectedIdentitySlot: `{
+				"status": "ACTIVE",
+				"active_version": 1,
+				"type": "x509",
+				"versions": {
+					"0": "02f4d54b50bf26ba75276820555a925",
+					"1": "42bde9fc7acc2520eb913ede2150f41d"
+				},
+				"events": {}
+			}`,
+			shouldUpdate: false,
+		},
+		{
+			name:     "Device with mixed case and hyphens",
+			deviceID: "device-mixed-case",
+			inputIdentitySlot: `{
+				"status": "ACTIVE",
+				"active_version": 0,
+				"type": "x509",
+				"versions": {
+					"0": "aa-BB-CC-DD-EE-ff-11-22-33-44-55-66-77-88-99-00"
+				},
+				"events": {}
+			}`,
+			expectedIdentitySlot: `{
+				"status": "ACTIVE",
+				"active_version": 0,
+				"type": "x509",
+				"versions": {
+					"0": "aabbccddeeff11223344556677889900"
+				},
+				"events": {}
+			}`,
+			shouldUpdate: true,
+		},
+		{
+			name:     "Device with empty versions",
+			deviceID: "device-empty-versions",
+			inputIdentitySlot: `{
+				"status": "INACTIVE",
+				"active_version": null,
+				"type": "x509",
+				"versions": {},
+				"events": {}
+			}`,
+			expectedIdentitySlot: `{
+				"status": "INACTIVE",
+				"active_version": null,
+				"type": "x509",
+				"versions": {},
+				"events": {}
+			}`,
+			shouldUpdate: false,
+		},
+		{
+			name:                 "Device with null identity_slot",
+			deviceID:             "device-null-identity",
+			inputIdentitySlot:    "",
+			expectedIdentitySlot: "",
+			shouldUpdate:         false,
+		},
+	}
+
+	// Insert test devices before migration
+	for _, tc := range testCases {
+		identitySlot := tc.inputIdentitySlot
+		if identitySlot == "" {
+			identitySlot = "NULL"
+		} else {
+			identitySlot = "'" + identitySlot + "'"
+		}
+
+		query := `INSERT INTO devices
+			(id, tags, status, icon, icon_color, creation_timestamp, metadata, dms_owner, identity_slot, extra_slots, events)
+			VALUES(?, '{}', 'ACTIVE', 'device', '#FF0000', '2024-11-25 11:45:48.620', '{}', 'test-dms', ` + identitySlot + `, '{}', '{}');`
+
+		con.Exec(query, tc.deviceID)
+	}
+
+	// Apply the migration
+	ApplyMigration(t, logger, con, DeviceManagerDBName)
+
+	// Verify the results
+	for _, tc := range testCases {
+		var actualIdentitySlot *string
+		tx := con.Raw("SELECT identity_slot FROM devices WHERE id = ?", tc.deviceID).Scan(&actualIdentitySlot)
+		if tx.Error != nil {
+			t.Fatalf("failed to select device %s: %v", tc.deviceID, tx.Error)
+		}
+
+		if tc.expectedIdentitySlot == "" {
+			// Expect NULL
+			assert.Nil(t, actualIdentitySlot, "Device %s should have NULL identity_slot", tc.name)
+		} else {
+			// Expect JSON content - compare by unmarshaling both to avoid whitespace/ordering issues
+			assert.NotNil(t, actualIdentitySlot, "Device %s should have non-NULL identity_slot", tc.name)
+
+			var expectedJSON, actualJSON map[string]any
+			err := json.Unmarshal([]byte(tc.expectedIdentitySlot), &expectedJSON)
+			assert.NoError(t, err, "Expected JSON should be valid for %s", tc.name)
+
+			err = json.Unmarshal([]byte(*actualIdentitySlot), &actualJSON)
+			assert.NoError(t, err, "Actual JSON should be valid for %s", tc.name)
+
+			assert.Equal(t, expectedJSON, actualJSON, "Identity slot JSON should match for %s", tc.name)
+		}
+	}
+
+	// Verify total number of devices
+	var count int64
+	con.Model(&struct{}{}).Table("devices").Count(&count)
+	assert.Equal(t, int64(len(testCases)), count, "Should have the expected number of devices")
+}
+
+func TestDeviceManagerMigrations(t *testing.T) {
+	logger := helpers.SetupLogger(config.Trace, "test", "test")
+	cleanup, con := RunDB(t, logger, DeviceManagerDBName)
+	defer cleanup()
+
+	MigrationTest_DeviceManager_00000000000001_create_table(t, logger, con)
+	if t.Failed() {
+		t.Fatalf("failed while running migration v00000000000001_create_table")
+	}
+
+	MigrationTest_DeviceManager_20250925120000_remove_serial_hyphens(t, logger, con)
+	if t.Failed() {
+		t.Fatalf("failed while running migration v20250925120000_remove_serial_hyphens")
+	}
+}


### PR DESCRIPTION
This PR addresses inconsistencies in device certificate serial number formatting by implementing a database migration that standardizes all serial numbers to lowercase, hyphen-free format across the device manager's `identity_slot` JSON data.

### Problem

Device certificate serial numbers were stored in an inconsistent format (with hyphens) within the `identity_slot` JSON column: `02-f4-d5-4b-50-bf-26-ba-75-27-68-20-55-51-a9-25`

### Solution
**Database Migration**

- **File**: `20250925120000_remove_serial_hyphens.go`
- **Target**: `devices` table's `identity_slot` JSON column
- **Transformations**:
   - Remove all hyphens from serial numbers
   - Convert all serial numbers to lowercase
   - Preserve all other JSON fields unchanged

**Example transformation**

``` go
// Before
{
  "versions": {
     "0": "02-f4-d5-4b-50-bf-26-ba-75-27-68-20-55-51-a9-25",
     "1": "42-bd-e9-fc-7a-cc-25-20-eb-91-3e-de-21-50-f4-1d",
     "2": "77-70-b4-07-8c-a0-4c-52-ee-0b-37-de-98-22-95-7b"
  }
}

// After  
{
  "versions": {
    "0": "02f4d54b50bf26ba752768205551a925",
    "1": "42bde9fc7acc2520eb913ede2150f41d", 
    "2": "7770b4078ca04c52ee0b37de9822957b"
  }
}
```

Closes #314 
