### PR TITLE
fix: remove key casting in kms module

### DIFF
--- a/backend/pkg/services/ca.go
+++ b/backend/pkg/services/ca.go
@@ -2328,13 +2328,6 @@ func (svc *CAServiceBackend) SignMessage(ctx context.Context, input services.Sig
 
 	var signature []byte
 	if setup.IsRSA {
-		rsaPriv, ok := setup.Signer.(*rsa.PrivateKey)
-		if !ok {
-			return nil, errors.New("key is not RSA key")
-		}
-		if rsaPriv == nil {
-			return nil, errors.New("RSA key is nil")
-		}
 		if digest == nil {
 			return nil, errors.New("digest is nil")
 		}
@@ -2353,13 +2346,6 @@ func (svc *CAServiceBackend) SignMessage(ctx context.Context, input services.Sig
 			}
 		}
 	} else {
-		ecdsaPriv, ok := setup.Signer.(*ecdsa.PrivateKey)
-		if !ok {
-			return nil, errors.New("key is not ECDSA key")
-		}
-		if ecdsaPriv == nil {
-			return nil, errors.New("ECDSA key is nil")
-		}
 		if digest == nil {
 			return nil, errors.New("digest is nil")
 		}


### PR DESCRIPTION
This pull request makes a minor change to the `SignMessage` method in `backend/pkg/services/ca.go`. The main update is the removal of redundant type and nil checks for RSA and ECDSA private keys, simplifying the code.

- Simplified private key handling by removing unnecessary type assertions and nil checks for both RSA and ECDSA keys in the `SignMessage` method (`backend/pkg/services/ca.go`). [[1]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L2331-L2337) [[2]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L2356-L2362)