### PR TITLE
fix: VA: Use certificate’s actual revocation timestamp in CRL calculation

### DIFF
--- a/backend/pkg/services/crl.go
+++ b/backend/pkg/services/crl.go
@@ -218,7 +218,7 @@ func (svc CRLServiceBackend) CalculateCRL(ctx context.Context, input services.Ca
 			ApplyFunc: func(cert models.Certificate) {
 				certList = append(certList, x509.RevocationListEntry{
 					SerialNumber:   cert.Certificate.SerialNumber,
-					RevocationTime: time.Now(),
+					RevocationTime: cert.RevocationTimestamp,
 					Extensions:     []pkix.Extension{},
 					ReasonCode:     int(cert.RevocationReason),
 				})


### PR DESCRIPTION
This pull request updates how the revocation time is set for certificates in the CRL calculation logic. Instead of using the current time, it now uses the certificate's actual revocation timestamp, ensuring more accurate tracking of when each certificate was revoked.

* CRL Calculation Logic: Changed `RevocationTime` in the `x509.RevocationListEntry` struct to use `cert.RevocationTimestamp` instead of `time.Now()`, ensuring the revocation time reflects the actual revocation event.