### PR TITLE
Potential fix for code scanning alert no. 344: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release_finalize.yaml
+++ b/.github/workflows/release_finalize.yaml
@@ -8,6 +8,10 @@ on:
       - "CHANGELOG.md" # optional: run only when CHANGELOG.md changed
       - "RELEASE-NOTES.md" # optional: run only when RELEASE-NOTES.md changed
 
+# Default to least-privilege read-only access for GITHUB_TOKEN
+permissions:
+  contents: read
+
 env:
   RELEASE_VERSION: "" # Global variable to be set by extract_version job
 
@@ -56,6 +60,8 @@ jobs:
     name: Bump Module Versions
     needs: extract_version
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -138,6 +144,8 @@ jobs:
     name: Create Global Tag & Release
     needs: finalize
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/lamassuiot/lamassuiot/security/code-scanning/344](https://github.com/lamassuiot/lamassuiot/security/code-scanning/344)

In general, the fix is to add an explicit `permissions` block to the workflow (and/or to individual jobs) so that the `GITHUB_TOKEN` has only the minimal scopes required. Jobs that only read repository contents can use `permissions: contents: read`, while jobs that push commits, tags, or create releases additionally need `contents: write`. Since CodeQL specifically flags the `finalize` job, we should ensure that at least that job is given restricted permissions and that the workflow as a whole documents its intended token scopes.

The best way to fix this file without changing existing functionality is:

- Add a workflow-level `permissions` block near the top (after `name:` and before/after `on:` is fine) that sets the default to read-only: `permissions: contents: read`.
- Override that default in the jobs that require write access to the repo:
  - `bump_versions` pushes commits to `main`, so give it `permissions: contents: write`.
  - `create_global_release` tags and pushes as well as calls `actions/create-release@v1` and `actions/upload-release-asset@v1`. These generally require `contents: write` for tags and releases, and (depending on action implementation) `contents` is typically sufficient for creating releases and uploading assets. To be safe while still applying least privilege within `contents`, we can set `permissions: contents: write` for this job.

The `extract_version`, `finalize`, and any other jobs that only read code or print information can rely on the workflow-level `contents: read` default and do not need their own `permissions` blocks. This change is limited to `.github/workflows/release_finalize.yaml` and does not require any new imports or code logic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
