### PR TITLE
Update test setup and correct field naming in certificate filtering logic

### DIFF
--- a/backend/pkg/assemblers/ca_certificates_test.go
+++ b/backend/pkg/assemblers/ca_certificates_test.go
@@ -306,7 +306,7 @@ func createCAAndCertificate(caSDK services.CAService) (*models.CACertificate, *m
 }
 
 func TestGetCertificatesFilterBySubjectKeyID(t *testing.T) {
-	serverTest, err := TestServiceBuilder{}.WithDatabase("ca").Build(t)
+	serverTest, err := TestServiceBuilder{}.WithDatabase("ca", "kms").Build(t)
 	if err != nil {
 		t.Fatalf("could not create CA test server: %s", err)
 	}

--- a/backend/pkg/controllers/utils_test.go
+++ b/backend/pkg/controllers/utils_test.go
@@ -15,7 +15,7 @@ func TestFilterQuery_SubjectKeyID(t *testing.T) {
 	q.Add("filter", "subject_key_id[eq]ABC123")
 	req.URL.RawQuery = q.Encode()
 
-	qp := FilterQuery(req, resources.CertificateFiltrableFields)
+	qp := FilterQuery(req, resources.CertificateFilterableFields)
 	if qp == nil {
 		t.Fatalf("expected QueryParameters, got nil")
 	}


### PR DESCRIPTION
This pull request introduces minor updates to test setup and naming consistency in the certificate filtering logic. The changes mainly ensure that tests use the correct database configuration and field naming.

Testing improvements:

* Updated test server initialization in `backend/pkg/assemblers/ca_certificates_test.go` to include the `kms` database, ensuring all dependencies are available for certificate-related tests.

Naming and consistency:

* Corrected the field name from `CertificateFiltrableFields` to `CertificateFilterableFields` in `backend/pkg/controllers/utils_test.go` for consistency and to prevent potential errors.