### PR TITLE
fix: ca: remove sensitive info in audit events

### DIFF
--- a/backend/pkg/middlewares/audit/ca.go
+++ b/backend/pkg/middlewares/audit/ca.go
@@ -55,6 +55,8 @@ func (mw CAAuditEventPublisher) RequestCACSR(ctx context.Context, input services
 
 func (mw CAAuditEventPublisher) ImportCA(ctx context.Context, input services.ImportCAInput) (output *models.CACertificate, err error) {
 	defer func() {
+		input.CARSAKey = nil // Remove private key from audit logs
+		input.CAECKey = nil  // Remove private key from audit logs
 		mw.auditPub.HandleServiceOutputAndPublishAuditRecord(ctx, models.EventImportCAKey, input, err, output)
 	}()
 
@@ -242,6 +244,7 @@ func (mw CAAuditEventPublisher) VerifySignature(ctx context.Context, input servi
 
 func (mw CAAuditEventPublisher) ImportKey(ctx context.Context, input services.ImportKeyInput) (output *models.Key, err error) {
 	defer func() {
+		input.PrivateKey = nil // Remove private key from audit logs
 		mw.auditPub.HandleServiceOutputAndPublishAuditRecord(ctx, models.EventImportKMSKey, input, err, output)
 	}()
 


### PR DESCRIPTION
This pull request improves security and privacy in the audit logging process for certificate and key management operations. Specifically, it ensures that private key material is removed from audit logs before publishing audit records.

Security and audit logging improvements:

* In `ImportCA`, the `CARSAKey` and `CAECKey` fields are set to `nil` before publishing the audit record, preventing private CA keys from being logged. (`backend/pkg/middlewares/audit/ca.go`)
* In `ImportKey`, the `PrivateKey` field is set to `nil` before publishing the audit record, preventing private key material from being logged. (`backend/pkg/middlewares/audit/ca.go`)