### PR TITLE
split tests

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -203,7 +203,7 @@ jobs:
         id: run
         working-directory: backend
         run: |
-          go run gotest.tools/gotestsum@latest --format github-actions $(go list ./... | grep -v '/pkg/assemblers/') -coverpkg=./... -timeout 300s -coverprofile coverage.txt -covermode=atomic
+          go run gotest.tools/gotestsum@latest --format github-actions -- $(go list ./... | grep -v '/pkg/assemblers$') -coverpkg=./... -timeout 300s -coverprofile coverage.txt -covermode=atomic
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5.1.2


### PR DESCRIPTION
This pull request updates the CI workflow configuration in `.github/workflows/ci-test.yaml` to improve test coverage reporting and optimize test execution for the `backend` module, especially its `assemblers` subpackage. The changes split backend tests into more granular jobs and reduce test timeouts for faster feedback.

**Backend test workflow improvements:**

* Introduced two new jobs: `setup-backend-assemblers` (to dynamically discover assembler test files and set up a test matrix) and `test-backend-assemblers` (to run each assembler test file in parallel, improving isolation and reporting granularity).
* Added a separate `test-backend-rest` job to run all other backend tests except for assemblers, ensuring clearer separation of test coverage and reporting.
* Removed the monolithic `backend` job from the main test matrix, replacing it with the new, more focused jobs for better scalability and maintainability.

**Test execution optimization:**

* Reduced the test timeout from 1200s to 300s for all jobs, speeding up CI feedback and preventing unnecessarily long test runs.

**Coverage reporting enhancements:**

* Updated all new jobs to upload coverage reports to Codecov with distinct flags for better traceability of coverage by test type.