### PR TITLE
fix: DMS creation date filtering functionality

### DIFF
--- a/backend/pkg/controllers/utils_test.go
+++ b/backend/pkg/controllers/utils_test.go
@@ -35,3 +35,31 @@ func TestFilterQuery_SubjectKeyID(t *testing.T) {
 		t.Fatalf("expected operation StringEqual, got %v", f.FilterOperation)
 	}
 }
+
+func TestFilterQuery_DMSCreationDate(t *testing.T) {
+	req := &http.Request{}
+	req.URL = &url.URL{}
+	q := req.URL.Query()
+	q.Add("filter", "creation_date[after]2024-01-01T00:00:00Z")
+	req.URL.RawQuery = q.Encode()
+
+	qp := FilterQuery(req, resources.DMSFilterableFields)
+	if qp == nil {
+		t.Fatalf("expected QueryParameters, got nil")
+	}
+
+	if len(qp.Filters) != 1 {
+		t.Fatalf("expected 1 filter, got %d", len(qp.Filters))
+	}
+
+	f := qp.Filters[0]
+	if f.Field != "creation_date" {
+		t.Fatalf("expected field 'creation_date', got '%s'", f.Field)
+	}
+	if f.Value != "2024-01-01T00:00:00Z" {
+		t.Fatalf("expected value '2024-01-01T00:00:00Z', got '%s'", f.Value)
+	}
+	if f.FilterOperation != resources.DateAfter {
+		t.Fatalf("expected operation DateAfter, got %v", f.FilterOperation)
+	}
+}

--- a/core/pkg/resources/fields.go
+++ b/core/pkg/resources/fields.go
@@ -1,9 +1,9 @@
 package resources
 
 var DMSFilterableFields = map[string]FilterFieldType{
-	"id":          StringFilterFieldType,
-	"name":        StringFilterFieldType,
-	"creation_ts": DateFilterFieldType,
+	"id":            StringFilterFieldType,
+	"name":          StringFilterFieldType,
+	"creation_date": DateFilterFieldType,
 }
 
 var DeviceFilterableFields = map[string]FilterFieldType{


### PR DESCRIPTION
This pull request updates the filterable fields for DMS resources and adds a corresponding unit test to ensure correct filtering behavior. The main changes include renaming the filterable field for creation date and validating its filtering logic.

**Filterable fields update:**

* Renamed the filterable field from `creation_ts` to `creation_date` in the `DMSFilterableFields` map in `core/pkg/resources/fields.go`.

**Testing improvements:**

* Added a new unit test `TestFilterQuery_DMSCreationDate` in `backend/pkg/controllers/utils_test.go` to verify that filtering by `creation_date` using the `after` operation works as expected.