### PR TITLE
fix: VA ski encoding in crl dp

### DIFF
--- a/backend/pkg/services/crl.go
+++ b/backend/pkg/services/crl.go
@@ -236,7 +236,7 @@ func (svc CRLServiceBackend) CalculateCRL(ctx context.Context, input services.Ca
 
 	extensions := []pkix.Extension{}
 
-	idp, err := svc.getDistributionPointExtension(string(crlCA.Certificate.Certificate.SubjectKeyId))
+	idp, err := svc.getDistributionPointExtension(string(crlCA.Certificate.SubjectKeyID))
 	if err != nil {
 		lFunc.Errorf("something went wrong while creating Issuing Distribution Point extension: %s", err)
 		return nil, err


### PR DESCRIPTION
This pull request makes a minor fix to the `CalculateCRL` method in `backend/pkg/services/crl.go`. The change corrects the field used to retrieve the subject key ID for the distribution point extension, ensuring that the correct value is passed to the `getDistributionPointExtension` function.

* Updated the call to `getDistributionPointExtension` to use `crlCA.Certificate.SubjectKeyID` instead of the incorrect `crlCA.Certificate.Certificate.SubjectKeyId` field.