### PR TITLE
feat: add support to filter certs by subject_key_id

### DIFF
--- a/backend/pkg/assemblers/ca_certificates_test.go
+++ b/backend/pkg/assemblers/ca_certificates_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/errs"
 	chelpers "github.com/lamassuiot/lamassuiot/core/v3/pkg/helpers"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/resources"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/services"
 )
 
@@ -302,4 +303,78 @@ func createCAAndCertificate(caSDK services.CAService) (*models.CACertificate, *m
 	}
 
 	return ca, cert, nil
+}
+
+func TestGetCertificatesFilterBySubjectKeyID(t *testing.T) {
+	serverTest, err := TestServiceBuilder{}.WithDatabase("ca").Build(t)
+	if err != nil {
+		t.Fatalf("could not create CA test server: %s", err)
+	}
+
+	caTest := serverTest.CA
+
+	// Ensure clean DB and init CA
+	if err := serverTest.BeforeEach(); err != nil {
+		t.Fatalf("failed running BeforeEach: %s", err)
+	}
+	_, err = initCA(caTest.Service)
+	if err != nil {
+		t.Fatalf("failed to init CA: %s", err)
+	}
+
+	// Create two CAs and issue a certificate each (ensure SKIs differ)
+	_, cert1, err := createCAAndCertificate(caTest.Service)
+	if err != nil {
+		t.Fatalf("failed to create first CA and certificate: %s", err)
+	}
+
+	_, cert2, err := createCAAndCertificate(caTest.Service)
+	if err != nil {
+		t.Fatalf("failed to create second CA and certificate: %s", err)
+	}
+
+	if cert1.SubjectKeyID == cert2.SubjectKeyID {
+		t.Fatalf("expected different SKIs for the two test certificates, got equal: %s", cert1.SubjectKeyID)
+	}
+	if err != nil {
+		t.Fatalf("failed to create CA and certificate: %s", err)
+	}
+
+	// Query certificates filtering by subject_key_id
+	found := []*models.Certificate{}
+	qp := &resources.QueryParameters{
+		PageSize: 25,
+		Filters: []resources.FilterOption{
+			{
+				Field:           "subject_key_id",
+				Value:           cert1.SubjectKeyID,
+				FilterOperation: resources.StringEqual,
+			},
+		},
+	}
+
+	_, err = caTest.HttpCASDK.GetCertificates(context.Background(), services.GetCertificatesInput{
+		ListInput: resources.ListInput[models.Certificate]{
+			QueryParameters: qp,
+			ExhaustiveRun:   true,
+			ApplyFunc: func(elem models.Certificate) {
+				found = append(found, &elem)
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("GetCertificates returned error: %s", err)
+	}
+
+	if len(found) != 1 {
+		t.Fatalf("expected 1 certificate filtered by subject_key_id, got %d", len(found))
+	}
+
+	if found[0].SerialNumber != cert1.SerialNumber {
+		t.Fatalf("expected certificate serial %s, got %s", cert1.SerialNumber, found[0].SerialNumber)
+	}
+
+	if found[0].SubjectKeyID != cert1.SubjectKeyID {
+		t.Fatalf("expected subject_key_id %s, got %s", cert1.SubjectKeyID, found[0].SubjectKeyID)
+	}
 }

--- a/backend/pkg/controllers/utils_test.go
+++ b/backend/pkg/controllers/utils_test.go
@@ -1,0 +1,37 @@
+package controllers
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/resources"
+)
+
+func TestFilterQuery_SubjectKeyID(t *testing.T) {
+	req := &http.Request{}
+	req.URL = &url.URL{}
+	q := req.URL.Query()
+	q.Add("filter", "subject_key_id[eq]ABC123")
+	req.URL.RawQuery = q.Encode()
+
+	qp := FilterQuery(req, resources.CertificateFiltrableFields)
+	if qp == nil {
+		t.Fatalf("expected QueryParameters, got nil")
+	}
+
+	if len(qp.Filters) != 1 {
+		t.Fatalf("expected 1 filter, got %d", len(qp.Filters))
+	}
+
+	f := qp.Filters[0]
+	if f.Field != "subject_key_id" {
+		t.Fatalf("expected field 'subject_key_id', got '%s'", f.Field)
+	}
+	if f.Value != "ABC123" {
+		t.Fatalf("expected value 'ABC123', got '%s'", f.Value)
+	}
+	if f.FilterOperation != resources.StringEqual {
+		t.Fatalf("expected operation StringEqual, got %v", f.FilterOperation)
+	}
+}

--- a/core/pkg/resources/fields.go
+++ b/core/pkg/resources/fields.go
@@ -18,6 +18,7 @@ var CertificateFiltrableFields = map[string]FilterFieldType{
 	"type":                 EnumFilterFieldType,
 	"serial_number":        StringFilterFieldType,
 	"subject.common_name":  StringFilterFieldType,
+	"subject_key_id":       StringFilterFieldType,
 	"issuer_meta.id":       StringFilterFieldType,
 	"status":               EnumFilterFieldType,
 	"engine_id":            StringFilterFieldType,


### PR DESCRIPTION
This pull request adds support for filtering certificates by their Subject Key ID (`subject_key_id`). The changes include updates to the certificate filtering logic, test coverage for this new filter, and validation of query parsing in controllers.

### Filtering enhancements

* Added `"subject_key_id"` as a supported filter field in the `CertificateFiltrableFields` map in `core/pkg/resources/fields.go`, enabling API clients to filter certificates by their Subject Key ID.

### Test coverage

* Added a new test `TestGetCertificatesFilterBySubjectKeyID` to `backend/pkg/assemblers/ca_certificates_test.go` that creates two certificates with different Subject Key IDs and verifies that filtering by `subject_key_id` returns the correct certificate.
* Imported the `resources` package in `backend/pkg/assemblers/ca_certificates_test.go` to support new filter logic in tests.
* Added a test `TestFilterQuery_SubjectKeyID` in `backend/pkg/controllers/utils_test.go` to verify that HTTP query parsing correctly recognizes and applies the `subject_key_id` filter.