### PR TITLE
chore: Adjust test timeout in CI workflow

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -65,7 +65,7 @@ jobs:
         id: run
         working-directory: ${{ matrix.module.path }}
         run: |
-          go run gotest.tools/gotestsum@latest --format github-actions ./... -coverpkg=./... -timeout 900s -coverprofile coverage.txt -covermode=atomic
+          go run gotest.tools/gotestsum@latest --format github-actions ./... -coverpkg=./... -timeout 1200s -coverprofile coverage.txt -covermode=atomic
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5.1.2


### PR DESCRIPTION
This pull request makes a minor adjustment to the CI test workflow by increasing the test timeout. This helps prevent test runs from failing due to timeouts during longer executions.

* Increased the test timeout in the `.github/workflows/ci-test.yaml` workflow from 900 seconds to 1200 seconds to allow more time for test completion.