### PR TITLE
fix: fixed support for dedicated DLQ event bus configuration across services

### DIFF
--- a/backend/pkg/assemblers/alerts.go
+++ b/backend/pkg/assemblers/alerts.go
@@ -54,7 +54,12 @@ func AssembleAlertsService(conf config.AlertsConfig) (*services.AlertsService, e
 		SmtpServerConfig: conf.SMTPConfig,
 	})
 
-	if conf.SubscriberEventBus.Enabled {
+	if conf.SubscriberEventBus.Enabled && !conf.SubscriberDLQEventBus.Enabled {
+		lMessaging := helpers.SetupLogger(conf.SubscriberEventBus.LogLevel, "Device Manager", "Event Bus")
+		lMessaging.Fatalf("Subscriber Event Bus is enabled but DLQ is not enabled. This is not supported. Exiting")
+	}
+
+	if conf.SubscriberEventBus.Enabled && conf.SubscriberDLQEventBus.Enabled {
 		log.Infof("Event Bus is enabled")
 
 		dlqPublisher, err := eventbus.NewEventBusPublisher(conf.SubscriberDLQEventBus, "alerts", lMessaging)

--- a/backend/pkg/assemblers/alerts.go
+++ b/backend/pkg/assemblers/alerts.go
@@ -55,7 +55,6 @@ func AssembleAlertsService(conf config.AlertsConfig) (*services.AlertsService, e
 	})
 
 	if conf.SubscriberEventBus.Enabled && !conf.SubscriberDLQEventBus.Enabled {
-		lMessaging := helpers.SetupLogger(conf.SubscriberEventBus.LogLevel, "Device Manager", "Event Bus")
 		lMessaging.Fatalf("Subscriber Event Bus is enabled but DLQ is not enabled. This is not supported. Exiting")
 	}
 

--- a/backend/pkg/assemblers/alerts.go
+++ b/backend/pkg/assemblers/alerts.go
@@ -57,7 +57,7 @@ func AssembleAlertsService(conf config.AlertsConfig) (*services.AlertsService, e
 	if conf.SubscriberEventBus.Enabled {
 		log.Infof("Event Bus is enabled")
 
-		dlqPublisher, err := eventbus.NewEventBusPublisher(conf.SubscriberEventBus, "alerts", lMessaging)
+		dlqPublisher, err := eventbus.NewEventBusPublisher(conf.SubscriberDLQEventBus, "alerts", lMessaging)
 		if err != nil {
 			return nil, fmt.Errorf("could not create Event Bus publisher: %s", err)
 		}

--- a/backend/pkg/assemblers/device-manager.go
+++ b/backend/pkg/assemblers/device-manager.go
@@ -76,7 +76,6 @@ func AssembleDeviceManagerService(conf config.DeviceManagerConfig, caService ser
 	}
 
 	if conf.SubscriberEventBus.Enabled && !conf.SubscriberDLQEventBus.Enabled {
-		lMessaging := helpers.SetupLogger(conf.SubscriberEventBus.LogLevel, "Device Manager", "Event Bus")
 		lMessaging.Fatalf("Subscriber Event Bus is enabled but DLQ is not enabled. This is not supported. Exiting")
 	}
 

--- a/backend/pkg/assemblers/device-manager.go
+++ b/backend/pkg/assemblers/device-manager.go
@@ -76,7 +76,7 @@ func AssembleDeviceManagerService(conf config.DeviceManagerConfig, caService ser
 	}
 
 	if conf.SubscriberEventBus.Enabled {
-		dlqPublisher, err := eventbus.NewEventBusPublisher(conf.SubscriberEventBus, serviceID, lMessaging)
+		dlqPublisher, err := eventbus.NewEventBusPublisher(conf.SubscriberDLQEventBus, serviceID, lMessaging)
 		if err != nil {
 			return nil, fmt.Errorf("could not create Event Bus publisher: %s", err)
 		}

--- a/backend/pkg/assemblers/device-manager.go
+++ b/backend/pkg/assemblers/device-manager.go
@@ -75,7 +75,12 @@ func AssembleDeviceManagerService(conf config.DeviceManagerConfig, caService ser
 		deviceSvc.SetService(svc)
 	}
 
-	if conf.SubscriberEventBus.Enabled {
+	if conf.SubscriberEventBus.Enabled && !conf.SubscriberDLQEventBus.Enabled {
+		lMessaging := helpers.SetupLogger(conf.SubscriberEventBus.LogLevel, "Device Manager", "Event Bus")
+		lMessaging.Fatalf("Subscriber Event Bus is enabled but DLQ is not enabled. This is not supported. Exiting")
+	}
+
+	if conf.SubscriberEventBus.Enabled && conf.SubscriberDLQEventBus.Enabled {
 		dlqPublisher, err := eventbus.NewEventBusPublisher(conf.SubscriberDLQEventBus, serviceID, lMessaging)
 		if err != nil {
 			return nil, fmt.Errorf("could not create Event Bus publisher: %s", err)

--- a/backend/pkg/assemblers/service-assembler_test.go
+++ b/backend/pkg/assemblers/service-assembler_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/elliptic"
 	"crypto/tls"
 	"fmt"
-	"maps"
 	"net/http"
 	"os"
 	"slices"
@@ -688,12 +687,19 @@ func SleepRetry(retry int, sleep time.Duration, f func() error) error {
 }
 
 func getDlqEventBusConfig(conf cconfig.EventBusEngine) cconfig.EventBusEngine {
-	conf2 := conf
+	dlqEventBus := conf
+	dlqEventBus.Config = deepCopy(conf.Config)
+	dlqEventBus.Config["exchange"] = "lamassu-dlq"
+	return dlqEventBus
+}
 
-	if conf2.Config != nil {
-		maps.Copy(conf2.Config, conf.Config)
-		conf2.Config["exchange"] = "lamassu-dlq"
+func deepCopy(src map[string]interface{}) map[string]interface{} {
+	if src == nil {
+		return nil
 	}
-
-	return conf2
+	dst := make(map[string]interface{}, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
 }

--- a/backend/pkg/assemblers/service-assembler_test.go
+++ b/backend/pkg/assemblers/service-assembler_test.go
@@ -690,7 +690,10 @@ func SleepRetry(retry int, sleep time.Duration, f func() error) error {
 func getDlqEventBusConfig(conf cconfig.EventBusEngine) cconfig.EventBusEngine {
 	conf2 := conf
 
-	maps.Copy(conf2.Config, conf.Config)
-	conf2.Config["exchange"] = "lamassu-dlq"
+	if conf2.Config != nil {
+		maps.Copy(conf2.Config, conf.Config)
+		conf2.Config["exchange"] = "lamassu-dlq"
+	}
+
 	return conf2
 }

--- a/backend/pkg/assemblers/service-assembler_test.go
+++ b/backend/pkg/assemblers/service-assembler_test.go
@@ -688,8 +688,11 @@ func SleepRetry(retry int, sleep time.Duration, f func() error) error {
 
 func getDlqEventBusConfig(conf cconfig.EventBusEngine) cconfig.EventBusEngine {
 	dlqEventBus := conf
-	dlqEventBus.Config = deepCopy(conf.Config)
-	dlqEventBus.Config["exchange"] = "lamassu-dlq"
+	if conf.Config != nil {
+		dlqEventBus.Config = deepCopy(conf.Config)
+		dlqEventBus.Config["exchange"] = "lamassu-dlq"
+	}
+
 	return dlqEventBus
 }
 

--- a/backend/pkg/assemblers/va.go
+++ b/backend/pkg/assemblers/va.go
@@ -127,7 +127,7 @@ func createSubscriberEventBus(conf config.VAconfig, crlSvc *beService.CRLService
 	lMessaging := helpers.SetupLogger(conf.SubscriberEventBus.LogLevel, "VA", "Event Bus")
 	lMessaging.Infof("Subscriber Event Bus is enabled")
 
-	dlqPublisher, err := eventbus.NewEventBusPublisher(conf.SubscriberEventBus, serviceID, lMessaging)
+	dlqPublisher, err := eventbus.NewEventBusPublisher(conf.SubscriberDLQEventBus, serviceID, lMessaging)
 	if err != nil {
 		return fmt.Errorf("could not create Event Bus publisher: %s", err)
 	}

--- a/backend/pkg/assemblers/va.go
+++ b/backend/pkg/assemblers/va.go
@@ -127,7 +127,6 @@ func createSubscriberEventBus(conf config.VAconfig, crlSvc *beService.CRLService
 	lMessaging := helpers.SetupLogger(conf.SubscriberEventBus.LogLevel, "VA", "Event Bus")
 
 	if conf.SubscriberEventBus.Enabled && !conf.SubscriberDLQEventBus.Enabled {
-		lMessaging := helpers.SetupLogger(conf.SubscriberEventBus.LogLevel, "Device Manager", "Event Bus")
 		lMessaging.Fatalf("Subscriber Event Bus is enabled but DLQ is not enabled. This is not supported. Exiting")
 	}
 

--- a/backend/pkg/config/alerts.go
+++ b/backend/pkg/config/alerts.go
@@ -3,11 +3,12 @@ package config
 import cconfig "github.com/lamassuiot/lamassuiot/core/v3/pkg/config"
 
 type AlertsConfig struct {
-	Logs               cconfig.Logging                `mapstructure:"logs"`
-	Server             cconfig.HttpServer             `mapstructure:"server"`
-	SubscriberEventBus cconfig.EventBusEngine         `mapstructure:"subscriber_event_bus"`
-	Storage            cconfig.PluggableStorageEngine `mapstructure:"storage"`
-	SMTPConfig         SMTPServer                     `mapstructure:"smtp_server"`
+	Logs                  cconfig.Logging                `mapstructure:"logs"`
+	Server                cconfig.HttpServer             `mapstructure:"server"`
+	SubscriberEventBus    cconfig.EventBusEngine         `mapstructure:"subscriber_event_bus"`
+	SubscriberDLQEventBus cconfig.EventBusEngine         `mapstructure:"subscriber_dlq_event_bus"`
+	Storage               cconfig.PluggableStorageEngine `mapstructure:"storage"`
+	SMTPConfig            SMTPServer                     `mapstructure:"smtp_server"`
 }
 
 type SMTPServer struct {

--- a/backend/pkg/config/devicemanger.go
+++ b/backend/pkg/config/devicemanger.go
@@ -3,12 +3,13 @@ package config
 import cconfig "github.com/lamassuiot/lamassuiot/core/v3/pkg/config"
 
 type DeviceManagerConfig struct {
-	Logs               cconfig.Logging                `mapstructure:"logs"`
-	Server             cconfig.HttpServer             `mapstructure:"server"`
-	PublisherEventBus  cconfig.EventBusEngine         `mapstructure:"publisher_event_bus"`
-	SubscriberEventBus cconfig.EventBusEngine         `mapstructure:"subscriber_event_bus"`
-	Storage            cconfig.PluggableStorageEngine `mapstructure:"storage"`
-	CAClient           struct {
+	Logs                  cconfig.Logging                `mapstructure:"logs"`
+	Server                cconfig.HttpServer             `mapstructure:"server"`
+	PublisherEventBus     cconfig.EventBusEngine         `mapstructure:"publisher_event_bus"`
+	SubscriberEventBus    cconfig.EventBusEngine         `mapstructure:"subscriber_event_bus"`
+	SubscriberDLQEventBus cconfig.EventBusEngine         `mapstructure:"subscriber_dlq_event_bus"`
+	Storage               cconfig.PluggableStorageEngine `mapstructure:"storage"`
+	CAClient              struct {
 		cconfig.HTTPClient `mapstructure:",squash"`
 	} `mapstructure:"ca_client"`
 }

--- a/backend/pkg/config/va.go
+++ b/backend/pkg/config/va.go
@@ -3,15 +3,16 @@ package config
 import cconfig "github.com/lamassuiot/lamassuiot/core/v3/pkg/config"
 
 type VAconfig struct {
-	Logs               cconfig.Logging                `mapstructure:"logs"`
-	Server             cconfig.HttpServer             `mapstructure:"server"`
-	SubscriberEventBus cconfig.EventBusEngine         `mapstructure:"subscriber_event_bus"`
-	PublisherEventBus  cconfig.EventBusEngine         `mapstructure:"publisher_event_bus"`
-	Storage            cconfig.PluggableStorageEngine `mapstructure:"storage"`
-	FilesystemStorage  cconfig.FSStorageConfig        `mapstructure:"filesystem_storage"`
-	CRLMonitoringJob   cconfig.MonitoringJob          `mapstructure:"crl_monitoring_job"`
-	CAClient           CAClient                       `mapstructure:"ca_client"`
-	VADomains          []string                       `mapstructure:"va_domains"`
+	Logs                  cconfig.Logging                `mapstructure:"logs"`
+	Server                cconfig.HttpServer             `mapstructure:"server"`
+	SubscriberEventBus    cconfig.EventBusEngine         `mapstructure:"subscriber_event_bus"`
+	SubscriberDLQEventBus cconfig.EventBusEngine         `mapstructure:"subscriber_dlq_event_bus"`
+	PublisherEventBus     cconfig.EventBusEngine         `mapstructure:"publisher_event_bus"`
+	Storage               cconfig.PluggableStorageEngine `mapstructure:"storage"`
+	FilesystemStorage     cconfig.FSStorageConfig        `mapstructure:"filesystem_storage"`
+	CRLMonitoringJob      cconfig.MonitoringJob          `mapstructure:"crl_monitoring_job"`
+	CAClient              CAClient                       `mapstructure:"ca_client"`
+	VADomains             []string                       `mapstructure:"va_domains"`
 }
 
 type CAClient struct {

--- a/backend/pkg/eventbus/pubsub.go
+++ b/backend/pkg/eventbus/pubsub.go
@@ -20,7 +20,7 @@ func NewEventBusSubscriber(conf cconfig.EventBusEngine, serviceID string, logger
 func NewEventBusPublisher(conf cconfig.EventBusEngine, serviceID string, logger *logrus.Entry) (message.Publisher, error) {
 	engine, err := builder.BuildEventBusEngine(string(conf.Provider), conf.Config, serviceID, logger)
 	if err != nil {
-		logger.Errorf("could not generate Event Bus Subscriber: %s", err)
+		logger.Errorf("could not generate Event Bus Publisher: %s", err)
 		return nil, err
 	}
 

--- a/connectors/awsiot/pkg/assembler.go
+++ b/connectors/awsiot/pkg/assembler.go
@@ -38,7 +38,7 @@ func AssembleAWSIoTManagerService(conf ConnectorServiceConfig, caService service
 	serviceID := fmt.Sprintf("aws-connector-%s", strings.ReplaceAll(conf.ConnectorID, "aws.", "-"))
 	eventHandlers := NewAWSIoTEventHandler(lMessaging, awsConnectorSvc)
 
-	dlqPublisher, err := eventbus.NewEventBusPublisher(conf.SubscriberEventBus, serviceID, lMessaging)
+	dlqPublisher, err := eventbus.NewEventBusPublisher(conf.SubscriberDLQEventBus, serviceID, lMessaging)
 	if err != nil {
 		lMessaging.Errorf("could not generate Event Bus Publisher: %s", err)
 		return nil, err

--- a/connectors/awsiot/pkg/config.go
+++ b/connectors/awsiot/pkg/config.go
@@ -6,8 +6,9 @@ import (
 )
 
 type ConnectorServiceConfig struct {
-	Logs               cconfig.Logging        `mapstructure:"logs"`
-	SubscriberEventBus cconfig.EventBusEngine `mapstructure:"subscriber_event_bus"`
+	Logs                  cconfig.Logging        `mapstructure:"logs"`
+	SubscriberEventBus    cconfig.EventBusEngine `mapstructure:"subscriber_event_bus"`
+	SubscriberDLQEventBus cconfig.EventBusEngine `mapstructure:"subscriber_dlq_event_bus"`
 
 	DMSManagerClient struct {
 		cconfig.HTTPClient `mapstructure:",squash"`

--- a/core/pkg/engines/eventbus/messaging.go
+++ b/core/pkg/engines/eventbus/messaging.go
@@ -27,6 +27,7 @@ func NewMessageRouter(logger *logrus.Entry, dlqPub message.Publisher) (*message.
 
 	//mw are applied in order they are added. So the first one is the outermost one (recovery wraps all the others for example)
 	router.AddMiddleware(
+		// Recoverer handles panics from handlers.
 		middleware.Recoverer,
 
 		// Dead letter queue middleware will move messages that have been Nacked more than MaxRetries to a separate topic.
@@ -35,12 +36,8 @@ func NewMessageRouter(logger *logrus.Entry, dlqPub message.Publisher) (*message.
 		// CorrelationID will copy the correlation id from the incoming message's metadata to the produced messages
 		middleware.CorrelationID,
 
-		// Recoverer handles panics from handlers.
-		// In this case, it passes them as errors to the Retry middleware.
-		// deadLetterMw,
-
 		// The handler function is retried if it returns an error.
-		// After MaxRetries, the message is Nacked and it's up to the PubSub to resend it.
+		// After MaxRetries, it's up to the PubSub to resend it, marck as ACK or NACK.
 		middleware.Retry{
 			MaxRetries:      3,
 			InitialInterval: time.Second * 2,

--- a/core/pkg/engines/eventbus/messaging.go
+++ b/core/pkg/engines/eventbus/messaging.go
@@ -37,7 +37,7 @@ func NewMessageRouter(logger *logrus.Entry, dlqPub message.Publisher) (*message.
 		middleware.CorrelationID,
 
 		// The handler function is retried if it returns an error.
-		// After MaxRetries, it's up to the PubSub to resend it, marck as ACK or NACK.
+		// After MaxRetries, it's up to the PubSub to resend it, mark as ACK or NACK.
 		middleware.Retry{
 			MaxRetries:      3,
 			InitialInterval: time.Second * 2,

--- a/monolithic/cmd/development/main.go
+++ b/monolithic/cmd/development/main.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"maps"
 	"net/http"
 	"os"
 	"os/signal"
@@ -293,13 +292,13 @@ func main() {
 
 		eventBus = rabbitmqSubsystem.Config.(cconfig.EventBusEngine)
 		// make a copy for DLQ using deep copy
-		dlqEventBus = eventBus
-		maps.Copy(dlqEventBus.Config, eventBus.Config)
 
 		adminPort = (*rabbitmqSubsystem.Extra)["adminPort"].(int)
 		basicAuth := eventBus.Config["basic_auth"].(map[string]interface{})
 
-		dlqEventBus.Config["exchange"] = "lamassu-events-dlq"
+		dlqEventBus = eventBus
+		dlqEventBus.Config = deepCopy(eventBus.Config)
+		dlqEventBus.Config["exchange"] = "lamassu-dlq"
 
 		fmt.Printf(" 	-- rabbitmq UI port: %d\n", adminPort)
 		fmt.Printf(" 	-- rabbitmq amqp port: %d\n", eventBus.Config["port"].(int))
@@ -493,4 +492,15 @@ func printWColor(str string, fg, bg color.Attribute) {
 	color.Set(bg)
 	fmt.Println(str)
 	color.Unset()
+}
+
+func deepCopy(src map[string]interface{}) map[string]interface{} {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]interface{}, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
 }

--- a/monolithic/cmd/development/main.go
+++ b/monolithic/cmd/development/main.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"maps"
 	"net/http"
 	"os"
 	"os/signal"

--- a/monolithic/cmd/development/main.go
+++ b/monolithic/cmd/development/main.go
@@ -291,6 +291,9 @@ func main() {
 		}
 
 		eventBus = rabbitmqSubsystem.Config.(cconfig.EventBusEngine)
+		// make a copy for DLQ using deep copy
+		dlqEventBus = eventBus
+		maps.Copy(dlqEventBus.Config, eventBus.Config)
 
 		adminPort = (*rabbitmqSubsystem.Extra)["adminPort"].(int)
 		basicAuth := eventBus.Config["basic_auth"].(map[string]interface{})

--- a/monolithic/pkg/assembler.go
+++ b/monolithic/pkg/assembler.go
@@ -112,11 +112,12 @@ func RunMonolithicLamassuPKI(conf MonolithicConfig) (int, int, error) {
 					"storage_directory": conf.VAStorageDir,
 				},
 			},
-			CRLMonitoringJob:   conf.Monitoring,
-			SubscriberEventBus: conf.SubscriberEventBus,
-			PublisherEventBus:  conf.PublisherEventBus,
-			Storage:            conf.Storage,
-			VADomains:          vaDomains,
+			CRLMonitoringJob:      conf.Monitoring,
+			SubscriberEventBus:    conf.SubscriberEventBus,
+			SubscriberDLQEventBus: conf.SubscriberDLQEventBus,
+			PublisherEventBus:     conf.PublisherEventBus,
+			Storage:               conf.Storage,
+			VADomains:             vaDomains,
 		}, caSDKBuilder("VA", models.VASource), apiInfo)
 		if err != nil {
 			return -1, -1, fmt.Errorf("could not assemble VA Service: %s", err)
@@ -133,9 +134,10 @@ func RunMonolithicLamassuPKI(conf MonolithicConfig) (int, int, error) {
 				Port:               0,
 				Protocol:           cconfig.HTTP,
 			},
-			PublisherEventBus:  conf.PublisherEventBus,
-			SubscriberEventBus: conf.SubscriberEventBus,
-			Storage:            conf.Storage,
+			PublisherEventBus:     conf.PublisherEventBus,
+			SubscriberEventBus:    conf.SubscriberEventBus,
+			SubscriberDLQEventBus: conf.SubscriberDLQEventBus,
+			Storage:               conf.Storage,
 		}, caSDKBuilder("Device Manager", models.DeviceManagerSource), apiInfo)
 		if err != nil {
 			return -1, -1, fmt.Errorf("could not assemble Device Manager Service: %s", err)
@@ -207,8 +209,9 @@ func RunMonolithicLamassuPKI(conf MonolithicConfig) (int, int, error) {
 				Port:               0,
 				Protocol:           cconfig.HTTP,
 			},
-			SubscriberEventBus: conf.SubscriberEventBus,
-			Storage:            conf.Storage,
+			SubscriberEventBus:    conf.SubscriberEventBus,
+			SubscriberDLQEventBus: conf.SubscriberDLQEventBus,
+			Storage:               conf.Storage,
 		}, apiInfo)
 		if err != nil {
 			return -1, -1, fmt.Errorf("could not assemble Alerts Service: %s", err)

--- a/monolithic/pkg/assembler_awsiot.go
+++ b/monolithic/pkg/assembler_awsiot.go
@@ -14,9 +14,10 @@ func AssembleAWSIoT(conf MonolithicConfig, caSDKBuilder func(serviceID string, s
 		Logs: cconfig.Logging{
 			Level: conf.Logs.Level,
 		},
-		SubscriberEventBus: conf.SubscriberEventBus,
-		ConnectorID:        conf.AWSIoTManager.ConnectorID,
-		AWSSDKConfig:       conf.AWSIoTManager.AWSSDKConfig,
+		SubscriberEventBus:    conf.SubscriberEventBus,
+		SubscriberDLQEventBus: conf.SubscriberDLQEventBus,
+		ConnectorID:           conf.AWSIoTManager.ConnectorID,
+		AWSSDKConfig:          conf.AWSIoTManager.AWSSDKConfig,
 	}, caSDKBuilder("AWS IoT Connector", awsiotconnector.AWSIoTSource(conf.AWSIoTManager.ConnectorID)),
 		dmsMngrSDKBuilder("AWS IoT Connector", awsiotconnector.AWSIoTSource(conf.AWSIoTManager.ConnectorID)),
 		deviceMngrSDKBuilder("AWS IoT Connector", awsiotconnector.AWSIoTSource(conf.AWSIoTManager.ConnectorID)))

--- a/monolithic/pkg/config.go
+++ b/monolithic/pkg/config.go
@@ -16,19 +16,20 @@ const (
 )
 
 type MonolithicConfig struct {
-	Logs               cconfig.Logging                `mapstructure:"logs"`
-	PublisherEventBus  cconfig.EventBusEngine         `mapstructure:"publisher_event_bus"`
-	SubscriberEventBus cconfig.EventBusEngine         `mapstructure:"subscriber_event_bus"`
-	Storage            cconfig.PluggableStorageEngine `mapstructure:"storage"`
-	CryptoEngines      []cconfig.CryptoEngineConfig   `mapstructure:"crypto_engines"`
-	Monitoring         cconfig.MonitoringJob          `mapstructure:"monitoring"`
-	Domains            []string                       `mapstructure:"domains"`
-	AssemblyMode       LamassuMonolithicAssembleMode  `mapstructure:"assembly_mode"`
-	GatewayPortHttps   int                            `mapstructure:"gateway_port_https"`
-	GatewayPortHttp    int                            `mapstructure:"gateway_port_http"`
-	AWSIoTManager      MonolithicAWSIoTManagerConfig  `mapstructure:"aws_iot_manager"`
-	VAStorageDir       string                         `mapstructure:"va_storage_directory"`
-	UIPort             int                            `mapstructure:"ui_port"`
+	Logs                  cconfig.Logging                `mapstructure:"logs"`
+	PublisherEventBus     cconfig.EventBusEngine         `mapstructure:"publisher_event_bus"`
+	SubscriberEventBus    cconfig.EventBusEngine         `mapstructure:"subscriber_event_bus"`
+	SubscriberDLQEventBus cconfig.EventBusEngine         `mapstructure:"subscriber_dlq_event_bus"`
+	Storage               cconfig.PluggableStorageEngine `mapstructure:"storage"`
+	CryptoEngines         []cconfig.CryptoEngineConfig   `mapstructure:"crypto_engines"`
+	Monitoring            cconfig.MonitoringJob          `mapstructure:"monitoring"`
+	Domains               []string                       `mapstructure:"domains"`
+	AssemblyMode          LamassuMonolithicAssembleMode  `mapstructure:"assembly_mode"`
+	GatewayPortHttps      int                            `mapstructure:"gateway_port_https"`
+	GatewayPortHttp       int                            `mapstructure:"gateway_port_http"`
+	AWSIoTManager         MonolithicAWSIoTManagerConfig  `mapstructure:"aws_iot_manager"`
+	VAStorageDir          string                         `mapstructure:"va_storage_directory"`
+	UIPort                int                            `mapstructure:"ui_port"`
 }
 
 type MonolithicAWSIoTManagerConfig struct {


### PR DESCRIPTION
This pull request introduces support for configuring a separate Dead Letter Queue (DLQ) event bus for multiple services. The main changes involve updating configuration structs to include a new `SubscriberDLQEventBus` field and ensuring that DLQ publishers use this new configuration. Additionally, the development environment is updated to properly set up and use the DLQ event bus.

Configuration updates:

* Added a `SubscriberDLQEventBus` field of type `EventBusEngine` to the configuration structs for `AlertsConfig`, `DeviceManagerConfig`, `VAconfig`, `ConnectorServiceConfig`, and `MonolithicConfig`, allowing each service to specify a dedicated DLQ event bus. [[1]](diffhunk://#diff-1cd4d349818e7a0e97edd3d131183461e564e1d92ae904974f40576c9c576f36R9) [[2]](diffhunk://#diff-b4ac2202482f22a916bc35b716c1d2b82fcb01e4142fbce140c44dde9ee6c1b0R10) [[3]](diffhunk://#diff-aa9877ecd095ad2ec93e3b98f4c5a6a25d3fd6d13a78ca82396f96f758ebe974R9) [[4]](diffhunk://#diff-ef97ad39c901a56d3669863cd39cd4d440e29bd8468796843939e8d98028338eR11) [[5]](diffhunk://#diff-f3459c9a51d29a6d42e3a30ed28efd40375f9e3c0981b9d598aee9be8e1b28f8R22)

DLQ publisher usage:

* Updated service assembler functions (`AssembleAlertsService`, `AssembleDeviceManagerService`, `createSubscriberEventBus`, `AssembleAWSIoTManagerService`) to use `SubscriberDLQEventBus` instead of `SubscriberEventBus` when creating DLQ publishers, ensuring messages are routed to the correct DLQ. [[1]](diffhunk://#diff-e0488f21e2d46e56fa26c644921d4dbb4c5321e466fb3c37f2e6c31e98e9b864L60-R60) [[2]](diffhunk://#diff-9ba6840212bfa0dec6d05be4b7cbad7b8e17cf25620dc8f41e104c7cf8e384e9L79-R79) [[3]](diffhunk://#diff-8fe0cfe52a16a3428bd5e2d7acc13d21907c0208a6c3195e4942df5de462af8cL130-R130) [[4]](diffhunk://#diff-4a2aed18ccdd0b397ad4959ac279e843e333c53aaf19aefb57369bb52d3d9e81L41-R41)

Development environment enhancements:

* Modified the monolithic development setup to create and configure a separate DLQ event bus (`dlqEventBus`), including setting its exchange to `lamassu-events-dlq` and passing it to service configs. [[1]](diffhunk://#diff-2986ca8d4d81d984e49859ed7ae335a6effcb228c4f419dfa2362f7dff0e607dR284-R285) [[2]](diffhunk://#diff-2986ca8d4d81d984e49859ed7ae335a6effcb228c4f419dfa2362f7dff0e607dR298-R299) [[3]](diffhunk://#diff-2986ca8d4d81d984e49859ed7ae335a6effcb228c4f419dfa2362f7dff0e607dR410)

Event bus middleware clarification:

* Improved comments and ordering in the event bus message router middleware to clarify the role of the `Recoverer` and retry logic for message handling. [[1]](diffhunk://#diff-81e9b1a4692eb0f1d35d22c50e758c1fa11e4116e430b312e30c6fe3e2fe4aedR30) [[2]](diffhunk://#diff-81e9b1a4692eb0f1d35d22c50e758c1fa11e4116e430b312e30c6fe3e2fe4aedL38-R40)