### PR TITLE
Device events v2

### DIFF
--- a/backend/pkg/assemblers/device-manager.go
+++ b/backend/pkg/assemblers/device-manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/lamassuiot/lamassuiot/backend/v3/pkg/config"
+	"github.com/lamassuiot/lamassuiot/backend/v3/pkg/controllers"
 	"github.com/lamassuiot/lamassuiot/backend/v3/pkg/eventbus"
 	"github.com/lamassuiot/lamassuiot/backend/v3/pkg/middlewares/eventpub"
 	"github.com/lamassuiot/lamassuiot/backend/v3/pkg/routes"
@@ -22,7 +23,7 @@ import (
 )
 
 func AssembleDeviceManagerServiceWithHTTPServer(conf config.DeviceManagerConfig, caService services.CAService, serviceInfo models.APIServiceInfo) (*services.DeviceManagerService, int, error) {
-	service, err := AssembleDeviceManagerService(conf, caService)
+	service, sseHub, err := AssembleDeviceManagerService(conf, caService)
 	if err != nil {
 		return nil, -1, fmt.Errorf("could not assemble Device Manager Service. Exiting: %s", err)
 	}
@@ -31,7 +32,11 @@ func AssembleDeviceManagerServiceWithHTTPServer(conf config.DeviceManagerConfig,
 
 	httpEngine := routes.NewGinEngine(lHttp)
 	httpGrp := httpEngine.Group("/")
-	routes.NewDeviceManagerHTTPLayer(httpGrp, *service)
+	if sseHub != nil {
+		routes.NewDeviceManagerHTTPLayerWithSSE(httpGrp, *service, sseHub)
+	} else {
+		routes.NewDeviceManagerHTTPLayer(httpGrp, *service)
+	}
 	port, err := routes.RunHttpRouter(lHttp, httpEngine, conf.Server, serviceInfo)
 	if err != nil {
 		return nil, -1, fmt.Errorf("could not run Device Manager http server: %s", err)
@@ -40,7 +45,7 @@ func AssembleDeviceManagerServiceWithHTTPServer(conf config.DeviceManagerConfig,
 	return service, port, nil
 }
 
-func AssembleDeviceManagerService(conf config.DeviceManagerConfig, caService services.CAService) (*services.DeviceManagerService, error) {
+func AssembleDeviceManagerService(conf config.DeviceManagerConfig, caService services.CAService) (*services.DeviceManagerService, *controllers.DeviceEventSSEHub, error) {
 	serviceID := "device-manager"
 	sdk.InitOtelSDK(context.Background(), "Device Manager Service", conf.OtelConfig)
 
@@ -49,7 +54,7 @@ func AssembleDeviceManagerService(conf config.DeviceManagerConfig, caService ser
 
 	devStorage, err := createDevicesStorageInstance(lStorage, conf.Storage)
 	if err != nil {
-		return nil, fmt.Errorf("could not create device storage: %s", err)
+		return nil, nil, fmt.Errorf("could not create device storage: %s", err)
 	}
 
 	svc := lservices.NewDeviceManagerService(lservices.DeviceManagerBuilder{
@@ -66,7 +71,7 @@ func AssembleDeviceManagerService(conf config.DeviceManagerConfig, caService ser
 	if conf.PublisherEventBus.Enabled {
 		pub, err := eventbus.NewEventBusPublisher(conf.PublisherEventBus, serviceID, lMessaging)
 		if err != nil {
-			return nil, fmt.Errorf("could not create Event Bus publisher: %s", err)
+			return nil, nil, fmt.Errorf("could not create Event Bus publisher: %s", err)
 		}
 
 		svc = eventpub.NewDeviceEventPublisher(&eventpub.CloudEventPublisher{
@@ -79,13 +84,15 @@ func AssembleDeviceManagerService(conf config.DeviceManagerConfig, caService ser
 		deviceSvc.SetService(svc)
 	}
 
+	var sseHub *controllers.DeviceEventSSEHub
+
 	if conf.SubscriberEventBus.Enabled {
 		if !conf.SubscriberDLQEventBus.Enabled {
 			lMessaging.Fatalf("Subscriber Event Bus is enabled but DLQ is not enabled. This is not supported. Exiting")
 		} else {
 			dlqPublisher, err := eventbus.NewEventBusPublisher(conf.SubscriberDLQEventBus, serviceID, lMessaging)
 			if err != nil {
-				return nil, fmt.Errorf("could not create Event Bus publisher: %s", err)
+				return nil, nil, fmt.Errorf("could not create Event Bus publisher: %s", err)
 			}
 
 			lMessaging := helpers.SetupLogger(conf.SubscriberEventBus.LogLevel, "Device Manager", "Event Bus")
@@ -94,23 +101,51 @@ func AssembleDeviceManagerService(conf config.DeviceManagerConfig, caService ser
 			subscriber, err := eventbus.NewEventBusSubscriber(conf.SubscriberEventBus, serviceID, lMessaging)
 			if err != nil {
 				lMessaging.Errorf("could not generate Event Bus Subscriber: %s", err)
-				return nil, err
+				return nil, nil, err
 			}
 
+			// Existing handler: react to certificate events to update device identity slots
 			eventHandlers := handlers.NewDeviceEventHandler(lMessaging, svc)
 			subHandler, err := ceventbus.NewEventBusMessageHandler("DeviceManger-DEFAULT", []string{"certificate.#"}, dlqPublisher, subscriber, lMessaging, *eventHandlers)
 			if err != nil {
-				return nil, fmt.Errorf("could not create Event Bus Subscription Handler: %s", err)
+				return nil, nil, fmt.Errorf("could not create Event Bus Subscription Handler: %s", err)
 			}
 
 			if err := subHandler.RunAsync(); err != nil {
 				lMessaging.Errorf("could not run Event Bus Subscription Handler: %s", err)
-				return nil, err
+				return nil, nil, err
+			}
+
+			// SSE hub: only create when SSE is enabled
+			if conf.SSEEnabled {
+				lSSE := helpers.SetupLogger(conf.SubscriberEventBus.LogLevel, "Device Manager", "SSE Hub")
+				sseHub = controllers.NewDeviceEventSSEHub(lSSE)
+
+				sseSubscriber, err := eventbus.NewEventBusSubscriber(conf.SubscriberEventBus, serviceID+"-sse", lSSE)
+				if err != nil {
+					lSSE.Errorf("could not generate SSE Event Bus Subscriber: %s", err)
+					return nil, nil, err
+				}
+
+				sseEventHandlers := handlers.NewDeviceEventSSEHandler(lSSE, sseHub)
+				sseSubHandler, err := ceventbus.NewEventBusMessageHandler("DeviceManager-SSE", []string{"device.#"}, dlqPublisher, sseSubscriber, lSSE, *sseEventHandlers)
+				if err != nil {
+					return nil, nil, fmt.Errorf("could not create SSE Event Bus Subscription Handler: %s", err)
+				}
+
+				if err := sseSubHandler.RunAsync(); err != nil {
+					lSSE.Errorf("could not run SSE Event Bus Subscription Handler: %s", err)
+					return nil, nil, err
+				}
+
+				lSSE.Infof("SSE hub started, listening for device.# events")
+			} else {
+				lMessaging.Infof("SSE is disabled by configuration")
 			}
 		}
 	}
 
-	return &svc, nil
+	return &svc, sseHub, nil
 }
 
 func createDevicesStorageInstance(logger *logrus.Entry, conf cconfig.PluggableStorageEngine) (storage.DeviceManagerRepo, error) {

--- a/backend/pkg/assemblers/device-manager.go
+++ b/backend/pkg/assemblers/device-manager.go
@@ -7,6 +7,7 @@ import (
 	"github.com/lamassuiot/lamassuiot/backend/v3/pkg/config"
 	"github.com/lamassuiot/lamassuiot/backend/v3/pkg/controllers"
 	"github.com/lamassuiot/lamassuiot/backend/v3/pkg/eventbus"
+	auditpub "github.com/lamassuiot/lamassuiot/backend/v3/pkg/middlewares/audit"
 	"github.com/lamassuiot/lamassuiot/backend/v3/pkg/middlewares/eventpub"
 	"github.com/lamassuiot/lamassuiot/backend/v3/pkg/routes"
 	lservices "github.com/lamassuiot/lamassuiot/backend/v3/pkg/services"
@@ -74,11 +75,19 @@ func AssembleDeviceManagerService(conf config.DeviceManagerConfig, caService ser
 			return nil, nil, fmt.Errorf("could not create Event Bus publisher: %s", err)
 		}
 
+		lAudit := helpers.SetupLogger(conf.PublisherEventBus.LogLevel, "Device Manager", "Audit Bus")
+
 		svc = eventpub.NewDeviceEventPublisher(&eventpub.CloudEventPublisher{
 			Publisher: pub,
 			ServiceID: serviceID,
 			Logger:    lMessaging,
 		})(svc)
+
+		svc = auditpub.NewDeviceAuditEventPublisher(*auditpub.NewAuditPublisher(&eventpub.CloudEventPublisher{
+			Publisher: pub,
+			ServiceID: serviceID,
+			Logger:    lAudit,
+		}))(svc)
 
 		//this utilizes the middlewares from within the DeviceManager service (if svc.service.func is used instead of regular svc.func)
 		deviceSvc.SetService(svc)

--- a/backend/pkg/assemblers/device-manager.go
+++ b/backend/pkg/assemblers/device-manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/lamassuiot/lamassuiot/backend/v3/pkg/config"
 	"github.com/lamassuiot/lamassuiot/backend/v3/pkg/controllers"
 	"github.com/lamassuiot/lamassuiot/backend/v3/pkg/eventbus"
@@ -130,7 +131,19 @@ func AssembleDeviceManagerService(conf config.DeviceManagerConfig, caService ser
 				lSSE := helpers.SetupLogger(conf.SubscriberEventBus.LogLevel, "Device Manager", "SSE Hub")
 				sseHub = controllers.NewDeviceEventSSEHub(lSSE)
 
-				sseSubscriber, err := eventbus.NewEventBusSubscriber(conf.SubscriberEventBus, serviceID+"-sse", lSSE)
+				// SSE needs fan-out across instances: every instance with connected
+				// SSE clients must receive every device.* event. With the underlying
+				// AMQP pubsub, serviceID becomes the queue suffix and instances
+				// sharing it form a competing-consumer group — only one instance
+				// would get each event, leaving SSE clients on the others silent.
+				// Append a per-process UUID so each instance binds its own queue
+				// to the exchange and they all receive the broadcast.
+				//
+				// Caveat: queues are declared durable by the eventbus layer, so
+				// queues from crashed/replaced instances linger until cleaned up
+				// out-of-band (operator tooling or RabbitMQ TTL policies).
+				sseServiceID := fmt.Sprintf("%s-sse-%s", serviceID, uuid.NewString())
+				sseSubscriber, err := eventbus.NewEventBusSubscriber(conf.SubscriberEventBus, sseServiceID, lSSE)
 				if err != nil {
 					lSSE.Errorf("could not generate SSE Event Bus Subscriber: %s", err)
 					return nil, nil, err

--- a/backend/pkg/assemblers/tests/alerts/main_test.go
+++ b/backend/pkg/assemblers/tests/alerts/main_test.go
@@ -109,7 +109,13 @@ func TestGetLastEvents(t *testing.T) {
 	}
 
 	alertsTest := serverTest.Alerts
-	eventSamples, err := alertsTest.Service.GetLatestEventsPerEventType(context.TODO(), &services.GetLatestEventsPerEventTypeInput{})
+	eventSamples := []models.AlertLatestEvent{}
+	_, err = alertsTest.Service.GetLatestEventsPerEventType(context.TODO(), &services.GetLatestEventsPerEventTypeInput{
+		ExhaustiveRun: true,
+		ApplyFunc: func(ev models.AlertLatestEvent) {
+			eventSamples = append(eventSamples, ev)
+		},
+	})
 	if err != nil {
 		t.Fatalf("could not get latest events: %s", err)
 	}
@@ -133,7 +139,13 @@ func TestGetLastEvents(t *testing.T) {
 		t.Fatalf("could not handle event: %s", err)
 	}
 
-	eventSamples, err = alertsTest.Service.GetLatestEventsPerEventType(context.TODO(), &services.GetLatestEventsPerEventTypeInput{})
+	eventSamples = []models.AlertLatestEvent{}
+	_, err = alertsTest.Service.GetLatestEventsPerEventType(context.TODO(), &services.GetLatestEventsPerEventTypeInput{
+		ExhaustiveRun: true,
+		ApplyFunc: func(ev models.AlertLatestEvent) {
+			eventSamples = append(eventSamples, ev)
+		},
+	})
 	if err != nil {
 		t.Fatalf("could not get latest events: %s", err)
 	}
@@ -148,7 +160,13 @@ func TestGetLastEvents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not handle event: %s", err)
 	}
-	eventSamples, err = alertsTest.Service.GetLatestEventsPerEventType(context.TODO(), &services.GetLatestEventsPerEventTypeInput{})
+	eventSamples = []models.AlertLatestEvent{}
+	_, err = alertsTest.Service.GetLatestEventsPerEventType(context.TODO(), &services.GetLatestEventsPerEventTypeInput{
+		ExhaustiveRun: true,
+		ApplyFunc: func(ev models.AlertLatestEvent) {
+			eventSamples = append(eventSamples, ev)
+		},
+	})
 	if err != nil {
 		t.Fatalf("could not get latest events: %s", err)
 	}

--- a/backend/pkg/assemblers/tests/device-manager/main_test.go
+++ b/backend/pkg/assemblers/tests/device-manager/main_test.go
@@ -752,6 +752,62 @@ func TestGetDeviceByID(t *testing.T) {
 	}
 }
 
+func TestGetDeviceEvents(t *testing.T) {
+	ctx := context.Background()
+	dmgr, _, err := StartDeviceManagerServiceTestServer(t, false, false)
+	if err != nil {
+		t.Fatalf("could not create Device Manager test server: %s", err)
+	}
+
+	deviceID := "events-device"
+	_, err = dmgr.Service.CreateDevice(ctx, services.CreateDeviceInput{
+		ID:        deviceID,
+		Alias:     "events-device",
+		Tags:      []string{"events"},
+		Metadata:  map[string]interface{}{"env": "test"},
+		DMSID:     "test",
+		Icon:      "test",
+		IconColor: "#000000",
+	})
+	if err != nil {
+		t.Fatalf("could not create device: %s", err)
+	}
+
+	_, err = dmgr.Service.UpdateDeviceStatus(ctx, services.UpdateDeviceStatusInput{
+		ID:        deviceID,
+		NewStatus: models.DeviceActive,
+	})
+	if err != nil {
+		t.Fatalf("could not update device status: %s", err)
+	}
+
+	events := []models.DeviceEvent{}
+	_, err = dmgr.HttpDeviceManagerSDK.GetDeviceEvents(ctx, services.GetDeviceEventsInput{
+		DeviceID: deviceID,
+		ListInput: resources.ListInput[models.DeviceEvent]{
+			ExhaustiveRun: true,
+			ApplyFunc: func(event models.DeviceEvent) {
+				events = append(events, event)
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("could not get device events: %s", err)
+	}
+
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+
+	eventTypes := []models.DeviceEventType{events[0].EvenType, events[1].EvenType}
+	if !slices.Contains(eventTypes, models.DeviceEventTypeCreated) {
+		t.Fatalf("expected events to contain CREATED, got %v", eventTypes)
+	}
+	if !slices.Contains(eventTypes, models.DeviceEventTypeStatusUpdated) {
+		t.Fatalf("expected events to contain STATUS-UPDATED, got %v", eventTypes)
+	}
+}
+
 func TestUpdateDeviceMetadata(t *testing.T) {
 	// t.Parallel()
 
@@ -1650,8 +1706,8 @@ func checkDevice(t *testing.T, device *models.Device, deviceSample services.Crea
 		t.Fatalf("device creation timestamp is zero")
 	}
 
-	if device.Events == nil {
-		t.Fatalf("device events is nil")
+	if device.Events != nil {
+		t.Fatalf("device events should not be included in device payload")
 	}
 
 	if device.IdentitySlot != nil {

--- a/backend/pkg/config/devicemanger.go
+++ b/backend/pkg/config/devicemanger.go
@@ -10,6 +10,7 @@ type DeviceManagerConfig struct {
 	SubscriberEventBus    cconfig.EventBusEngine         `mapstructure:"subscriber_event_bus"`
 	SubscriberDLQEventBus cconfig.EventBusEngine         `mapstructure:"subscriber_dlq_event_bus"`
 	Storage               cconfig.PluggableStorageEngine `mapstructure:"storage"`
+	SSEEnabled            bool                           `mapstructure:"sse_enabled"`
 	CAClient              struct {
 		cconfig.HTTPClient `mapstructure:",squash"`
 	} `mapstructure:"ca_client"`

--- a/backend/pkg/controllers/alerts.go
+++ b/backend/pkg/controllers/alerts.go
@@ -2,7 +2,9 @@ package controllers
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/lamassuiot/lamassuiot/backend/v3/pkg/resources"
+	backendresources "github.com/lamassuiot/lamassuiot/backend/v3/pkg/resources"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/resources"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/services"
 )
 
@@ -44,7 +46,20 @@ func (r *alertsHttpRoutes) GetUserSubscriptions(ctx *gin.Context) {
 }
 
 func (r *alertsHttpRoutes) GetLatestEventsPerEventType(ctx *gin.Context) {
-	response, err := r.svc.GetLatestEventsPerEventType(ctx.Request.Context(), &services.GetLatestEventsPerEventTypeInput{})
+	queryParams, err := FilterQuery(ctx.Request, resources.AlertFilterableFields)
+	if err != nil {
+		ctx.JSON(400, gin.H{"err": err.Error()})
+		return
+	}
+
+	events := []models.AlertLatestEvent{}
+	nextBookmark, err := r.svc.GetLatestEventsPerEventType(ctx.Request.Context(), &services.GetLatestEventsPerEventTypeInput{
+		QueryParameters: queryParams,
+		ExhaustiveRun:   false,
+		ApplyFunc: func(ev models.AlertLatestEvent) {
+			events = append(events, ev)
+		},
+	})
 
 	if err != nil {
 		switch err {
@@ -55,11 +70,16 @@ func (r *alertsHttpRoutes) GetLatestEventsPerEventType(ctx *gin.Context) {
 		return
 	}
 
-	ctx.JSON(200, response)
+	ctx.JSON(200, resources.GetAlertsResponse{
+		IterableList: resources.IterableList[models.AlertLatestEvent]{
+			NextBookmark: nextBookmark,
+			List:         events,
+		},
+	})
 }
 
 func (r *alertsHttpRoutes) Subscribe(ctx *gin.Context) {
-	var requestBody resources.SubscribeBody
+	var requestBody backendresources.SubscribeBody
 	if err := ctx.BindJSON(&requestBody); err != nil {
 		ctx.JSON(400, gin.H{"err": err.Error()})
 		return

--- a/backend/pkg/controllers/devmanager.go
+++ b/backend/pkg/controllers/devmanager.go
@@ -142,6 +142,92 @@ func (r *devManagerHttpRoutes) GetDeviceByID(ctx *gin.Context) {
 	ctx.JSON(200, dms)
 }
 
+func (r *devManagerHttpRoutes) GetDeviceEvents(ctx *gin.Context) {
+	type uriParams struct {
+		ID string `uri:"id" binding:"required"`
+	}
+
+	var params uriParams
+	if err := ctx.ShouldBindUri(&params); err != nil {
+		ctx.JSON(400, gin.H{"err": err.Error()})
+		return
+	}
+
+	queryParams, err := FilterQuery(ctx.Request, resources.DeviceEventFilterableFields)
+	if err != nil {
+		ctx.JSON(400, gin.H{"err": err.Error()})
+		return
+	}
+
+	events := []models.DeviceEvent{}
+	nextBookmark, err := r.svc.GetDeviceEvents(ctx.Request.Context(), services.GetDeviceEventsInput{
+		DeviceID: params.ID,
+		ListInput: resources.ListInput[models.DeviceEvent]{
+			QueryParameters: queryParams,
+			ExhaustiveRun:   false,
+			ApplyFunc: func(ev models.DeviceEvent) {
+				events = append(events, ev)
+			},
+		},
+	})
+	if err != nil {
+		switch err {
+		case errs.ErrDeviceNotFound:
+			ctx.JSON(404, gin.H{"err": err.Error()})
+		default:
+			ctx.JSON(500, gin.H{"err": err.Error()})
+		}
+		return
+	}
+
+	ctx.JSON(200, resources.GetDeviceEventsResponse{
+		IterableList: resources.IterableList[models.DeviceEvent]{
+			NextBookmark: nextBookmark,
+			List:         events,
+		},
+	})
+}
+
+func (r *devManagerHttpRoutes) CreateDeviceEvent(ctx *gin.Context) {
+	type uriParams struct {
+		ID string `uri:"id" binding:"required"`
+	}
+
+	var params uriParams
+	if err := ctx.ShouldBindUri(&params); err != nil {
+		ctx.JSON(400, gin.H{"err": err.Error()})
+		return
+	}
+
+	var requestBody resources.CreateDeviceEventBody
+	if err := ctx.BindJSON(&requestBody); err != nil {
+		ctx.JSON(400, gin.H{"err": err.Error()})
+		return
+	}
+
+	event, err := r.svc.CreateDeviceEvent(ctx.Request.Context(), services.CreateDeviceEventInput{
+		DeviceID:         params.ID,
+		Timestamp:        requestBody.Timestamp,
+		Type:             requestBody.Type,
+		Description:      requestBody.Description,
+		Source:           requestBody.Source,
+		StructuredFields: requestBody.StructuredFields,
+	})
+	if err != nil {
+		switch err {
+		case errs.ErrValidateBadRequest:
+			ctx.JSON(400, gin.H{"err": err.Error()})
+		case errs.ErrDeviceNotFound:
+			ctx.JSON(404, gin.H{"err": err.Error()})
+		default:
+			ctx.JSON(500, gin.H{"err": err.Error()})
+		}
+		return
+	}
+
+	ctx.JSON(201, event)
+}
+
 func (r *devManagerHttpRoutes) CreateDevice(ctx *gin.Context) {
 	var requestBody resources.CreateDeviceBody
 	if err := ctx.BindJSON(&requestBody); err != nil {

--- a/backend/pkg/controllers/devmanager.go
+++ b/backend/pkg/controllers/devmanager.go
@@ -1,6 +1,9 @@
 package controllers
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/gin-gonic/gin"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/errs"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
@@ -9,12 +12,20 @@ import (
 )
 
 type devManagerHttpRoutes struct {
-	svc services.DeviceManagerService
+	svc    services.DeviceManagerService
+	sseHub *DeviceEventSSEHub
 }
 
 func NewDeviceManagerHttpRoutes(svc services.DeviceManagerService) *devManagerHttpRoutes {
 	return &devManagerHttpRoutes{
 		svc: svc,
+	}
+}
+
+func NewDeviceManagerHttpRoutesWithSSE(svc services.DeviceManagerService, hub *DeviceEventSSEHub) *devManagerHttpRoutes {
+	return &devManagerHttpRoutes{
+		svc:    svc,
+		sseHub: hub,
 	}
 }
 
@@ -150,6 +161,12 @@ func (r *devManagerHttpRoutes) GetDeviceEvents(ctx *gin.Context) {
 	var params uriParams
 	if err := ctx.ShouldBindUri(&params); err != nil {
 		ctx.JSON(400, gin.H{"err": err.Error()})
+		return
+	}
+
+	// Content negotiation: if the client requests SSE, stream events in real time
+	if ctx.GetHeader("Accept") == "text/event-stream" {
+		r.streamDeviceEventsSSE(ctx, params.ID)
 		return
 	}
 
@@ -636,4 +653,62 @@ func (r *devManagerHttpRoutes) GetDeviceGroupStats(ctx *gin.Context) {
 	}
 
 	ctx.JSON(200, stats)
+}
+
+// streamDeviceEventsSSE handles the SSE streaming path for GetDeviceEvents.
+// Called when the client sends Accept: text/event-stream.
+func (r *devManagerHttpRoutes) streamDeviceEventsSSE(ctx *gin.Context, deviceID string) {
+	if r.sseHub == nil {
+		ctx.JSON(501, gin.H{"err": "SSE not enabled: event bus subscriber is not configured"})
+		return
+	}
+
+	// Verify device exists
+	_, err := r.svc.GetDeviceByID(ctx.Request.Context(), services.GetDeviceByIDInput{
+		ID: deviceID,
+	})
+	if err != nil {
+		switch err {
+		case errs.ErrDeviceNotFound:
+			ctx.JSON(404, gin.H{"err": err.Error()})
+		default:
+			ctx.JSON(500, gin.H{"err": err.Error()})
+		}
+		return
+	}
+
+	ch := r.sseHub.Subscribe(deviceID)
+	defer r.sseHub.Unsubscribe(deviceID, ch)
+
+	ctx.Header("Content-Type", "text/event-stream")
+	ctx.Header("Cache-Control", "no-cache")
+	ctx.Header("Connection", "keep-alive")
+	ctx.Header("X-Accel-Buffering", "no")
+
+	// Flush headers immediately so the client sees the SSE connection is open
+	ctx.Writer.Flush()
+
+	// Use a ticker to send keepalive comments every 15 seconds.
+	// Without this, idle connections are dropped by proxies or Go's HTTP server.
+	keepalive := time.NewTicker(15 * time.Second)
+	defer keepalive.Stop()
+
+	clientGone := ctx.Request.Context().Done()
+	for {
+		select {
+		case <-clientGone:
+			return
+		case data, ok := <-ch:
+			if !ok {
+				return
+			}
+			// SSE data frame
+			fmt.Fprintf(ctx.Writer, "event: device-event\ndata: %s\n\n", data)
+			ctx.Writer.Flush()
+		case <-keepalive.C:
+			// SSE comment line — keeps the connection alive without triggering client events
+			fmt.Fprintf(ctx.Writer, ": keepalive\n\n")
+			ctx.Writer.Flush()
+		}
+	}
 }

--- a/backend/pkg/controllers/devmanager.go
+++ b/backend/pkg/controllers/devmanager.go
@@ -167,7 +167,8 @@ func (r *devManagerHttpRoutes) GetDeviceEvents(ctx *gin.Context) {
 
 	// Content negotiation: if the client requests SSE, stream events in real time.
 	// Match any Accept header that includes text/event-stream (e.g. "text/event-stream, */*;q=0.5").
-	if strings.Contains(ctx.GetHeader("Accept"), "text/event-stream") {
+	// RFC 7231 declares media types case-insensitive, so normalize before matching.
+	if strings.Contains(strings.ToLower(ctx.GetHeader("Accept")), "text/event-stream") {
 		r.streamDeviceEventsSSE(ctx, params.ID)
 		return
 	}
@@ -225,17 +226,14 @@ func (r *devManagerHttpRoutes) CreateDeviceEvent(ctx *gin.Context) {
 	}
 
 	// Normalize Source: external API callers are not allowed to impersonate
-	// internal service sources (service/*). Override to "api/external" unless
-	// the request comes from a trusted internal service (identified by the
-	// x-lms-source header matching a known service source).
+	// internal service sources (service/*). Always override to "api/external"
+	// when callers leave it empty or claim a service-* source. The previous
+	// x-lms-source header escape hatch was unauthenticated and client-controlled,
+	// so it could be spoofed to forge audit/alert attribution; internal services
+	// must use a different (authenticated) ingress path to record service-* events.
 	source := requestBody.Source
 	if source == "" || strings.HasPrefix(source, "service/") {
-		internalSource := ctx.GetHeader("x-lms-source")
-		if internalSource != "" && strings.HasPrefix(internalSource, "service/") {
-			source = internalSource
-		} else {
-			source = "api/external"
-		}
+		source = "api/external"
 	}
 
 	// Normalize Timestamp: default to now; reject timestamps more than 5

--- a/backend/pkg/controllers/devmanager.go
+++ b/backend/pkg/controllers/devmanager.go
@@ -225,15 +225,29 @@ func (r *devManagerHttpRoutes) CreateDeviceEvent(ctx *gin.Context) {
 		return
 	}
 
-	// Normalize Source: external API callers are not allowed to impersonate
-	// internal service sources (service/*). Always override to "api/external"
-	// when callers leave it empty or claim a service-* source. The previous
-	// x-lms-source header escape hatch was unauthenticated and client-controlled,
-	// so it could be spoofed to forge audit/alert attribution; internal services
-	// must use a different (authenticated) ingress path to record service-* events.
+	// Normalize Source attribution.
+	//
+	// Internal services (DMS Manager, CA, etc.) must be able to record events
+	// attributed to themselves (e.g. models.DMSManagerSource = "service/ra")
+	// when they call this endpoint through their HTTP SDK clients — the SDK
+	// injects an x-lms-source header carrying the calling service's identity
+	// (see sdk.HttpClientWithSourceHeaderInjector).
+	//
+	// External API callers, on the other hand, must not be able to forge
+	// service-* attribution. The trust here ultimately rests on the deployment
+	// mTLS-protecting this endpoint at the edge so only authenticated callers
+	// (services or human operators with client certs) can reach it; given that,
+	// honoring x-lms-source for service-* sources is acceptable. If the body
+	// claims service-* but the x-lms-source header doesn't, the body is
+	// downgraded to api/external rather than honored.
 	source := requestBody.Source
 	if source == "" || strings.HasPrefix(source, "service/") {
-		source = "api/external"
+		internalSource := ctx.GetHeader("x-lms-source")
+		if internalSource != "" && strings.HasPrefix(internalSource, "service/") {
+			source = internalSource
+		} else {
+			source = "api/external"
+		}
 	}
 
 	// Normalize Timestamp: default to now; reject timestamps more than 5

--- a/backend/pkg/controllers/devmanager.go
+++ b/backend/pkg/controllers/devmanager.go
@@ -227,24 +227,17 @@ func (r *devManagerHttpRoutes) CreateDeviceEvent(ctx *gin.Context) {
 
 	// Normalize Source attribution.
 	//
-	// Internal services (DMS Manager, CA, etc.) must be able to record events
-	// attributed to themselves (e.g. models.DMSManagerSource = "service/ra")
-	// when they call this endpoint through their HTTP SDK clients — the SDK
-	// injects an x-lms-source header carrying the calling service's identity
-	// (see sdk.HttpClientWithSourceHeaderInjector).
+	// Priority: body > x-lms-source header > "api/external".
 	//
-	// External API callers, on the other hand, must not be able to forge
-	// service-* attribution. The trust here ultimately rests on the deployment
-	// mTLS-protecting this endpoint at the edge so only authenticated callers
-	// (services or human operators with client certs) can reach it; given that,
-	// honoring x-lms-source for service-* sources is acceptable. If the body
-	// claims service-* but the x-lms-source header doesn't, the body is
-	// downgraded to api/external rather than honored.
+	// Internal SDK clients (DMS Manager, CA, etc.) inject an x-lms-source
+	// header via sdk.HttpClientWithSourceHeaderInjector but leave the body
+	// field empty, so the header acts as the fallback for service-attributed
+	// events. Callers that provide an explicit source in the body bypass the
+	// header entirely.
 	source := requestBody.Source
-	if source == "" || strings.HasPrefix(source, "service/") {
-		internalSource := ctx.GetHeader("x-lms-source")
-		if internalSource != "" && strings.HasPrefix(internalSource, "service/") {
-			source = internalSource
+	if source == "" {
+		if ctx.GetHeader(models.HttpSourceHeader) != "" {
+			source = ctx.GetHeader(models.HttpSourceHeader)
 		} else {
 			source = "api/external"
 		}

--- a/backend/pkg/controllers/devmanager.go
+++ b/backend/pkg/controllers/devmanager.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -164,8 +165,9 @@ func (r *devManagerHttpRoutes) GetDeviceEvents(ctx *gin.Context) {
 		return
 	}
 
-	// Content negotiation: if the client requests SSE, stream events in real time
-	if ctx.GetHeader("Accept") == "text/event-stream" {
+	// Content negotiation: if the client requests SSE, stream events in real time.
+	// Match any Accept header that includes text/event-stream (e.g. "text/event-stream, */*;q=0.5").
+	if strings.Contains(ctx.GetHeader("Accept"), "text/event-stream") {
 		r.streamDeviceEventsSSE(ctx, params.ID)
 		return
 	}
@@ -222,12 +224,36 @@ func (r *devManagerHttpRoutes) CreateDeviceEvent(ctx *gin.Context) {
 		return
 	}
 
+	// Normalize Source: external API callers are not allowed to impersonate
+	// internal service sources (service/*). Override to "api/external" unless
+	// the request comes from a trusted internal service (identified by the
+	// x-lms-source header matching a known service source).
+	source := requestBody.Source
+	if source == "" || strings.HasPrefix(source, "service/") {
+		internalSource := ctx.GetHeader("x-lms-source")
+		if internalSource != "" && strings.HasPrefix(internalSource, "service/") {
+			source = internalSource
+		} else {
+			source = "api/external"
+		}
+	}
+
+	// Normalize Timestamp: default to now; reject timestamps more than 5
+	// minutes in the future to prevent forging future events.
+	ts := requestBody.Timestamp
+	if ts.IsZero() {
+		ts = time.Now()
+	} else if ts.After(time.Now().Add(5 * time.Minute)) {
+		ctx.JSON(400, gin.H{"err": "timestamp cannot be more than 5 minutes in the future"})
+		return
+	}
+
 	event, err := r.svc.CreateDeviceEvent(ctx.Request.Context(), services.CreateDeviceEventInput{
 		DeviceID:         params.ID,
-		Timestamp:        requestBody.Timestamp,
+		Timestamp:        ts,
 		Type:             requestBody.Type,
 		Description:      requestBody.Description,
-		Source:           requestBody.Source,
+		Source:           source,
 		StructuredFields: requestBody.StructuredFields,
 	})
 	if err != nil {
@@ -659,7 +685,7 @@ func (r *devManagerHttpRoutes) GetDeviceGroupStats(ctx *gin.Context) {
 // Called when the client sends Accept: text/event-stream.
 func (r *devManagerHttpRoutes) streamDeviceEventsSSE(ctx *gin.Context, deviceID string) {
 	if r.sseHub == nil {
-		ctx.JSON(501, gin.H{"err": "SSE not enabled: event bus subscriber is not configured"})
+		ctx.JSON(501, gin.H{"err": "SSE is disabled by configuration or not supported in this deployment"})
 		return
 	}
 

--- a/backend/pkg/controllers/sse_hub.go
+++ b/backend/pkg/controllers/sse_hub.go
@@ -1,0 +1,99 @@
+package controllers
+
+import (
+	"encoding/json"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+// DeviceSSEMessage represents a generic SSE message for a device.
+// EventType is the CloudEvent type (e.g. "device.create", "device.status.update").
+// Data is the raw JSON payload of the event.
+type DeviceSSEMessage struct {
+	EventType string          `json:"event_type"`
+	Data      json.RawMessage `json:"data"`
+}
+
+// DeviceEventSSEHub is an in-memory pub/sub broker that fans out device events
+// to SSE clients. Each SSE client registers a channel keyed by device ID.
+// The hub is fed by the AMQP event bus subscription so it works across instances.
+type DeviceEventSSEHub struct {
+	mu          sync.RWMutex
+	subscribers map[string]map[chan string]struct{} // deviceID → set of SSE channels
+	logger      *logrus.Entry
+}
+
+func NewDeviceEventSSEHub(logger *logrus.Entry) *DeviceEventSSEHub {
+	return &DeviceEventSSEHub{
+		subscribers: make(map[string]map[chan string]struct{}),
+		logger:      logger,
+	}
+}
+
+// Subscribe registers a new SSE listener for a given device ID.
+// Returns a channel that will receive JSON-encoded DeviceSSEMessage strings.
+func (h *DeviceEventSSEHub) Subscribe(deviceID string) chan string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	ch := make(chan string, 64)
+	if _, ok := h.subscribers[deviceID]; !ok {
+		h.subscribers[deviceID] = make(map[chan string]struct{})
+	}
+	h.subscribers[deviceID][ch] = struct{}{}
+	h.logger.Debugf("SSE client subscribed for device %s (total: %d)", deviceID, len(h.subscribers[deviceID]))
+	return ch
+}
+
+// Unsubscribe removes an SSE listener and closes its channel.
+func (h *DeviceEventSSEHub) Unsubscribe(deviceID string, ch chan string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if subs, ok := h.subscribers[deviceID]; ok {
+		delete(subs, ch)
+		close(ch)
+		if len(subs) == 0 {
+			delete(h.subscribers, deviceID)
+		}
+		h.logger.Debugf("SSE client unsubscribed for device %s", deviceID)
+	}
+}
+
+// Publish sends a device event to all SSE listeners for the given device ID.
+// The payload is any serializable object; it will be wrapped in a DeviceSSEMessage with the event type.
+func (h *DeviceEventSSEHub) Publish(deviceID string, eventType string, payload interface{}) {
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		h.logger.Errorf("could not marshal SSE payload for device %s: %s", deviceID, err)
+		return
+	}
+
+	msg := DeviceSSEMessage{
+		EventType: eventType,
+		Data:      payloadBytes,
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		h.logger.Errorf("could not marshal SSE message for device %s: %s", deviceID, err)
+		return
+	}
+
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	subs, ok := h.subscribers[deviceID]
+	if !ok {
+		return
+	}
+
+	for ch := range subs {
+		select {
+		case ch <- string(data):
+		default:
+			h.logger.Warnf("SSE channel full for device %s, dropping event", deviceID)
+		}
+	}
+}

--- a/backend/pkg/middlewares/audit/devices.go
+++ b/backend/pkg/middlewares/audit/devices.go
@@ -41,6 +41,14 @@ func (mw *DeviceAuditEventPublisher) GetDeviceByID(ctx context.Context, input se
 	return mw.next.GetDeviceByID(ctx, input)
 }
 
+func (mw *DeviceAuditEventPublisher) GetDeviceEvents(ctx context.Context, input services.GetDeviceEventsInput) (string, error) {
+	return mw.next.GetDeviceEvents(ctx, input)
+}
+
+func (mw *DeviceAuditEventPublisher) CreateDeviceEvent(ctx context.Context, input services.CreateDeviceEventInput) (*models.DeviceEvent, error) {
+	return mw.next.CreateDeviceEvent(ctx, input)
+}
+
 func (mw *DeviceAuditEventPublisher) GetDevices(ctx context.Context, input services.GetDevicesInput) (string, error) {
 	return mw.next.GetDevices(ctx, input)
 }

--- a/backend/pkg/middlewares/audit/devices.go
+++ b/backend/pkg/middlewares/audit/devices.go
@@ -45,7 +45,11 @@ func (mw *DeviceAuditEventPublisher) GetDeviceEvents(ctx context.Context, input 
 	return mw.next.GetDeviceEvents(ctx, input)
 }
 
-func (mw *DeviceAuditEventPublisher) CreateDeviceEvent(ctx context.Context, input services.CreateDeviceEventInput) (*models.DeviceEvent, error) {
+func (mw *DeviceAuditEventPublisher) CreateDeviceEvent(ctx context.Context, input services.CreateDeviceEventInput) (output *models.DeviceEvent, err error) {
+	defer func() {
+		mw.auditPub.HandleServiceOutputAndPublishAuditRecord(ctx, models.EventCreateDeviceEventKey, input, err, output)
+	}()
+
 	return mw.next.CreateDeviceEvent(ctx, input)
 }
 

--- a/backend/pkg/middlewares/eventpub/devices.go
+++ b/backend/pkg/middlewares/eventpub/devices.go
@@ -44,6 +44,14 @@ func (mw *deviceEventPublisher) GetDeviceByID(ctx context.Context, input service
 	return mw.next.GetDeviceByID(ctx, input)
 }
 
+func (mw *deviceEventPublisher) GetDeviceEvents(ctx context.Context, input services.GetDeviceEventsInput) (string, error) {
+	return mw.next.GetDeviceEvents(ctx, input)
+}
+
+func (mw *deviceEventPublisher) CreateDeviceEvent(ctx context.Context, input services.CreateDeviceEventInput) (*models.DeviceEvent, error) {
+	return mw.next.CreateDeviceEvent(ctx, input)
+}
+
 func (mw *deviceEventPublisher) GetDevices(ctx context.Context, input services.GetDevicesInput) (string, error) {
 	return mw.next.GetDevices(ctx, input)
 }

--- a/backend/pkg/middlewares/eventpub/devices.go
+++ b/backend/pkg/middlewares/eventpub/devices.go
@@ -49,7 +49,14 @@ func (mw *deviceEventPublisher) GetDeviceEvents(ctx context.Context, input servi
 }
 
 func (mw *deviceEventPublisher) CreateDeviceEvent(ctx context.Context, input services.CreateDeviceEventInput) (*models.DeviceEvent, error) {
-	return mw.next.CreateDeviceEvent(ctx, input)
+	ctx = context.WithValue(ctx, core.LamassuContextKeyEventType, models.EventCreateDeviceEventKey)
+	ctx = context.WithValue(ctx, core.LamassuContextKeyEventSubject, fmt.Sprintf("device/%s/event", input.DeviceID))
+
+	output, err := mw.next.CreateDeviceEvent(ctx, input)
+	if err == nil {
+		mw.eventMWPub.PublishCloudEvent(ctx, output)
+	}
+	return output, err
 }
 
 func (mw *deviceEventPublisher) GetDevices(ctx context.Context, input services.GetDevicesInput) (string, error) {

--- a/backend/pkg/routes/devmanager.go
+++ b/backend/pkg/routes/devmanager.go
@@ -7,7 +7,11 @@ import (
 )
 
 func NewDeviceManagerHTTPLayer(router *gin.RouterGroup, svc services.DeviceManagerService) {
-	routes := controllers.NewDeviceManagerHttpRoutes(svc)
+	NewDeviceManagerHTTPLayerWithSSE(router, svc, nil)
+}
+
+func NewDeviceManagerHTTPLayerWithSSE(router *gin.RouterGroup, svc services.DeviceManagerService, sseHub *controllers.DeviceEventSSEHub) {
+	routes := controllers.NewDeviceManagerHttpRoutesWithSSE(svc, sseHub)
 
 	rv1 := router.Group("/v1")
 	rv1.GET("/stats", routes.GetStats)

--- a/backend/pkg/routes/devmanager.go
+++ b/backend/pkg/routes/devmanager.go
@@ -14,6 +14,8 @@ func NewDeviceManagerHTTPLayer(router *gin.RouterGroup, svc services.DeviceManag
 	rv1.GET("/devices", routes.GetAllDevices)
 	rv1.POST("/devices", routes.CreateDevice)
 	rv1.GET("/devices/:id", routes.GetDeviceByID)
+	rv1.GET("/devices/:id/events", routes.GetDeviceEvents)
+	rv1.POST("/devices/:id/events", routes.CreateDeviceEvent)
 	rv1.DELETE("/devices/:id", routes.DeleteDevice)
 	rv1.PUT("/devices/:id/idslot", routes.UpdateDeviceIdentitySlot)
 	rv1.PUT("/devices/:id/metadata", routes.UpdateDeviceMetadata)

--- a/backend/pkg/services/alerts.go
+++ b/backend/pkg/services/alerts.go
@@ -98,16 +98,29 @@ func (svc *AlertsServiceBackend) HandleEvent(ctx context.Context, input *service
 	return nil
 }
 
-func (svc *AlertsServiceBackend) GetLatestEventsPerEventType(ctx context.Context, input *services.GetLatestEventsPerEventTypeInput) ([]*models.AlertLatestEvent, error) {
+func (svc *AlertsServiceBackend) GetLatestEventsPerEventType(ctx context.Context, input *services.GetLatestEventsPerEventTypeInput) (string, error) {
 	lFunc := helpers.ConfigureLogger(ctx, svc.logger)
 
-	events, err := svc.eventStorage.GetLatestEvents(ctx)
-	if err != nil {
-		lFunc.Errorf("got unexpected error while reading events: %s", err)
-		return nil, err
+	if input == nil {
+		input = &services.GetLatestEventsPerEventTypeInput{}
 	}
 
-	return events, nil
+	applyFunc := input.ApplyFunc
+	if applyFunc == nil {
+		applyFunc = func(models.AlertLatestEvent) {}
+	}
+
+	nextBookmark, err := svc.eventStorage.GetLatestEvents(ctx, storage.StorageListRequest[models.AlertLatestEvent]{
+		ExhaustiveRun: input.ExhaustiveRun,
+		ApplyFunc:     applyFunc,
+		QueryParams:   input.QueryParameters,
+	})
+	if err != nil {
+		lFunc.Errorf("got unexpected error while reading events: %s", err)
+		return "", err
+	}
+
+	return nextBookmark, nil
 }
 
 func (svc *AlertsServiceBackend) GetUserSubscriptions(ctx context.Context, input *services.GetUserSubscriptionsInput) ([]*models.Subscription, error) {

--- a/backend/pkg/services/devicemanager.go
+++ b/backend/pkg/services/devicemanager.go
@@ -295,6 +295,17 @@ func (svc DeviceManagerServiceBackend) GetDeviceEvents(ctx context.Context, inpu
 		return "", errs.ErrDeviceNotFound
 	}
 
+	// Default sort: latest events first
+	if input.QueryParameters == nil {
+		input.QueryParameters = &resources.QueryParameters{}
+	}
+	if input.QueryParameters.Sort.SortField == "" {
+		input.QueryParameters.Sort = resources.SortOptions{
+			SortField: "event_ts",
+			SortMode:  resources.SortModeDesc,
+		}
+	}
+
 	applyFunc := input.ApplyFunc
 	if applyFunc == nil {
 		applyFunc = func(models.DeviceEvent) {}
@@ -539,6 +550,9 @@ func (svc DeviceManagerServiceBackend) UpdateDeviceIdentitySlot(ctx context.Cont
 		newDevStatus = models.DeviceExpired
 	}
 
+	// Determine if this is a first-time provisioning or a re-provisioning
+	isFirstProvisioning := device.IdentitySlot == nil
+
 	device.IdentitySlot = &newSlot
 
 	lFunc.Debugf("updating %s device identity slot. New device status %s. ID slot status %s", input.ID, device.Status, device.IdentitySlot.Status)
@@ -547,13 +561,24 @@ func (svc DeviceManagerServiceBackend) UpdateDeviceIdentitySlot(ctx context.Cont
 		return nil, err
 	}
 
-	if slotStatusChanged {
-		err = svc.persistDeviceEvent(ctx, device.ID, time.Now(), models.DeviceEvent{
-			EvenType:          models.DeviceEventTypeStatusUpdated,
+	// Persist provisioning event
+	now := time.Now()
+	if isFirstProvisioning {
+		err = svc.persistDeviceEvent(ctx, device.ID, now, models.DeviceEvent{
+			EvenType:          models.DeviceEventTypeProvisioned,
+			EventDescriptions: fmt.Sprintf("Identity slot provisioned with status '%s'", newSlot.Status),
+		})
+		if err != nil {
+			lFunc.Errorf("could not persist provisioning event for device %s: %s", input.ID, err)
+			return nil, err
+		}
+	} else if slotStatusChanged {
+		err = svc.persistDeviceEvent(ctx, device.ID, now, models.DeviceEvent{
+			EvenType:          models.DeviceEventTypeReProvisioned,
 			EventDescriptions: fmt.Sprintf("Identity Slot Status updated from '%s' to '%s'", oldSlotStatus, newSlot.Status),
 		})
 		if err != nil {
-			lFunc.Errorf("could not persist identity slot status update event for device %s: %s", input.ID, err)
+			lFunc.Errorf("could not persist re-provisioning event for device %s: %s", input.ID, err)
 			return nil, err
 		}
 	}

--- a/backend/pkg/services/devicemanager.go
+++ b/backend/pkg/services/devicemanager.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/go-playground/validator/v10"
+	"github.com/google/uuid"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/engines/storage"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/errs"
 	chelpers "github.com/lamassuiot/lamassuiot/core/v3/pkg/helpers"
@@ -17,6 +18,8 @@ import (
 )
 
 var deviceValidate *validator.Validate
+
+const defaultDeviceEventSource = "service/devmanager"
 
 type DeviceMiddleware func(services.DeviceManagerService) services.DeviceManagerService
 
@@ -141,6 +144,43 @@ func addStatusFilter(queryParams *resources.QueryParameters, status models.Devic
 	return statusQueryParams
 }
 
+func toDeviceEventRecord(deviceID string, eventTS time.Time, event models.DeviceEvent) *models.DeviceEventRecord {
+	if eventTS.IsZero() {
+		eventTS = time.Now()
+	}
+
+	source := event.Source
+	if source == "" {
+		source = defaultDeviceEventSource
+	}
+
+	return &models.DeviceEventRecord{
+		ID:               uuid.NewString(),
+		DeviceID:         deviceID,
+		EventTS:          eventTS,
+		EventType:        string(event.EvenType),
+		Description:      event.EventDescriptions,
+		Source:           source,
+		StructuredFields: event.StructuredFields,
+	}
+}
+
+func (svc DeviceManagerServiceBackend) persistDeviceEvent(ctx context.Context, deviceID string, eventTS time.Time, event models.DeviceEvent) error {
+	_, err := svc.devicesStorage.DeviceEvents().Insert(ctx, toDeviceEventRecord(deviceID, eventTS, event))
+	return err
+}
+
+func deviceEventFromRecord(record models.DeviceEventRecord) models.DeviceEvent {
+	return models.DeviceEvent{
+		ID:                record.ID,
+		EventTS:           record.EventTS,
+		EvenType:          models.DeviceEventType(record.EventType),
+		EventDescriptions: record.Description,
+		Source:            record.Source,
+		StructuredFields:  record.StructuredFields,
+	}
+}
+
 func (svc DeviceManagerServiceBackend) CreateDevice(ctx context.Context, input services.CreateDeviceInput) (*models.Device, error) {
 	lFunc := chelpers.ConfigureLogger(ctx, svc.logger)
 
@@ -172,12 +212,6 @@ func (svc DeviceManagerServiceBackend) CreateDevice(ctx context.Context, input s
 		IconColor:         input.IconColor,
 		DMSOwner:          input.DMSID,
 		CreationTimestamp: now,
-		Events: map[time.Time]models.DeviceEvent{
-			now: {
-				EvenType:          models.DeviceEventTypeCreated,
-				EventDescriptions: "",
-			},
-		},
 	}
 
 	dev, err := svc.devicesStorage.Insert(ctx, device)
@@ -185,6 +219,15 @@ func (svc DeviceManagerServiceBackend) CreateDevice(ctx context.Context, input s
 		lFunc.Errorf("could not insert device %s in storage engine: %s", input.ID, err)
 		return nil, err
 	}
+
+	if err = svc.persistDeviceEvent(ctx, dev.ID, now, models.DeviceEvent{EvenType: models.DeviceEventTypeCreated}); err != nil {
+		lFunc.Errorf("could not persist creation event for device %s: %s", input.ID, err)
+		if rollbackErr := svc.devicesStorage.Delete(ctx, dev.ID); rollbackErr != nil {
+			lFunc.Errorf("could not rollback device %s after event persistence failure: %s", input.ID, rollbackErr)
+		}
+		return nil, err
+	}
+
 	return dev, nil
 }
 
@@ -192,14 +235,24 @@ func (svc DeviceManagerServiceBackend) GetDevices(ctx context.Context, input ser
 	lFunc := chelpers.ConfigureLogger(ctx, svc.logger)
 
 	lFunc.Debugf("getting all devices")
-	return svc.devicesStorage.SelectAll(ctx, input.ExhaustiveRun, input.ApplyFunc, input.QueryParameters, nil)
+	applyFunc := input.ApplyFunc
+	if applyFunc == nil {
+		applyFunc = func(models.Device) {}
+	}
+
+	return svc.devicesStorage.SelectAll(ctx, input.ExhaustiveRun, applyFunc, input.QueryParameters, nil)
 }
 
 func (svc DeviceManagerServiceBackend) GetDeviceByDMS(ctx context.Context, input services.GetDevicesByDMSInput) (string, error) {
 	lFunc := chelpers.ConfigureLogger(ctx, svc.logger)
 
 	lFunc.Debugf("getting all devices owned by DMS with ID=%s", input.DMSID)
-	return svc.devicesStorage.SelectByDMS(ctx, input.DMSID, input.ExhaustiveRun, input.ApplyFunc, input.QueryParameters, nil)
+	applyFunc := input.ApplyFunc
+	if applyFunc == nil {
+		applyFunc = func(models.Device) {}
+	}
+
+	return svc.devicesStorage.SelectByDMS(ctx, input.DMSID, input.ExhaustiveRun, applyFunc, input.QueryParameters, nil)
 }
 
 func (svc DeviceManagerServiceBackend) GetDeviceByID(ctx context.Context, input services.GetDeviceByIDInput) (*models.Device, error) {
@@ -221,6 +274,76 @@ func (svc DeviceManagerServiceBackend) GetDeviceByID(ctx context.Context, input 
 	}
 
 	return device, nil
+}
+
+func (svc DeviceManagerServiceBackend) GetDeviceEvents(ctx context.Context, input services.GetDeviceEventsInput) (string, error) {
+	lFunc := chelpers.ConfigureLogger(ctx, svc.logger)
+
+	err := deviceValidate.Struct(input)
+	if err != nil {
+		lFunc.Errorf("struct validation error: %s", err)
+		return "", errs.ErrValidateBadRequest
+	}
+
+	lFunc.Debugf("checking if device '%s' exists", input.DeviceID)
+	exists, _, err := svc.devicesStorage.SelectExists(ctx, input.DeviceID)
+	if err != nil {
+		lFunc.Errorf("something went wrong while checking if device '%s' exists in storage engine: %s", input.DeviceID, err)
+		return "", err
+	} else if !exists {
+		lFunc.Errorf("device %s can not be found in storage engine", input.DeviceID)
+		return "", errs.ErrDeviceNotFound
+	}
+
+	applyFunc := input.ApplyFunc
+	if applyFunc == nil {
+		applyFunc = func(models.DeviceEvent) {}
+	}
+
+	return svc.devicesStorage.DeviceEvents().SelectByDeviceID(ctx, storage.StorageListRequest[models.DeviceEventRecord]{
+		ExhaustiveRun: input.ExhaustiveRun,
+		QueryParams:   input.QueryParameters,
+		ApplyFunc: func(event models.DeviceEventRecord) {
+			applyFunc(deviceEventFromRecord(event))
+		},
+	}, input.DeviceID)
+}
+
+func (svc DeviceManagerServiceBackend) CreateDeviceEvent(ctx context.Context, input services.CreateDeviceEventInput) (*models.DeviceEvent, error) {
+	lFunc := chelpers.ConfigureLogger(ctx, svc.logger)
+
+	err := deviceValidate.Struct(input)
+	if err != nil {
+		lFunc.Errorf("struct validation error: %s", err)
+		return nil, errs.ErrValidateBadRequest
+	}
+
+	lFunc.Debugf("checking if device '%s' exists", input.DeviceID)
+	exists, _, err := svc.devicesStorage.SelectExists(ctx, input.DeviceID)
+	if err != nil {
+		lFunc.Errorf("something went wrong while checking if device '%s' exists in storage engine: %s", input.DeviceID, err)
+		return nil, err
+	} else if !exists {
+		lFunc.Errorf("device %s can not be found in storage engine", input.DeviceID)
+		return nil, errs.ErrDeviceNotFound
+	}
+
+	event := models.DeviceEvent{
+		EvenType:          input.Type,
+		EventDescriptions: input.Description,
+		Source:            input.Source,
+		StructuredFields:  input.StructuredFields,
+	}
+
+	record := toDeviceEventRecord(input.DeviceID, input.Timestamp, event)
+	_, err = svc.devicesStorage.DeviceEvents().Insert(ctx, record)
+	if err != nil {
+		lFunc.Errorf("could not persist event for device %s: %s", input.DeviceID, err)
+		return nil, err
+	}
+
+	domainEvent := deviceEventFromRecord(*record)
+	return &domainEvent, nil
 }
 
 func (svc DeviceManagerServiceBackend) UpdateDeviceStatus(ctx context.Context, input services.UpdateDeviceStatusInput) (*models.Device, error) {
@@ -249,9 +372,12 @@ func (svc DeviceManagerServiceBackend) UpdateDeviceStatus(ctx context.Context, i
 		return device, nil
 	}
 
-	if input.NewStatus == models.DeviceDecommissioned {
+	var statusEvent *models.DeviceEvent
+	statusEventTS := time.Time{}
 
-		device.Events[time.Now()] = models.DeviceEvent{
+	if input.NewStatus == models.DeviceDecommissioned {
+		statusEventTS = time.Now()
+		statusEvent = &models.DeviceEvent{
 			EvenType: models.DeviceEventTypeStatusDecommissioned,
 		}
 
@@ -281,7 +407,8 @@ func (svc DeviceManagerServiceBackend) UpdateDeviceStatus(ctx context.Context, i
 			}
 		}
 	} else {
-		device.Events[time.Now()] = models.DeviceEvent{
+		statusEventTS = time.Now()
+		statusEvent = &models.DeviceEvent{
 			EvenType:          models.DeviceEventTypeStatusUpdated,
 			EventDescriptions: fmt.Sprintf("Status updated from '%s' to '%s'", device.Status, input.NewStatus),
 		}
@@ -293,6 +420,14 @@ func (svc DeviceManagerServiceBackend) UpdateDeviceStatus(ctx context.Context, i
 	if err != nil {
 		lFunc.Errorf("error while updating %s device status. could not update DB: %s", device.ID, err)
 		return nil, err
+	}
+
+	if statusEvent != nil {
+		err = svc.persistDeviceEvent(ctx, device.ID, statusEventTS, *statusEvent)
+		if err != nil {
+			lFunc.Errorf("could not persist status event for device %s: %s", device.ID, err)
+			return nil, err
+		}
 	}
 
 	lFunc.Debugf("device %s status updated. new status: %s", input.ID, input.NewStatus)
@@ -329,7 +464,12 @@ func (svc DeviceManagerServiceBackend) UpdateDeviceMetadata(ctx context.Context,
 	device.Metadata = *updatedMetadata
 
 	lFunc.Debugf("updating %s device metadata", input.ID)
-	return svc.devicesStorage.Update(ctx, device)
+	device, err = svc.devicesStorage.Update(ctx, device)
+	if err != nil {
+		return nil, err
+	}
+
+	return device, nil
 
 }
 
@@ -357,6 +497,13 @@ func (svc DeviceManagerServiceBackend) UpdateDeviceIdentitySlot(ctx context.Cont
 	}
 
 	newSlot := input.Slot
+	oldSlotStatus := models.SlotStatus("")
+	slotStatusChanged := false
+	if device.IdentitySlot != nil {
+		oldSlotStatus = device.IdentitySlot.Status
+		slotStatusChanged = newSlot.Status != oldSlotStatus
+	}
+
 	var newDevStatus models.DeviceStatus
 	switch input.Slot.Status {
 	case models.SlotRevoke:
@@ -392,18 +539,23 @@ func (svc DeviceManagerServiceBackend) UpdateDeviceIdentitySlot(ctx context.Cont
 		newDevStatus = models.DeviceExpired
 	}
 
-	if device.IdentitySlot != nil && newSlot.Status != device.IdentitySlot.Status {
-		newSlot.Events[time.Now()] = models.DeviceEvent{
-			EvenType:          models.DeviceEventTypeStatusUpdated,
-			EventDescriptions: fmt.Sprintf("Identity Slot Status updated from '%s' to '%s'", device.Status, newSlot.Status),
-		}
-	}
 	device.IdentitySlot = &newSlot
 
 	lFunc.Debugf("updating %s device identity slot. New device status %s. ID slot status %s", input.ID, device.Status, device.IdentitySlot.Status)
 	device, err = svc.devicesStorage.Update(ctx, device)
 	if err != nil {
 		return nil, err
+	}
+
+	if slotStatusChanged {
+		err = svc.persistDeviceEvent(ctx, device.ID, time.Now(), models.DeviceEvent{
+			EvenType:          models.DeviceEventTypeStatusUpdated,
+			EventDescriptions: fmt.Sprintf("Identity Slot Status updated from '%s' to '%s'", oldSlotStatus, newSlot.Status),
+		})
+		if err != nil {
+			lFunc.Errorf("could not persist identity slot status update event for device %s: %s", input.ID, err)
+			return nil, err
+		}
 	}
 
 	if device.Status != newDevStatus {
@@ -444,6 +596,12 @@ func (svc DeviceManagerServiceBackend) DeleteDevice(ctx context.Context, input s
 	if device.Status != models.DeviceDecommissioned {
 		lFunc.Errorf("cannot delete device '%s': device must be decommissioned first. Current status: %s", id, device.Status)
 		return errs.ErrDeviceInvalidStatus
+	}
+
+	err = svc.devicesStorage.DeviceEvents().DeleteByDeviceID(ctx, id)
+	if err != nil {
+		lFunc.Errorf("could not delete events for device '%s': %s", id, err)
+		return err
 	}
 
 	lFunc.Debugf("deleting device '%s'", id)

--- a/backend/pkg/services/devicemanager.go
+++ b/backend/pkg/services/devicemanager.go
@@ -434,10 +434,10 @@ func (svc DeviceManagerServiceBackend) UpdateDeviceStatus(ctx context.Context, i
 	}
 
 	if statusEvent != nil {
-		err = svc.persistDeviceEvent(ctx, device.ID, statusEventTS, *statusEvent)
-		if err != nil {
-			lFunc.Errorf("could not persist status event for device %s: %s", device.ID, err)
-			return nil, err
+		// Best-effort: the device row is already committed; failing here would leave the
+		// caller thinking the status change was rolled back when it wasn't. Log and proceed.
+		if eventErr := svc.persistDeviceEvent(ctx, device.ID, statusEventTS, *statusEvent); eventErr != nil {
+			lFunc.Errorf("could not persist status event for device %s (status change still applied): %s", device.ID, eventErr)
 		}
 	}
 
@@ -561,25 +561,21 @@ func (svc DeviceManagerServiceBackend) UpdateDeviceIdentitySlot(ctx context.Cont
 		return nil, err
 	}
 
-	// Persist provisioning event
+	// Persist provisioning event (best-effort: identity slot is already committed).
 	now := time.Now()
 	if isFirstProvisioning {
-		err = svc.persistDeviceEvent(ctx, device.ID, now, models.DeviceEvent{
+		if eventErr := svc.persistDeviceEvent(ctx, device.ID, now, models.DeviceEvent{
 			EvenType:          models.DeviceEventTypeProvisioned,
 			EventDescriptions: fmt.Sprintf("Identity slot provisioned with status '%s'", newSlot.Status),
-		})
-		if err != nil {
-			lFunc.Errorf("could not persist provisioning event for device %s: %s", input.ID, err)
-			return nil, err
+		}); eventErr != nil {
+			lFunc.Errorf("could not persist provisioning event for device %s (slot change still applied): %s", input.ID, eventErr)
 		}
 	} else if slotStatusChanged {
-		err = svc.persistDeviceEvent(ctx, device.ID, now, models.DeviceEvent{
+		if eventErr := svc.persistDeviceEvent(ctx, device.ID, now, models.DeviceEvent{
 			EvenType:          models.DeviceEventTypeReProvisioned,
 			EventDescriptions: fmt.Sprintf("Identity Slot Status updated from '%s' to '%s'", oldSlotStatus, newSlot.Status),
-		})
-		if err != nil {
-			lFunc.Errorf("could not persist re-provisioning event for device %s: %s", input.ID, err)
-			return nil, err
+		}); eventErr != nil {
+			lFunc.Errorf("could not persist re-provisioning event for device %s (slot change still applied): %s", input.ID, eventErr)
 		}
 	}
 
@@ -623,13 +619,8 @@ func (svc DeviceManagerServiceBackend) DeleteDevice(ctx context.Context, input s
 		return errs.ErrDeviceInvalidStatus
 	}
 
-	err = svc.devicesStorage.DeviceEvents().DeleteByDeviceID(ctx, id)
-	if err != nil {
-		lFunc.Errorf("could not delete events for device '%s': %s", id, err)
-		return err
-	}
-
 	lFunc.Debugf("deleting device '%s'", id)
+	// device_events rows are removed by the ON DELETE CASCADE FK on device_events.device_id.
 	err = svc.devicesStorage.Delete(ctx, id)
 	if err != nil {
 		lFunc.Errorf("something went wrong while deleting device '%s' from storage engine: %s", id, err)

--- a/backend/pkg/services/devicemanager.go
+++ b/backend/pkg/services/devicemanager.go
@@ -19,7 +19,7 @@ import (
 
 var deviceValidate *validator.Validate
 
-const defaultDeviceEventSource = "service/devmanager"
+const defaultDeviceEventSource = models.DeviceManagerSource
 
 type DeviceMiddleware func(services.DeviceManagerService) services.DeviceManagerService
 

--- a/backend/pkg/services/devicemanager.go
+++ b/backend/pkg/services/devicemanager.go
@@ -154,6 +154,13 @@ func toDeviceEventRecord(deviceID string, eventTS time.Time, event models.Device
 		source = defaultDeviceEventSource
 	}
 
+	// Normalize nil → empty map so the row stores {} (matching the OpenAPI object schema)
+	// rather than JSON null, which would also surface inconsistently to API consumers.
+	structuredFields := event.StructuredFields
+	if structuredFields == nil {
+		structuredFields = map[string]any{}
+	}
+
 	return &models.DeviceEventRecord{
 		ID:               uuid.NewString(),
 		DeviceID:         deviceID,
@@ -161,7 +168,7 @@ func toDeviceEventRecord(deviceID string, eventTS time.Time, event models.Device
 		EventType:        string(event.EvenType),
 		Description:      event.EventDescriptions,
 		Source:           source,
-		StructuredFields: event.StructuredFields,
+		StructuredFields: structuredFields,
 	}
 }
 

--- a/backend/pkg/services/dmsmanager.go
+++ b/backend/pkg/services/dmsmanager.go
@@ -1165,6 +1165,8 @@ func (svc DMSManagerServiceBackend) BindIdentityToDevice(ctx context.Context, in
 	}
 
 	idSlot := device.IdentitySlot
+	eventType := models.DeviceEventTypeProvisioned
+	eventDescription := ""
 	if idSlot == nil {
 		idSlot = &models.Slot[string]{
 			Status:         models.SlotActive,
@@ -1174,22 +1176,15 @@ func (svc DMSManagerServiceBackend) BindIdentityToDevice(ctx context.Context, in
 			Secrets: map[int]string{
 				0: crt.SerialNumber,
 			},
-			Events: map[time.Time]models.DeviceEvent{
-				time.Now(): {
-					EvenType: models.DeviceEventTypeProvisioned,
-				},
-			},
+			Events: map[time.Time]models.DeviceEvent{},
 		}
 	} else {
 		idSlot.ActiveVersion = idSlot.ActiveVersion + 1
 		idSlot.Status = models.SlotActive
 		idSlot.ExpirationDate = &crt.ValidTo
 		idSlot.Secrets[idSlot.ActiveVersion] = crt.SerialNumber
-
-		idSlot.Events[time.Now()] = models.DeviceEvent{
-			EvenType:          input.BindMode,
-			EventDescriptions: fmt.Sprintf("New Active Version set to %d", idSlot.ActiveVersion),
-		}
+		eventType = input.BindMode
+		eventDescription = fmt.Sprintf("New Active Version set to %d", idSlot.ActiveVersion)
 	}
 	_, err = svc.deviceManagerCli.UpdateDeviceIdentitySlot(ctx, services.UpdateDeviceIdentitySlotInput{
 		ID:   crt.Subject.CommonName,
@@ -1197,6 +1192,18 @@ func (svc DMSManagerServiceBackend) BindIdentityToDevice(ctx context.Context, in
 	})
 	if err != nil {
 		lFunc.Errorf("could not update device '%s' identity slot. Aborting enrollment process: %s", device.ID, err)
+		return nil, err
+	}
+
+	_, err = svc.deviceManagerCli.CreateDeviceEvent(ctx, services.CreateDeviceEventInput{
+		DeviceID:    crt.Subject.CommonName,
+		Timestamp:   time.Now(),
+		Type:        eventType,
+		Description: eventDescription,
+		Source:      models.DMSManagerSource,
+	})
+	if err != nil {
+		lFunc.Errorf("could not create device event for device '%s': %s", device.ID, err)
 		return nil, err
 	}
 

--- a/backend/pkg/services/handlers/device-sse-handlers.go
+++ b/backend/pkg/services/handlers/device-sse-handlers.go
@@ -1,0 +1,74 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/cloudevents/sdk-go/v2/event"
+	"github.com/lamassuiot/lamassuiot/backend/v3/pkg/controllers"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/services/eventhandling"
+	"github.com/sirupsen/logrus"
+)
+
+func NewDeviceEventSSEHandler(l *logrus.Entry, hub *controllers.DeviceEventSSEHub) *eventhandling.CloudEventHandler {
+	genericHandler := func(ctx context.Context, e *event.Event) error {
+		return handleAnyDeviceEventForSSE(ctx, e, hub, l)
+	}
+
+	return &eventhandling.CloudEventHandler{
+		Logger: l,
+		DispatchMap: map[string]func(context.Context, *event.Event) error{
+			string(models.EventCreateDeviceKey):         genericHandler,
+			string(models.EventUpdateDeviceStatusKey):   genericHandler,
+			string(models.EventUpdateDeviceIDSlotKey):   genericHandler,
+			string(models.EventUpdateDeviceMetadataKey): genericHandler,
+			string(models.EventDeleteDeviceKey):         genericHandler,
+			string(models.EventCreateDeviceEventKey):    genericHandler,
+		},
+	}
+}
+
+func handleAnyDeviceEventForSSE(ctx context.Context, cloudEvent *event.Event, hub *controllers.DeviceEventSSEHub, l *logrus.Entry) error {
+	// Extract device ID from the cloud event subject
+	// Subjects: "device/{deviceID}" or "device/{deviceID}/event"
+	subject := cloudEvent.Subject()
+	deviceID := extractDeviceIDFromSubject(subject)
+	if deviceID == "" {
+		l.Warnf("could not extract device ID from event subject: %s", subject)
+		return nil
+	}
+
+	// Forward the raw cloud event data as-is
+	var payload interface{}
+	if err := json.Unmarshal(cloudEvent.Data(), &payload); err != nil {
+		err = fmt.Errorf("could not decode cloud event data for SSE: %s", err)
+		l.Error(err)
+		return err
+	}
+
+	l.Debugf("pushing %s event to SSE hub for device %s", cloudEvent.Type(), deviceID)
+	hub.Publish(deviceID, cloudEvent.Type(), payload)
+	return nil
+}
+
+func extractDeviceIDFromSubject(subject string) string {
+	// Subject formats:
+	//   "device/{deviceID}"        - for device create, update, delete
+	//   "device/{deviceID}/event"  - for device event create
+	const prefix = "device/"
+	if !strings.HasPrefix(subject, prefix) {
+		return ""
+	}
+
+	rest := subject[len(prefix):]
+	// Strip trailing "/event" if present
+	rest = strings.TrimSuffix(rest, "/event")
+
+	if rest == "" {
+		return ""
+	}
+	return rest
+}

--- a/backend/pkg/services/handlers/device-sse-handlers.go
+++ b/backend/pkg/services/handlers/device-sse-handlers.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"github.com/cloudevents/sdk-go/v2/event"
@@ -41,16 +40,14 @@ func handleAnyDeviceEventForSSE(ctx context.Context, cloudEvent *event.Event, hu
 		return nil
 	}
 
-	// Forward the raw cloud event data as-is
-	var payload interface{}
-	if err := json.Unmarshal(cloudEvent.Data(), &payload); err != nil {
-		err = fmt.Errorf("could not decode cloud event data for SSE: %s", err)
-		l.Error(err)
-		return err
-	}
-
+	// Forward the raw cloud event data as-is. SSE streaming is a best-effort
+	// side channel, so we never NACK the cloud event from this handler — that
+	// would have the Watermill router retry and eventually DLQ the message,
+	// creating operational noise for what is at most a missed UI tick.
+	// Passing json.RawMessage also avoids a decode step that could fail on
+	// schema drift.
 	l.Debugf("pushing %s event to SSE hub for device %s", cloudEvent.Type(), deviceID)
-	hub.Publish(deviceID, cloudEvent.Type(), payload)
+	hub.Publish(deviceID, cloudEvent.Type(), json.RawMessage(cloudEvent.Data()))
 	return nil
 }
 

--- a/connectors/awsiot/pkg/service.go
+++ b/connectors/awsiot/pkg/service.go
@@ -606,17 +606,18 @@ func (svc *AWSCloudConnectorServiceBackend) UpdateDeviceShadow(ctx context.Conte
 		return err
 	}
 
-	device.IdentitySlot.Events[time.Now()] = models.DeviceEvent{
-		EvenType:          models.DeviceEventTypeShadowUpdated,
-		EventDescriptions: fmt.Sprintf("Remediation Actions: %s", strings.Join(actionsLogs, ", ")),
-	}
-
-	_, err = svc.DeviceSDK.UpdateDeviceIdentitySlot(ctx, services.UpdateDeviceIdentitySlotInput{
-		ID:   input.DeviceID,
-		Slot: *device.IdentitySlot,
+	_, err = svc.DeviceSDK.CreateDeviceEvent(ctx, services.CreateDeviceEventInput{
+		DeviceID:    input.DeviceID,
+		Timestamp:   time.Now(),
+		Type:        models.DeviceEventTypeShadowUpdated,
+		Description: fmt.Sprintf("Remediation Actions: %s", strings.Join(actionsLogs, ", ")),
+		Source:      AWSIoTSource(svc.ConnectorID),
+		StructuredFields: map[string]any{
+			"actions": actions,
+		},
 	})
 	if err != nil {
-		lFunc.Errorf("could not update device metadata: %s", err)
+		lFunc.Errorf("could not create device event: %s", err)
 		return err
 	}
 

--- a/core/pkg/engines/storage/alerts.go
+++ b/core/pkg/engines/storage/alerts.go
@@ -17,5 +17,5 @@ type SubscriptionsRepository interface {
 type EventRepository interface {
 	GetLatestEventByEventType(ctx context.Context, eventType models.EventType) (bool, *models.AlertLatestEvent, error)
 	InsertUpdateEvent(ctx context.Context, ev *models.AlertLatestEvent) (*models.AlertLatestEvent, error)
-	GetLatestEvents(ctx context.Context) ([]*models.AlertLatestEvent, error)
+	GetLatestEvents(ctx context.Context, req StorageListRequest[models.AlertLatestEvent]) (string, error)
 }

--- a/core/pkg/engines/storage/devicemanager.go
+++ b/core/pkg/engines/storage/devicemanager.go
@@ -18,6 +18,15 @@ type DeviceManagerRepo interface {
 
 	// DeviceGroups returns the device groups repository
 	DeviceGroups() DeviceGroupsRepo
+
+	// DeviceEvents returns the device events repository
+	DeviceEvents() DeviceEventsRepo
+}
+
+type DeviceEventsRepo interface {
+	Insert(ctx context.Context, event *models.DeviceEventRecord) (*models.DeviceEventRecord, error)
+	SelectByDeviceID(ctx context.Context, req StorageListRequest[models.DeviceEventRecord], deviceID string) (string, error)
+	DeleteByDeviceID(ctx context.Context, deviceID string) error
 }
 
 type DeviceGroupsRepo interface {

--- a/core/pkg/models/device.go
+++ b/core/pkg/models/device.go
@@ -37,7 +37,7 @@ type Device struct {
 	DMSOwner          string                    `json:"dms_owner"`
 	IdentitySlot      *Slot[string]             `json:"identity,omitempty" gorm:"serializer:json"`
 	ExtraSlots        map[string]*Slot[any]     `json:"slots" gorm:"serializer:json"`
-	Events            map[time.Time]DeviceEvent `json:"events" gorm:"serializer:json"`
+	Events            map[time.Time]DeviceEvent `json:"events,omitempty" gorm:"-"`
 }
 
 type Slot[E any] struct {
@@ -62,8 +62,26 @@ const (
 )
 
 type DeviceEvent struct {
+	ID                string          `json:"id,omitempty" gorm:"-"`
+	EventTS           time.Time       `json:"event_ts,omitempty" gorm:"-"`
 	EvenType          DeviceEventType `json:"type"`
 	EventDescriptions string          `json:"description"`
+	Source            string          `json:"source,omitempty" gorm:"-"`
+	StructuredFields  map[string]any  `json:"structured_fields" gorm:"serializer:json"`
+}
+
+type DeviceEventRecord struct {
+	ID               string         `json:"id" gorm:"primaryKey"`
+	DeviceID         string         `json:"device_id"`
+	EventTS          time.Time      `json:"event_ts"`
+	EventType        string         `json:"event_type"`
+	Description      string         `json:"description,omitempty"`
+	Source           string         `json:"source,omitempty"`
+	StructuredFields map[string]any `json:"structured_fields" gorm:"serializer:json"`
+}
+
+func (DeviceEventRecord) TableName() string {
+	return "device_events"
 }
 
 type DevicesStats struct {

--- a/core/pkg/models/device.go
+++ b/core/pkg/models/device.go
@@ -59,6 +59,10 @@ const (
 	DeviceEventTypeShadowUpdated        DeviceEventType = "SHADOW-UPDATED"
 	DeviceEventTypeStatusUpdated        DeviceEventType = "STATUS-UPDATED"
 	DeviceEventTypeStatusDecommissioned DeviceEventType = "DECOMMISSIONED"
+	// DeviceEventTypeUnknown is emitted by the legacy-events migration when an
+	// event's `type` was missing in the old JSON column. Keep it in the enum so
+	// API responses for migrated rows don't violate the OpenAPI contract.
+	DeviceEventTypeUnknown DeviceEventType = "UNKNOWN"
 )
 
 type DeviceEvent struct {

--- a/core/pkg/models/device.go
+++ b/core/pkg/models/device.go
@@ -37,7 +37,7 @@ type Device struct {
 	DMSOwner          string                    `json:"dms_owner"`
 	IdentitySlot      *Slot[string]             `json:"identity,omitempty" gorm:"serializer:json"`
 	ExtraSlots        map[string]*Slot[any]     `json:"slots" gorm:"serializer:json"`
-	Events            map[time.Time]DeviceEvent `json:"events,omitempty" gorm:"-"`
+	Events            map[time.Time]DeviceEvent `json:"-" gorm:"-"`
 }
 
 type Slot[E any] struct {

--- a/core/pkg/models/device_test.go
+++ b/core/pkg/models/device_test.go
@@ -1,0 +1,9 @@
+package models
+
+import "testing"
+
+func TestDeviceEventRecordTableName(t *testing.T) {
+	if got, want := (DeviceEventRecord{}).TableName(), "device_events"; got != want {
+		t.Fatalf("DeviceEventRecord.TableName() = %q, want %q", got, want)
+	}
+}

--- a/core/pkg/models/events.go
+++ b/core/pkg/models/events.go
@@ -63,6 +63,7 @@ const (
 	EventUpdateDeviceStatusKey   EventType = "device.status.update"
 	EventUpdateDeviceMetadataKey EventType = "device.metadata.update"
 	EventDeleteDeviceKey         EventType = "device.delete"
+	EventCreateDeviceEventKey    EventType = "device.event.create"
 
 	EventCreateDeviceGroupKey EventType = "device-group.create"
 	EventUpdateDeviceGroupKey EventType = "device-group.update"

--- a/core/pkg/resources/caresp.go
+++ b/core/pkg/resources/caresp.go
@@ -6,6 +6,10 @@ type GetCAsResponse struct {
 	IterableList[models.CACertificate]
 }
 
+type GetAlertsResponse struct {
+	IterableList[models.AlertLatestEvent]
+}
+
 type GetItemsResponse[T any] struct {
 	IterableList[T]
 }

--- a/core/pkg/resources/devreq.go
+++ b/core/pkg/resources/devreq.go
@@ -1,6 +1,8 @@
 package resources
 
 import (
+	"time"
+
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
 )
 
@@ -20,6 +22,14 @@ type UpdateDeviceIdentitySlotBody struct {
 
 type UpdateDeviceMetadataBody struct {
 	Patches []models.PatchOperation `json:"patches"`
+}
+
+type CreateDeviceEventBody struct {
+	Timestamp        time.Time              `json:"event_ts"`
+	Type             models.DeviceEventType `json:"type"`
+	Description      string                 `json:"description"`
+	Source           string                 `json:"source"`
+	StructuredFields map[string]any         `json:"structured_fields"`
 }
 
 // Device Group Request Bodies

--- a/core/pkg/resources/devreq.go
+++ b/core/pkg/resources/devreq.go
@@ -25,7 +25,10 @@ type UpdateDeviceMetadataBody struct {
 }
 
 type CreateDeviceEventBody struct {
-	Timestamp        time.Time              `json:"event_ts"`
+	// omitzero (Go 1.24+) is required here: stdlib `omitempty` has no effect on
+	// time.Time because it's a struct, so the zero value would still be marshalled
+	// as "0001-01-01T00:00:00Z" if a client encoded this struct directly.
+	Timestamp        time.Time              `json:"event_ts,omitzero"`
 	Type             models.DeviceEventType `json:"type"`
 	Description      string                 `json:"description"`
 	Source           string                 `json:"source"`

--- a/core/pkg/resources/devresp.go
+++ b/core/pkg/resources/devresp.go
@@ -6,6 +6,10 @@ type GetDevicesResponse struct {
 	IterableList[models.Device]
 }
 
+type GetDeviceEventsResponse struct {
+	IterableList[models.DeviceEvent]
+}
+
 type GetDeviceGroupsResponse struct {
 	IterableList[models.DeviceGroup]
 }

--- a/core/pkg/resources/fields.go
+++ b/core/pkg/resources/fields.go
@@ -18,6 +18,14 @@ var DeviceFilterableFields = map[string]FilterFieldType{
 	"identity_slot":      JsonFilterFieldType,
 }
 
+var DeviceEventFilterableFields = map[string]FilterFieldType{
+	"event_ts":          DateFilterFieldType,
+	"event_type":        EnumFilterFieldType,
+	"description":       StringFilterFieldType,
+	"source":            StringFilterFieldType,
+	"structured_fields": JsonFilterFieldType,
+}
+
 var CertificateFilterableFields = map[string]FilterFieldType{
 	"type":                 EnumFilterFieldType,
 	"serial_number":        StringFilterFieldType,
@@ -31,4 +39,10 @@ var CertificateFilterableFields = map[string]FilterFieldType{
 	"revocation_timestamp": DateFilterFieldType,
 	"revocation_reason":    EnumFilterFieldType,
 	"metadata":             JsonFilterFieldType,
+}
+
+var AlertFilterableFields = map[string]FilterFieldType{
+	"event_type": StringFilterFieldType,
+	"seen_at":    DateFilterFieldType,
+	"counter":    NumberFilterFieldType,
 }

--- a/core/pkg/resources/fields.go
+++ b/core/pkg/resources/fields.go
@@ -76,15 +76,15 @@ var DeviceFilterableFields = map[string]FilterFieldType{
 }
 
 var DeviceEventFilterableFields = map[string]FilterFieldType{
-        "event_ts":          DateFilterFieldType,
-        "event_type":        EnumFilterFieldType,
-        "description":       StringFilterFieldType,
-        "source":            StringFilterFieldType,
-        "structured_fields": JsonFilterFieldType,
+	"event_ts":          DateFilterFieldType,
+	"event_type":        EnumFilterFieldType,
+	"description":       StringFilterFieldType,
+	"source":            StringFilterFieldType,
+	"structured_fields": JsonFilterFieldType,
 }
 
 var AlertFilterableFields = map[string]FilterFieldType{
-        "event_type": StringFilterFieldType,
-        "seen_at":    DateFilterFieldType,
-        "counter":    NumberFilterFieldType,
+	"event_type": StringFilterFieldType,
+	"seen_at":    DateFilterFieldType,
+	"counter":    NumberFilterFieldType,
 }

--- a/core/pkg/resources/fields.go
+++ b/core/pkg/resources/fields.go
@@ -74,3 +74,17 @@ var DeviceFilterableFields = map[string]FilterFieldType{
 	"metadata":           JsonFilterFieldType,
 	"identity_slot":      JsonFilterFieldType,
 }
+
+var DeviceEventFilterableFields = map[string]FilterFieldType{
+        "event_ts":          DateFilterFieldType,
+        "event_type":        EnumFilterFieldType,
+        "description":       StringFilterFieldType,
+        "source":            StringFilterFieldType,
+        "structured_fields": JsonFilterFieldType,
+}
+
+var AlertFilterableFields = map[string]FilterFieldType{
+        "event_type": StringFilterFieldType,
+        "seen_at":    DateFilterFieldType,
+        "counter":    NumberFilterFieldType,
+}

--- a/core/pkg/services/alerts.go
+++ b/core/pkg/services/alerts.go
@@ -5,6 +5,7 @@ import (
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/resources"
 )
 
 type AlertsService interface {
@@ -13,14 +14,19 @@ type AlertsService interface {
 	Subscribe(ctx context.Context, input *SubscribeInput) ([]*models.Subscription, error)
 	Unsubscribe(ctx context.Context, input *UnsubscribeInput) ([]*models.Subscription, error)
 
-	GetLatestEventsPerEventType(ctx context.Context, input *GetLatestEventsPerEventTypeInput) ([]*models.AlertLatestEvent, error)
+	GetLatestEventsPerEventType(ctx context.Context, input *GetLatestEventsPerEventTypeInput) (string, error)
 }
 
 type HandleEventInput struct {
 	Event cloudevents.Event
 }
 
-type GetLatestEventsPerEventTypeInput struct{}
+type GetLatestEventsPerEventTypeInput struct {
+	QueryParameters *resources.QueryParameters
+
+	ExhaustiveRun bool
+	ApplyFunc     func(event models.AlertLatestEvent)
+}
 
 type GetUserSubscriptionsInput struct {
 	UserID string

--- a/core/pkg/services/devicemanager.go
+++ b/core/pkg/services/devicemanager.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"time"
 
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/resources"
@@ -11,12 +12,18 @@ type DeviceManagerService interface {
 	GetDevicesStats(ctx context.Context, input GetDevicesStatsInput) (*models.DevicesStats, error)
 	CreateDevice(ctx context.Context, input CreateDeviceInput) (*models.Device, error)
 	GetDeviceByID(ctx context.Context, input GetDeviceByIDInput) (*models.Device, error)
+
 	GetDevices(ctx context.Context, input GetDevicesInput) (string, error)
 	GetDeviceByDMS(ctx context.Context, input GetDevicesByDMSInput) (string, error)
 	UpdateDeviceStatus(ctx context.Context, input UpdateDeviceStatusInput) (*models.Device, error)
 	UpdateDeviceIdentitySlot(ctx context.Context, input UpdateDeviceIdentitySlotInput) (*models.Device, error)
 	UpdateDeviceMetadata(ctx context.Context, input UpdateDeviceMetadataInput) (*models.Device, error)
 	DeleteDevice(ctx context.Context, input DeleteDeviceInput) error
+
+	// Device Event operations
+	GetDeviceEvents(ctx context.Context, input GetDeviceEventsInput) (string, error)
+	CreateDeviceEvent(ctx context.Context, input CreateDeviceEventInput) (*models.DeviceEvent, error)
+	
 
 	// Device Group operations
 	CreateDeviceGroup(ctx context.Context, input CreateDeviceGroupInput) (*models.DeviceGroup, error)
@@ -58,6 +65,20 @@ type GetDevicesByDMSInput struct {
 
 type GetDeviceByIDInput struct {
 	ID string `validate:"required"`
+}
+
+type GetDeviceEventsInput struct {
+	DeviceID string `validate:"required"`
+	resources.ListInput[models.DeviceEvent]
+}
+
+type CreateDeviceEventInput struct {
+	DeviceID         string `validate:"required"`
+	Timestamp        time.Time
+	Type             models.DeviceEventType `validate:"required"`
+	Description      string
+	Source           string
+	StructuredFields map[string]any
 }
 
 type UpdateDeviceStatusInput struct {

--- a/core/pkg/services/mock/devicemanager_mock.go
+++ b/core/pkg/services/mock/devicemanager_mock.go
@@ -27,6 +27,16 @@ func (dm *MockDeviceManagerService) GetDeviceByID(ctx context.Context, input ser
 	return args.Get(0).(*models.Device), args.Error(1)
 }
 
+func (dm *MockDeviceManagerService) GetDeviceEvents(ctx context.Context, input services.GetDeviceEventsInput) (string, error) {
+	args := dm.Called(ctx, input)
+	return args.String(0), args.Error(1)
+}
+
+func (dm *MockDeviceManagerService) CreateDeviceEvent(ctx context.Context, input services.CreateDeviceEventInput) (*models.DeviceEvent, error) {
+	args := dm.Called(ctx, input)
+	return args.Get(0).(*models.DeviceEvent), args.Error(1)
+}
+
 func (dm *MockDeviceManagerService) GetDevices(ctx context.Context, input services.GetDevicesInput) (string, error) {
 	args := dm.Called(ctx, input)
 	return args.String(0), args.Error(1)

--- a/docs/alerts-openapi.yaml
+++ b/docs/alerts-openapi.yaml
@@ -29,15 +29,36 @@ paths:
       tags: [Events]
       summary: Get the latest event per event type
       operationId: getLatestEvents
+      parameters:
+        - name: page_size
+          in: query
+          required: false
+          description: Maximum number of events to return
+          schema:
+            type: integer
+            minimum: 1
+            default: 25
+        - name: bookmark
+          in: query
+          required: false
+          description: Opaque bookmark token for next page retrieval
+          schema:
+            type: string
       responses:
         '200':
           description: Latest events grouped by type
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/AlertLatestEvent'
+                type: object
+                properties:
+                  next:
+                    type: string
+                    description: Bookmark for the next page. Empty when no more items are available.
+                  list:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/AlertLatestEvent'
         '500':
           description: Internal server error
           content:

--- a/docs/alerts-openapi.yaml
+++ b/docs/alerts-openapi.yaml
@@ -44,6 +44,41 @@ paths:
           description: Opaque bookmark token for next page retrieval
           schema:
             type: string
+        - name: sort_by
+          in: query
+          required: false
+          description: |
+            Field to sort by. Supported fields: `event_type`, `seen_at`, `counter`.
+          schema:
+            type: string
+            enum: [event_type, seen_at, counter]
+        - name: sort_mode
+          in: query
+          required: false
+          description: Sort direction.
+          schema:
+            type: string
+            enum: [asc, desc]
+        - name: filter
+          in: query
+          required: false
+          description: |
+            Filter expression. Repeat the parameter to combine multiple filters
+            (e.g. `filter=event_type[eq]:DEVICE-CREATED&filter=counter[gt]:5`).
+
+            **Supported fields and types:**
+            - `event_type` (string)
+            - `seen_at` (date)
+            - `counter` (number)
+
+            **Operators by type:**
+            - String: `eq`, `eq_ic`, `ne`, `ne_ic`, `ct`, `ct_ic`, `nc`, `nc_ic`
+            - Date: `eq`, `bf`, `af`
+            - Number: `eq`, `ne`, `lt`, `le`, `gt`, `ge`
+          schema:
+            type: string
+          explode: true
+          style: form
       responses:
         '200':
           description: Latest events grouped by type

--- a/docs/device-manager-openapi.yaml
+++ b/docs/device-manager-openapi.yaml
@@ -231,10 +231,12 @@ paths:
                 $ref: '#/components/schemas/GetDeviceEventsResponse'
             text/event-stream:
               schema:
-                $ref: '#/components/schemas/DeviceEvent'
+                $ref: '#/components/schemas/DeviceSSEMessage'
               description: |
-                When negotiated via `Accept: text/event-stream`, each SSE message's
-                `data` field carries a single `DeviceEvent` JSON object.
+                When negotiated via `Accept: text/event-stream`, each SSE event's
+                JSON body is a `DeviceSSEMessage` envelope: an `event_type` string
+                (the CloudEvent type, e.g. `device.status.update`) and a `data`
+                field containing the underlying payload (typically a `DeviceEvent`).
         '400': { $ref: '#/components/responses/BadRequest' }
         '404': { $ref: '#/components/responses/NotFound' }
         '500': { $ref: '#/components/responses/InternalError' }
@@ -1100,6 +1102,25 @@ components:
         structured_fields:
           type: object
           additionalProperties: true
+
+    DeviceSSEMessage:
+      type: object
+      description: |
+        Envelope streamed over Server-Sent Events for `/devices/{id}/events`.
+        `event_type` is the underlying CloudEvent type and `data` is the
+        event-specific payload (currently a `DeviceEvent` for device-event
+        streams, but may evolve to other shapes for other event types).
+      required: [event_type, data]
+      properties:
+        event_type:
+          type: string
+          description: CloudEvent type, e.g. `device.status.update`.
+        data:
+          description: Event payload. For device-event streams this is a DeviceEvent.
+          oneOf:
+            - $ref: '#/components/schemas/DeviceEvent'
+            - type: object
+              additionalProperties: true
 
     GetDeviceEventsResponse:
       type: object

--- a/docs/device-manager-openapi.yaml
+++ b/docs/device-manager-openapi.yaml
@@ -1084,6 +1084,7 @@ components:
         - SHADOW-UPDATED
         - STATUS-UPDATED
         - DECOMMISSIONED
+        - UNKNOWN
 
     DeviceEvent:
       type: object

--- a/docs/device-manager-openapi.yaml
+++ b/docs/device-manager-openapi.yaml
@@ -205,6 +205,68 @@ paths:
         '404': { $ref: '#/components/responses/NotFound' }
         '500': { $ref: '#/components/responses/InternalError' }
 
+  /devices/{id}/events:
+    get:
+      tags: [Devices]
+      summary: List device events
+      description: |
+        Returns the audit/event history for a single device, with pagination, sorting
+        and filtering. When the client sends `Accept: text/event-stream`, the server
+        switches to a Server-Sent Events stream of new events instead of returning a
+        paginated JSON list.
+      operationId: getDeviceEvents
+      parameters:
+        - $ref: '#/components/parameters/DeviceId'
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/Bookmark'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/SortMode'
+        - $ref: '#/components/parameters/DeviceEventFilter'
+      responses:
+        '200':
+          description: Paginated list of device events
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetDeviceEventsResponse'
+            text/event-stream:
+              schema:
+                $ref: '#/components/schemas/DeviceEvent'
+              description: |
+                When negotiated via `Accept: text/event-stream`, each SSE message's
+                `data` field carries a single `DeviceEvent` JSON object.
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '500': { $ref: '#/components/responses/InternalError' }
+        '501':
+          description: SSE is disabled by configuration or not supported in this deployment
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      tags: [Devices]
+      summary: Create a device event
+      operationId: createDeviceEvent
+      parameters:
+        - $ref: '#/components/parameters/DeviceId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateDeviceEventBody'
+      responses:
+        '201':
+          description: Created event
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceEvent'
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '500': { $ref: '#/components/responses/InternalError' }
+
   /devices/{id}/decommission:
     delete:
       tags: [Devices]
@@ -638,6 +700,27 @@ components:
         - Multiple filters: `filter=dms_owner[eq]:dms-prod&filter=tags[contains]:server`
         - Date range: `filter=creation_timestamp[af]:2024-01-01T00:00:00Z`
 
+    DeviceEventFilter:
+      name: filter
+      in: query
+      required: false
+      explode: true
+      style: form
+      schema:
+        type: string
+      description: |
+        Filter expression for device event search. Repeat the parameter to combine
+        multiple filters (e.g. `filter=event_type[eq]:STATUS-UPDATED&filter=event_ts[af]:2026-01-01T00:00:00Z`).
+
+        **Supported Fields:**
+        - `event_ts` (date): Event timestamp
+        - `event_type` (enum): Event type (CREATED, PROVISIONED, RE-PROVISIONED, RENEWED, SHADOW-UPDATED, STATUS-UPDATED, DECOMMISSIONED)
+        - `description` (string): Free-text event description
+        - `source` (string): Originating subsystem
+        - `structured_fields` (json): Structured payload, queryable via JSON-path operators
+
+        Operators follow the same conventions as device filtering (see `filter` on `/devices`).
+
     DeviceGroupFilter:
       name: filter
       in: query
@@ -988,7 +1071,61 @@ components:
         slots:
           type: object
           additionalProperties: true
-        events:
+
+    DeviceEventType:
+      type: string
+      enum:
+        - CREATED
+        - PROVISIONED
+        - RE-PROVISIONED
+        - RENEWED
+        - SHADOW-UPDATED
+        - STATUS-UPDATED
+        - DECOMMISSIONED
+
+    DeviceEvent:
+      type: object
+      properties:
+        id:
+          type: string
+        event_ts:
+          type: string
+          format: date-time
+        type:
+          $ref: '#/components/schemas/DeviceEventType'
+        description:
+          type: string
+        source:
+          type: string
+        structured_fields:
+          type: object
+          additionalProperties: true
+
+    GetDeviceEventsResponse:
+      type: object
+      properties:
+        next:
+          type: string
+        list:
+          type: array
+          items:
+            $ref: '#/components/schemas/DeviceEvent'
+
+    CreateDeviceEventBody:
+      type: object
+      required: [type]
+      properties:
+        event_ts:
+          type: string
+          format: date-time
+          description: Optional client-supplied timestamp; server timestamps when omitted.
+        type:
+          $ref: '#/components/schemas/DeviceEventType'
+        description:
+          type: string
+        source:
+          type: string
+        structured_fields:
           type: object
           additionalProperties: true
 

--- a/engines/storage/postgres/device_events.go
+++ b/engines/storage/postgres/device_events.go
@@ -1,0 +1,43 @@
+package postgres
+
+import (
+	"context"
+
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/engines/storage"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
+	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+)
+
+type PostgresDeviceEventsStore struct {
+	db      *gorm.DB
+	querier *postgresDBQuerier[models.DeviceEventRecord]
+}
+
+func NewDeviceEventsRepository(logger *logrus.Entry, db *gorm.DB) (storage.DeviceEventsRepo, error) {
+	querier, err := TableQuery(logger, db, "device_events", "id", models.DeviceEventRecord{})
+	if err != nil {
+		return nil, err
+	}
+
+	return &PostgresDeviceEventsStore{
+		db:      db,
+		querier: querier,
+	}, nil
+}
+
+func (db *PostgresDeviceEventsStore) Insert(ctx context.Context, event *models.DeviceEventRecord) (*models.DeviceEventRecord, error) {
+	return db.querier.Insert(ctx, event, event.ID)
+}
+
+func (db *PostgresDeviceEventsStore) SelectByDeviceID(ctx context.Context, req storage.StorageListRequest[models.DeviceEventRecord], deviceID string) (string, error) {
+	opts := []gormExtraOps{
+		{query: "device_id = ?", additionalWhere: []any{deviceID}},
+	}
+
+	return db.querier.SelectAll(ctx, req.QueryParams, opts, req.ExhaustiveRun, req.ApplyFunc)
+}
+
+func (db *PostgresDeviceEventsStore) DeleteByDeviceID(ctx context.Context, deviceID string) error {
+	return db.db.WithContext(ctx).Where("device_id = ?", deviceID).Delete(&models.DeviceEventRecord{}).Error
+}

--- a/engines/storage/postgres/devicemanager.go
+++ b/engines/storage/postgres/devicemanager.go
@@ -14,6 +14,7 @@ type PostgresDeviceManagerStore struct {
 	db               *gorm.DB
 	querier          *postgresDBQuerier[models.Device]
 	deviceGroupsRepo storage.DeviceGroupsRepo
+	deviceEventsRepo storage.DeviceEventsRepo
 }
 
 func NewDeviceManagerRepository(logger *logrus.Entry, db *gorm.DB) (storage.DeviceManagerRepo, error) {
@@ -28,10 +29,16 @@ func NewDeviceManagerRepository(logger *logrus.Entry, db *gorm.DB) (storage.Devi
 		return nil, err
 	}
 
+	deviceEventsRepo, err := NewDeviceEventsRepository(logger, db)
+	if err != nil {
+		return nil, err
+	}
+
 	return &PostgresDeviceManagerStore{
 		db:               db,
 		querier:          querier,
 		deviceGroupsRepo: deviceGroupsRepo,
+		deviceEventsRepo: deviceEventsRepo,
 	}, nil
 }
 
@@ -72,4 +79,8 @@ func (db *PostgresDeviceManagerStore) Delete(ctx context.Context, ID string) err
 
 func (db *PostgresDeviceManagerStore) DeviceGroups() storage.DeviceGroupsRepo {
 	return db.deviceGroupsRepo
+}
+
+func (db *PostgresDeviceManagerStore) DeviceEvents() storage.DeviceEventsRepo {
+	return db.deviceEventsRepo
 }

--- a/engines/storage/postgres/eventstore.go
+++ b/engines/storage/postgres/eventstore.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/engines/storage"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
-	"github.com/lamassuiot/lamassuiot/core/v3/pkg/resources"
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )
@@ -42,16 +41,6 @@ func (db *PostgresEventsStore) GetLatestEventByEventType(ctx context.Context, ev
 	return db.querier.SelectExists(ctx, string(eventType), nil)
 }
 
-func (db *PostgresEventsStore) GetLatestEvents(ctx context.Context) ([]*models.AlertLatestEvent, error) {
-	evs := []*models.AlertLatestEvent{}
-	_, err := db.querier.SelectAll(ctx, &resources.QueryParameters{}, []gormExtraOps{}, true, func(elem models.AlertLatestEvent) {
-		derefElem := elem
-		evs = append(evs, &derefElem)
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	return evs, nil
+func (db *PostgresEventsStore) GetLatestEvents(ctx context.Context, req storage.StorageListRequest[models.AlertLatestEvent]) (string, error) {
+	return db.querier.SelectAll(ctx, req.QueryParams, []gormExtraOps{}, req.ExhaustiveRun, req.ApplyFunc)
 }

--- a/engines/storage/postgres/migrations/devicemanager/20260317120000_create_device_events.sql
+++ b/engines/storage/postgres/migrations/devicemanager/20260317120000_create_device_events.sql
@@ -1,0 +1,71 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE device_events (
+	id text NOT NULL,
+	device_id text NOT NULL,
+	event_ts timestamptz NOT NULL,
+	event_type text NOT NULL,
+	description text NULL,
+	source text NULL,
+	structured_fields jsonb NULL,
+	CONSTRAINT device_events_pkey PRIMARY KEY (id),
+	CONSTRAINT fk_device_events_device FOREIGN KEY (device_id) REFERENCES devices (id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_device_events_device_id ON device_events (device_id);
+CREATE INDEX idx_device_events_event_ts ON device_events (event_ts DESC);
+CREATE INDEX idx_device_events_event_type ON device_events (event_type);
+CREATE INDEX idx_device_events_structured_fields_gin ON device_events USING GIN (structured_fields);
+
+INSERT INTO device_events (id, device_id, event_ts, event_type, description, source, structured_fields)
+SELECT
+	md5(d.id || ':' || ev.key || ':' || ev.value::text),
+	d.id,
+	CASE
+		WHEN ev.key ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}.*$' THEN ev.key::timestamptz
+		ELSE COALESCE(d.creation_timestamp, now())
+	END,
+	COALESCE(ev.value->>'type', 'UNKNOWN'),
+	COALESCE(ev.value->>'description', ''),
+	COALESCE(NULLIF(ev.value->>'source', ''), 'service/devmanager'),
+	CASE
+		WHEN jsonb_typeof(ev.value) = 'object' THEN (ev.value - 'type' - 'description' - 'source')
+		ELSE '{}'::jsonb
+	END
+FROM devices d
+CROSS JOIN LATERAL jsonb_each(
+	CASE
+		WHEN d.events IS NULL OR btrim(d.events) = '' THEN '{}'::jsonb
+		ELSE d.events::jsonb
+	END
+) ev;
+
+ALTER TABLE devices DROP COLUMN IF EXISTS events;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE devices ADD COLUMN IF NOT EXISTS events text NULL;
+
+UPDATE devices d
+SET events = COALESCE(
+	(
+		SELECT jsonb_object_agg(
+				de.event_ts::text,
+				jsonb_strip_nulls(
+					jsonb_build_object(
+						'type', de.event_type,
+						'description', de.description,
+						'source', NULLIF(de.source, ''),
+						'structured_fields', COALESCE(de.structured_fields, '{}'::jsonb)
+					)
+				)
+			)::text
+		FROM device_events de
+		WHERE de.device_id = d.id
+	),
+	'{}'
+);
+
+DROP TABLE IF EXISTS device_events;
+-- +goose StatementEnd

--- a/engines/storage/postgres/migrations/devicemanager/20260317120000_create_device_events.sql
+++ b/engines/storage/postgres/migrations/devicemanager/20260317120000_create_device_events.sql
@@ -12,7 +12,9 @@ CREATE TABLE device_events (
 	CONSTRAINT fk_device_events_device FOREIGN KEY (device_id) REFERENCES devices (id) ON DELETE CASCADE
 );
 
-CREATE INDEX idx_device_events_device_id ON device_events (device_id);
+-- Composite index covers the common access pattern: filter by device_id, ordered by event_ts DESC.
+-- It also subsumes lookups by device_id alone, so no separate single-column index is needed.
+CREATE INDEX idx_device_events_device_id_event_ts ON device_events (device_id, event_ts DESC);
 CREATE INDEX idx_device_events_event_ts ON device_events (event_ts DESC);
 CREATE INDEX idx_device_events_event_type ON device_events (event_type);
 CREATE INDEX idx_device_events_structured_fields_gin ON device_events USING GIN (structured_fields);
@@ -21,8 +23,11 @@ INSERT INTO device_events (id, device_id, event_ts, event_type, description, sou
 SELECT
 	md5(d.id || ':' || ev.key || ':' || ev.value::text),
 	d.id,
+	-- Strict ISO 8601 prefix (valid month and day) before attempting the timestamptz cast,
+	-- so loose-but-invalid keys like "2026-13-99..." fall through to the fallback branch
+	-- instead of aborting the migration.
 	CASE
-		WHEN ev.key ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}.*$' THEN ev.key::timestamptz
+		WHEN ev.key ~ '^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T[0-9]{2}:[0-9]{2}:[0-9]{2}' THEN ev.key::timestamptz
 		ELSE COALESCE(d.creation_timestamp, now())
 	END,
 	COALESCE(ev.value->>'type', 'UNKNOWN'),
@@ -47,6 +52,8 @@ ALTER TABLE devices DROP COLUMN IF EXISTS events;
 -- +goose StatementBegin
 ALTER TABLE devices ADD COLUMN IF NOT EXISTS events text NULL;
 
+-- Restore the legacy flat JSON shape: structured_fields keys live alongside type/description/source
+-- on the event object (matching what the Up migration consumed), not nested under a wrapper key.
 UPDATE devices d
 SET events = COALESCE(
 	(
@@ -56,10 +63,9 @@ SET events = COALESCE(
 					jsonb_build_object(
 						'type', de.event_type,
 						'description', de.description,
-						'source', NULLIF(de.source, ''),
-						'structured_fields', COALESCE(de.structured_fields, '{}'::jsonb)
+						'source', NULLIF(de.source, '')
 					)
-				)
+				) || COALESCE(de.structured_fields, '{}'::jsonb)
 			)::text
 		FROM device_events de
 		WHERE de.device_id = d.id

--- a/engines/storage/postgres/migrations_test/devicemanager_test.go
+++ b/engines/storage/postgres/migrations_test/devicemanager_test.go
@@ -234,6 +234,13 @@ func TestDeviceManagerMigrations(t *testing.T) {
 	if t.Failed() {
 		t.Fatalf("failed while running migration v20260120114736_create_device_groups")
 	}
+
+	CleanAllTables(t, logger, con)
+
+	MigrationTest_DeviceManager_20260317120000_create_device_events(t, logger, con)
+	if t.Failed() {
+		t.Fatalf("failed while running migration v20260317120000_create_device_events")
+	}
 }
 
 func MigrationTest_DeviceManager_20251217120000_metadata_text_to_jsonb(t *testing.T, logger *logrus.Entry, con *gorm.DB) {
@@ -423,4 +430,96 @@ func MigrationTest_DeviceManager_20260120114736_create_device_groups(t *testing.
 		WHERE tablename = 'device_groups' 
 		AND indexname IN ('idx_device_groups_parent', 'idx_device_groups_name')`).Scan(&indexCount)
 	assert.Equal(t, int64(2), indexCount, "Should have both indexes")
+}
+
+func MigrationTest_DeviceManager_20260317120000_create_device_events(t *testing.T, logger *logrus.Entry, con *gorm.DB) {
+	// Insert test device with legacy events payload in devices.events
+	con.Exec(`INSERT INTO devices
+		(id, tags, status, icon, icon_color, creation_timestamp, metadata, dms_owner, identity_slot, extra_slots, events)
+		VALUES('device-with-events', '{}', 'ACTIVE', 'device', '#FF0000', '2026-03-17 10:00:00+00', '{}', 'test-dms', '{}', '{}',
+		'{"2026-03-17T10:30:00Z":{"type":"CREATED","description":"created"},"2026-03-17T11:30:00Z":{"type":"STATUS-UPDATED","description":"status changed","source":"legacy","details":{"from":"NO_IDENTITY","to":"ACTIVE"}},"2026-03-17T12:00:00Z":{"type":"CREATED","description":"created from main format"}}');
+	`)
+
+	// Insert another device without events to validate migration robustness
+	con.Exec(`INSERT INTO devices
+		(id, tags, status, icon, icon_color, creation_timestamp, metadata, dms_owner, identity_slot, extra_slots, events)
+		VALUES('device-without-events', '{}', 'NO_IDENTITY', 'device', '#00FF00', '2026-03-17 10:00:00+00', '{}', 'test-dms', NULL, '{}', NULL);
+	`)
+
+	ApplyMigration(t, logger, con, DeviceManagerDBName)
+
+	// Verify events column was removed from devices table
+	var eventsColumnCount int64
+	tx := con.Raw(`SELECT COUNT(*) FROM information_schema.columns WHERE table_name = 'devices' AND column_name = 'events'`).Scan(&eventsColumnCount)
+	if tx.Error != nil {
+		t.Fatalf("failed to inspect devices columns: %v", tx.Error)
+	}
+	assert.Equal(t, int64(0), eventsColumnCount, "devices.events column should be removed")
+
+	// Verify migrated events exist in normalized table
+	var migratedEventsCount int64
+	tx = con.Raw("SELECT COUNT(*) FROM device_events WHERE device_id = 'device-with-events'").Scan(&migratedEventsCount)
+	if tx.Error != nil {
+		t.Fatalf("failed to count device_events rows: %v", tx.Error)
+	}
+	assert.Equal(t, int64(3), migratedEventsCount, "expected three migrated events")
+
+	// Verify status-updated event mapped legacy source into source column
+	var source string
+	tx = con.Raw(`
+		SELECT source
+		FROM device_events
+		WHERE device_id = 'device-with-events' AND event_type = 'STATUS-UPDATED'
+		LIMIT 1
+	`).Scan(&source)
+	if tx.Error != nil {
+		t.Fatalf("failed to query migrated event data: %v", tx.Error)
+	}
+	assert.Equal(t, "legacy", source)
+
+	// Verify status-updated event data payload preserved extra fields
+	var fromInData string
+	tx = con.Raw(`
+		SELECT structured_fields->'details'->>'from'
+		FROM device_events
+		WHERE device_id = 'device-with-events' AND event_type = 'STATUS-UPDATED'
+		LIMIT 1
+	`).Scan(&fromInData)
+	if tx.Error != nil {
+		t.Fatalf("failed to query migrated event details payload: %v", tx.Error)
+	}
+	assert.Equal(t, "NO_IDENTITY", fromInData)
+
+	// Verify main-format created event receives default source and empty structured_fields
+	var createdEventSource string
+	tx = con.Raw(`
+		SELECT source
+		FROM device_events
+		WHERE device_id = 'device-with-events' AND event_type = 'CREATED' AND description = 'created from main format'
+		LIMIT 1
+	`).Scan(&createdEventSource)
+	if tx.Error != nil {
+		t.Fatalf("failed to query created event source: %v", tx.Error)
+	}
+	assert.Equal(t, "service/devmanager", createdEventSource)
+
+	var createdEventPayload string
+	tx = con.Raw(`
+		SELECT COALESCE(structured_fields::text, '{}')
+		FROM device_events
+		WHERE device_id = 'device-with-events' AND event_type = 'CREATED' AND description = 'created from main format'
+		LIMIT 1
+	`).Scan(&createdEventPayload)
+	if tx.Error != nil {
+		t.Fatalf("failed to query created event structured fields: %v", tx.Error)
+	}
+	assert.Equal(t, "{}", createdEventPayload)
+
+	// Verify no events migrated for device with NULL events payload
+	var noEventsCount int64
+	tx = con.Raw("SELECT COUNT(*) FROM device_events WHERE device_id = 'device-without-events'").Scan(&noEventsCount)
+	if tx.Error != nil {
+		t.Fatalf("failed to count events for device-without-events: %v", tx.Error)
+	}
+	assert.Equal(t, int64(0), noEventsCount)
 }

--- a/engines/storage/postgres/migrations_test/devicemanager_test.go
+++ b/engines/storage/postgres/migrations_test/devicemanager_test.go
@@ -2,6 +2,7 @@ package migrationstest
 
 import (
 	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/config"
@@ -446,11 +447,21 @@ func MigrationTest_DeviceManager_20260317120000_create_device_events(t *testing.
 		VALUES('device-without-events', '{}', 'NO_IDENTITY', 'device', '#00FF00', '2026-03-17 10:00:00+00', '{}', 'test-dms', NULL, '{}', NULL);
 	`)
 
+	// Insert real-world device data from production-like SQL dump (4 devices with ~218 events total)
+	sqlData, err := os.ReadFile("testdata/devices_202603301338.sql")
+	if err != nil {
+		t.Fatalf("failed to read testdata/devices_202603301338.sql: %v", err)
+	}
+	tx := con.Exec(string(sqlData))
+	if tx.Error != nil {
+		t.Fatalf("failed to insert real-world device data: %v", tx.Error)
+	}
+
 	ApplyMigration(t, logger, con, DeviceManagerDBName)
 
 	// Verify events column was removed from devices table
 	var eventsColumnCount int64
-	tx := con.Raw(`SELECT COUNT(*) FROM information_schema.columns WHERE table_name = 'devices' AND column_name = 'events'`).Scan(&eventsColumnCount)
+	tx = con.Raw(`SELECT COUNT(*) FROM information_schema.columns WHERE table_name = 'devices' AND column_name = 'events'`).Scan(&eventsColumnCount)
 	if tx.Error != nil {
 		t.Fatalf("failed to inspect devices columns: %v", tx.Error)
 	}
@@ -522,4 +533,79 @@ func MigrationTest_DeviceManager_20260317120000_create_device_events(t *testing.
 		t.Fatalf("failed to count events for device-without-events: %v", tx.Error)
 	}
 	assert.Equal(t, int64(0), noEventsCount)
+
+	// ---- Real-world data assertions ----
+	// Verify migrated event counts per device from production SQL dump
+	expectedCounts := map[string]int64{
+		"device_1": 58,
+		"device_2": 82,
+		"device_3": 41,
+		"device_4": 37,
+	}
+
+	for deviceID, expectedCount := range expectedCounts {
+		var count int64
+		tx = con.Raw("SELECT COUNT(*) FROM device_events WHERE device_id = ?", deviceID).Scan(&count)
+		if tx.Error != nil {
+			t.Fatalf("failed to count events for %s: %v", deviceID, tx.Error)
+		}
+		assert.Equal(t, expectedCount, count, "Event count mismatch for %s", deviceID)
+	}
+
+	// Verify total: 218 (real-world) + 3 (simple test device) = 221
+	var totalEvents int64
+	tx = con.Raw("SELECT COUNT(*) FROM device_events").Scan(&totalEvents)
+	if tx.Error != nil {
+		t.Fatalf("failed to count total events: %v", tx.Error)
+	}
+	assert.Equal(t, int64(221), totalEvents, "Total events: 218 real-world + 3 test")
+
+	// Each real-world device should have exactly 1 CREATED event
+	for _, deviceID := range []string{"device_1", "device_2", "device_3", "device_4"} {
+		var createdCount int64
+		tx = con.Raw("SELECT COUNT(*) FROM device_events WHERE device_id = ? AND event_type = 'CREATED'", deviceID).Scan(&createdCount)
+		if tx.Error != nil {
+			t.Fatalf("failed to count CREATED events for %s: %v", deviceID, tx.Error)
+		}
+		assert.Equal(t, int64(1), createdCount, "Device %s should have exactly 1 CREATED event", deviceID)
+	}
+
+	// All real-world events should have source defaulted to 'service/devmanager' (no source in original data)
+	var nonDefaultSourceCount int64
+	tx = con.Raw(`SELECT COUNT(*) FROM device_events 
+		WHERE device_id IN ('device_1','device_2','device_3','device_4') 
+		AND source != 'service/devmanager'`).Scan(&nonDefaultSourceCount)
+	if tx.Error != nil {
+		t.Fatalf("failed to check sources: %v", tx.Error)
+	}
+	assert.Equal(t, int64(0), nonDefaultSourceCount, "All real-world events should use default source")
+
+	// Verify all timestamps from real-world data fall within March 2026
+	var invalidTsCount int64
+	tx = con.Raw(`SELECT COUNT(*) FROM device_events 
+		WHERE device_id IN ('device_1','device_2','device_3','device_4') 
+		AND (event_ts < '2026-03-01' OR event_ts > '2026-04-01')`).Scan(&invalidTsCount)
+	if tx.Error != nil {
+		t.Fatalf("failed to check timestamps: %v", tx.Error)
+	}
+	assert.Equal(t, int64(0), invalidTsCount, "All real-world timestamps should be in March 2026")
+
+	// Verify all 4 real-world devices still exist in the devices table
+	var realDeviceCount int64
+	tx = con.Raw("SELECT COUNT(*) FROM devices WHERE id IN ('device_1','device_2','device_3','device_4')").Scan(&realDeviceCount)
+	if tx.Error != nil {
+		t.Fatalf("failed to count real-world devices: %v", tx.Error)
+	}
+	assert.Equal(t, int64(4), realDeviceCount, "All 4 real-world devices should still exist")
+
+	// Verify wfx events have non-empty description (the nested JSON job data)
+	var emptyDescWfxCount int64
+	tx = con.Raw(`SELECT COUNT(*) FROM device_events 
+		WHERE device_id IN ('device_1','device_2','device_3','device_4') 
+		AND event_type = 'lamaassu.io/device-event/wfx/update/job' 
+		AND (description IS NULL OR description = '')`).Scan(&emptyDescWfxCount)
+	if tx.Error != nil {
+		t.Fatalf("failed to check wfx event descriptions: %v", tx.Error)
+	}
+	assert.Equal(t, int64(0), emptyDescWfxCount, "All wfx events should have non-empty descriptions")
 }

--- a/engines/storage/postgres/migrations_test/devicemanager_test.go
+++ b/engines/storage/postgres/migrations_test/devicemanager_test.go
@@ -2,7 +2,6 @@ package migrationstest
 
 import (
 	"encoding/json"
-	"os"
 	"testing"
 
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/config"
@@ -447,21 +446,11 @@ func MigrationTest_DeviceManager_20260317120000_create_device_events(t *testing.
 		VALUES('device-without-events', '{}', 'NO_IDENTITY', 'device', '#00FF00', '2026-03-17 10:00:00+00', '{}', 'test-dms', NULL, '{}', NULL);
 	`)
 
-	// Insert real-world device data from production-like SQL dump (4 devices with ~218 events total)
-	sqlData, err := os.ReadFile("testdata/devices_202603301338.sql")
-	if err != nil {
-		t.Fatalf("failed to read testdata/devices_202603301338.sql: %v", err)
-	}
-	tx := con.Exec(string(sqlData))
-	if tx.Error != nil {
-		t.Fatalf("failed to insert real-world device data: %v", tx.Error)
-	}
-
 	ApplyMigration(t, logger, con, DeviceManagerDBName)
 
 	// Verify events column was removed from devices table
 	var eventsColumnCount int64
-	tx = con.Raw(`SELECT COUNT(*) FROM information_schema.columns WHERE table_name = 'devices' AND column_name = 'events'`).Scan(&eventsColumnCount)
+	tx := con.Raw(`SELECT COUNT(*) FROM information_schema.columns WHERE table_name = 'devices' AND column_name = 'events'`).Scan(&eventsColumnCount)
 	if tx.Error != nil {
 		t.Fatalf("failed to inspect devices columns: %v", tx.Error)
 	}
@@ -533,79 +522,4 @@ func MigrationTest_DeviceManager_20260317120000_create_device_events(t *testing.
 		t.Fatalf("failed to count events for device-without-events: %v", tx.Error)
 	}
 	assert.Equal(t, int64(0), noEventsCount)
-
-	// ---- Real-world data assertions ----
-	// Verify migrated event counts per device from production SQL dump
-	expectedCounts := map[string]int64{
-		"device_1": 58,
-		"device_2": 82,
-		"device_3": 41,
-		"device_4": 37,
-	}
-
-	for deviceID, expectedCount := range expectedCounts {
-		var count int64
-		tx = con.Raw("SELECT COUNT(*) FROM device_events WHERE device_id = ?", deviceID).Scan(&count)
-		if tx.Error != nil {
-			t.Fatalf("failed to count events for %s: %v", deviceID, tx.Error)
-		}
-		assert.Equal(t, expectedCount, count, "Event count mismatch for %s", deviceID)
-	}
-
-	// Verify total: 218 (real-world) + 3 (simple test device) = 221
-	var totalEvents int64
-	tx = con.Raw("SELECT COUNT(*) FROM device_events").Scan(&totalEvents)
-	if tx.Error != nil {
-		t.Fatalf("failed to count total events: %v", tx.Error)
-	}
-	assert.Equal(t, int64(221), totalEvents, "Total events: 218 real-world + 3 test")
-
-	// Each real-world device should have exactly 1 CREATED event
-	for _, deviceID := range []string{"device_1", "device_2", "device_3", "device_4"} {
-		var createdCount int64
-		tx = con.Raw("SELECT COUNT(*) FROM device_events WHERE device_id = ? AND event_type = 'CREATED'", deviceID).Scan(&createdCount)
-		if tx.Error != nil {
-			t.Fatalf("failed to count CREATED events for %s: %v", deviceID, tx.Error)
-		}
-		assert.Equal(t, int64(1), createdCount, "Device %s should have exactly 1 CREATED event", deviceID)
-	}
-
-	// All real-world events should have source defaulted to 'service/devmanager' (no source in original data)
-	var nonDefaultSourceCount int64
-	tx = con.Raw(`SELECT COUNT(*) FROM device_events 
-		WHERE device_id IN ('device_1','device_2','device_3','device_4') 
-		AND source != 'service/devmanager'`).Scan(&nonDefaultSourceCount)
-	if tx.Error != nil {
-		t.Fatalf("failed to check sources: %v", tx.Error)
-	}
-	assert.Equal(t, int64(0), nonDefaultSourceCount, "All real-world events should use default source")
-
-	// Verify all timestamps from real-world data fall within March 2026
-	var invalidTsCount int64
-	tx = con.Raw(`SELECT COUNT(*) FROM device_events 
-		WHERE device_id IN ('device_1','device_2','device_3','device_4') 
-		AND (event_ts < '2026-03-01' OR event_ts > '2026-04-01')`).Scan(&invalidTsCount)
-	if tx.Error != nil {
-		t.Fatalf("failed to check timestamps: %v", tx.Error)
-	}
-	assert.Equal(t, int64(0), invalidTsCount, "All real-world timestamps should be in March 2026")
-
-	// Verify all 4 real-world devices still exist in the devices table
-	var realDeviceCount int64
-	tx = con.Raw("SELECT COUNT(*) FROM devices WHERE id IN ('device_1','device_2','device_3','device_4')").Scan(&realDeviceCount)
-	if tx.Error != nil {
-		t.Fatalf("failed to count real-world devices: %v", tx.Error)
-	}
-	assert.Equal(t, int64(4), realDeviceCount, "All 4 real-world devices should still exist")
-
-	// Verify wfx events have non-empty description (the nested JSON job data)
-	var emptyDescWfxCount int64
-	tx = con.Raw(`SELECT COUNT(*) FROM device_events 
-		WHERE device_id IN ('device_1','device_2','device_3','device_4') 
-		AND event_type = 'lamaassu.io/device-event/wfx/update/job' 
-		AND (description IS NULL OR description = '')`).Scan(&emptyDescWfxCount)
-	if tx.Error != nil {
-		t.Fatalf("failed to check wfx event descriptions: %v", tx.Error)
-	}
-	assert.Equal(t, int64(0), emptyDescWfxCount, "All wfx events should have non-empty descriptions")
 }

--- a/monolithic/cmd/development/main.go
+++ b/monolithic/cmd/development/main.go
@@ -99,6 +99,7 @@ func main() {
 	cryptoengineOptions := flag.String("cryptoengines", "filesystem", ", separated list of crypto engines to enable ['aws-secrets','aws-kms','vault','pkcs11','filesystem']")
 	disableMonitor := flag.Bool("disable-monitor", false, "disable crypto monitoring")
 	disableEventbus := flag.Bool("disable-eventbus", false, "disable eventbus")
+	disableSSE := flag.Bool("disable-sse", false, "disable SSE streaming on device events endpoint")
 	useAwsEventbus := flag.Bool("use-aws-eventbus", false, "use AWS Eventbus")
 	useInMemoryEventbus := flag.Bool("inmemory-eventbus", false, "use in-memory eventbus (no Docker required)")
 	disableUI := flag.Bool("disable-ui", false, "Disable UI docker loading")
@@ -469,6 +470,7 @@ func main() {
 		},
 		Storage:            *pluglableStorageConfig,
 		PopulateSampleData: *sampleData,
+		SSEEnabled:         !*disableSSE,
 		AWSIoTManager: pkg.MonolithicAWSIoTManagerConfig{
 			Enabled:     *awsIoTManager,
 			ConnectorID: fmt.Sprintf("aws.%s", *awsIoTManagerID),

--- a/monolithic/pkg/assembler.go
+++ b/monolithic/pkg/assembler.go
@@ -179,6 +179,7 @@ func RunMonolithicLamassuPKI(conf MonolithicConfig) (int, int, error) {
 			SubscriberEventBus:    conf.SubscriberEventBus,
 			SubscriberDLQEventBus: conf.SubscriberDLQEventBus,
 			Storage:               conf.Storage,
+			SSEEnabled:            conf.SSEEnabled,
 		}, caSDKBuilder("Device Manager", models.DeviceManagerSource), apiInfo)
 		if err != nil {
 			return -1, -1, fmt.Errorf("could not assemble Device Manager Service: %s", err)

--- a/monolithic/pkg/config.go
+++ b/monolithic/pkg/config.go
@@ -32,6 +32,7 @@ type MonolithicConfig struct {
 	VAStorageDir          string                         `mapstructure:"va_storage_directory"`
 	UIPort                int                            `mapstructure:"ui_port"`
 	PopulateSampleData    bool                           `mapstructure:"populate_sample_data"`
+	SSEEnabled            bool                           `mapstructure:"sse_enabled"`
 }
 
 type MonolithicAWSIoTManagerConfig struct {

--- a/monolithic/pkg/storage/sqlite/schema.go
+++ b/monolithic/pkg/storage/sqlite/schema.go
@@ -112,9 +112,25 @@ func initializeSchema(db *gorm.DB) error {
 			dms_owner TEXT NULL,
 			identity_slot TEXT NULL,
 			extra_slots TEXT NULL,
-			events TEXT NULL,
 			PRIMARY KEY (id)
 		)`,
+
+		// Device events table - Final state (no migrations).
+		// FK cascade mirrors the Postgres migration so deleting a device removes its events.
+		`CREATE TABLE IF NOT EXISTS device_events (
+			id TEXT NOT NULL,
+			device_id TEXT NOT NULL,
+			event_ts DATETIME NOT NULL,
+			event_type TEXT NOT NULL,
+			description TEXT NULL,
+			source TEXT NULL,
+			structured_fields TEXT NULL,
+			PRIMARY KEY (id),
+			FOREIGN KEY (device_id) REFERENCES devices (id) ON DELETE CASCADE
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_device_events_device_id_event_ts ON device_events (device_id, event_ts DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_device_events_event_ts ON device_events (event_ts DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_device_events_event_type ON device_events (event_type)`,
 
 		// DMS table - Final state (no migrations)
 		`CREATE TABLE IF NOT EXISTS dms (

--- a/sdk/alerts.go
+++ b/sdk/alerts.go
@@ -15,15 +15,24 @@ type httpAlertsClient struct {
 	baseUrl    string
 }
 
-func (cli *httpAlertsClient) GetLatestEventsPerEventType(ctx context.Context, input *services.GetLatestEventsPerEventTypeInput) ([]*models.AlertLatestEvent, error) {
+func (cli *httpAlertsClient) GetLatestEventsPerEventType(ctx context.Context, input *services.GetLatestEventsPerEventTypeInput) (string, error) {
 	url := cli.baseUrl + "/v1/events/latest"
-	results := make([]*models.AlertLatestEvent, 0)
-	_, err := IterGet[models.AlertLatestEvent, *resources.GetItemsResponse[models.AlertLatestEvent]](ctx, cli.httpClient, url, true, nil,
-		func(ale models.AlertLatestEvent) {
-			results = append(results, &ale)
-		}, map[int][]error{})
+	if input == nil {
+		input = &services.GetLatestEventsPerEventTypeInput{}
+	}
+	if input.ApplyFunc == nil {
+		input.ApplyFunc = func(models.AlertLatestEvent) {}
+	}
 
-	return results, err
+	return IterGet[models.AlertLatestEvent, *resources.GetAlertsResponse](
+		ctx,
+		cli.httpClient,
+		url,
+		input.ExhaustiveRun,
+		input.QueryParameters,
+		input.ApplyFunc,
+		map[int][]error{},
+	)
 }
 
 func (cli *httpAlertsClient) GetUserSubscriptions(ctx context.Context, input *services.GetUserSubscriptionsInput) ([]*models.Subscription, error) {

--- a/sdk/devicemanager.go
+++ b/sdk/devicemanager.go
@@ -62,6 +62,37 @@ func (cli *deviceManagerClient) GetDeviceByID(ctx context.Context, input service
 	return &response, nil
 }
 
+func (cli *deviceManagerClient) GetDeviceEvents(ctx context.Context, input services.GetDeviceEventsInput) (string, error) {
+	url := cli.baseUrl + "/v1/devices/" + input.DeviceID + "/events"
+
+	applyFunc := input.ApplyFunc
+	if applyFunc == nil {
+		applyFunc = func(models.DeviceEvent) {}
+	}
+
+	return IterGet[models.DeviceEvent, *resources.GetDeviceEventsResponse](ctx, cli.httpClient, url, input.ExhaustiveRun, input.QueryParameters, applyFunc, map[int][]error{
+		404: {errs.ErrDeviceNotFound},
+	})
+}
+
+func (cli *deviceManagerClient) CreateDeviceEvent(ctx context.Context, input services.CreateDeviceEventInput) (*models.DeviceEvent, error) {
+	response, err := Post[*models.DeviceEvent](ctx, cli.httpClient, cli.baseUrl+"/v1/devices/"+input.DeviceID+"/events", resources.CreateDeviceEventBody{
+		Timestamp:        input.Timestamp,
+		Type:             input.Type,
+		Description:      input.Description,
+		Source:           input.Source,
+		StructuredFields: input.StructuredFields,
+	}, map[int][]error{
+		400: {errs.ErrValidateBadRequest},
+		404: {errs.ErrDeviceNotFound},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
 func (cli *deviceManagerClient) GetDevices(ctx context.Context, input services.GetDevicesInput) (string, error) {
 	url := cli.baseUrl + "/v1/devices"
 

--- a/sdk/devicemanager.go
+++ b/sdk/devicemanager.go
@@ -76,13 +76,21 @@ func (cli *deviceManagerClient) GetDeviceEvents(ctx context.Context, input servi
 }
 
 func (cli *deviceManagerClient) CreateDeviceEvent(ctx context.Context, input services.CreateDeviceEventInput) (*models.DeviceEvent, error) {
-	response, err := Post[*models.DeviceEvent](ctx, cli.httpClient, cli.baseUrl+"/v1/devices/"+input.DeviceID+"/events", resources.CreateDeviceEventBody{
-		Timestamp:        input.Timestamp,
-		Type:             input.Type,
-		Description:      input.Description,
-		Source:           input.Source,
-		StructuredFields: input.StructuredFields,
-	}, map[int][]error{
+	// Build the body dynamically so we can omit event_ts when the caller leaves
+	// Timestamp at its zero value. Serializing time.Time{} would otherwise emit
+	// "0001-01-01T00:00:00Z" on the wire, defeating the server's
+	// "timestamp when omitted" contract.
+	body := map[string]any{
+		"type":              input.Type,
+		"description":       input.Description,
+		"source":            input.Source,
+		"structured_fields": input.StructuredFields,
+	}
+	if !input.Timestamp.IsZero() {
+		body["event_ts"] = input.Timestamp
+	}
+
+	response, err := Post[*models.DeviceEvent](ctx, cli.httpClient, cli.baseUrl+"/v1/devices/"+input.DeviceID+"/events", body, map[int][]error{
 		400: {errs.ErrValidateBadRequest},
 		404: {errs.ErrDeviceNotFound},
 	})


### PR DESCRIPTION
This pull request introduces device event streaming and querying capabilities to the Device Manager service, adds support for Server-Sent Events (SSE) for real-time device event delivery, and improves the flexibility of event querying and filtering throughout the backend. It also updates the alert event querying API for consistency and adds corresponding tests to ensure correct behavior.

**Device Event Streaming and Querying Enhancements:**

- Added new HTTP endpoints in `devmanager.go` to allow clients to retrieve device event history and stream device events in real time via SSE, including content negotiation based on the `Accept` header. Also introduced the ability to create device events via the API, with normalization of event source and timestamp.
- Updated the device manager service assembly logic to support optional SSE hubs, ensuring that each service instance receives all device events for SSE clients by generating unique queue names per instance. [[1]](diffhunk://#diff-9ba6840212bfa0dec6d05be4b7cbad7b8e17cf25620dc8f41e104c7cf8e384e9L25-R28) [[2]](diffhunk://#diff-9ba6840212bfa0dec6d05be4b7cbad7b8e17cf25620dc8f41e104c7cf8e384e9R37-R41) [[3]](diffhunk://#diff-9ba6840212bfa0dec6d05be4b7cbad7b8e17cf25620dc8f41e104c7cf8e384e9L43-R50) [[4]](diffhunk://#diff-9ba6840212bfa0dec6d05be4b7cbad7b8e17cf25620dc8f41e104c7cf8e384e9L52-R59) [[5]](diffhunk://#diff-9ba6840212bfa0dec6d05be4b7cbad7b8e17cf25620dc8f41e104c7cf8e384e9L69-R105) [[6]](diffhunk://#diff-9ba6840212bfa0dec6d05be4b7cbad7b8e17cf25620dc8f41e104c7cf8e384e9L97-R170)
- Added `SSEEnabled` configuration option to `DeviceManagerConfig` to allow enabling or disabling SSE support via config.

**API and Controller Improvements:**

- Refactored alert event querying in `alerts.go` to support flexible filtering and to use an `ApplyFunc` pattern for efficient event streaming, aligning with the new device event querying approach. [[1]](diffhunk://#diff-0993cf33863b066098a260adde78c5e8475f50dee7b6815af6e80cd9e7559071L47-R62) [[2]](diffhunk://#diff-0993cf33863b066098a260adde78c5e8475f50dee7b6815af6e80cd9e7559071L58-R82)
- Introduced new constructors and fields in the device manager HTTP routes to support SSE and event endpoints. [[1]](diffhunk://#diff-7cc8791b7582f6a4d89cfa492865d97765b7f5878099c17b2f186b4babb30ab8R17) [[2]](diffhunk://#diff-7cc8791b7582f6a4d89cfa492865d97765b7f5878099c17b2f186b4babb30ab8R26-R32)

**Testing and Validation:**

- Added comprehensive tests for device event retrieval, creation, and event type validation in `main_test.go`, ensuring the new endpoints and event logic work as intended. [[1]](diffhunk://#diff-ab3275724f47f741b61bfdbd34d182be59be9e133d06adf284f44ac5cf3d6313R755-R810) [[2]](diffhunk://#diff-ab3275724f47f741b61bfdbd34d182be59be9e133d06adf284f44ac5cf3d6313L1653-R1710)
- Updated alert event tests to use the new `ApplyFunc` pattern for event retrieval, ensuring consistency with the new event querying logic. [[1]](diffhunk://#diff-30398a3540764501894b3cad0fe7a8d104aa83f59ec8580f2c1a875032f5f776L112-R118) [[2]](diffhunk://#diff-30398a3540764501894b3cad0fe7a8d104aa83f59ec8580f2c1a875032f5f776L136-R148) [[3]](diffhunk://#diff-30398a3540764501894b3cad0fe7a8d104aa83f59ec8580f2c1a875032f5f776L151-R169)

**Internal/Dependency Updates:**

- Updated imports and dependencies to support new event publishing, SSE, and audit middleware functionality. [[1]](diffhunk://#diff-9ba6840212bfa0dec6d05be4b7cbad7b8e17cf25620dc8f41e104c7cf8e384e9R7-R11) [[2]](diffhunk://#diff-0993cf33863b066098a260adde78c5e8475f50dee7b6815af6e80cd9e7559071L5-R7) [[3]](diffhunk://#diff-7cc8791b7582f6a4d89cfa492865d97765b7f5878099c17b2f186b4babb30ab8R4-R7)

These changes collectively introduce robust device event history and streaming support, unify event querying patterns, and ensure the service is ready for scalable, real-time event delivery to clients.