### PR TITLE
feat: add X.509 certificate extensions support and enhance filtering capabilities

### DIFF
--- a/backend/pkg/assemblers/tests/ca/ca_certificates_test.go
+++ b/backend/pkg/assemblers/tests/ca/ca_certificates_test.go
@@ -307,6 +307,40 @@ func createCAAndCertificate(caSDK services.CAService) (*models.CACertificate, *m
 	return ca, cert, nil
 }
 
+func createCertificateWithExtensions(t *testing.T, caSDK services.CAService, caID string, commonName string, keyUsage x509.KeyUsage, extendedKeyUsage []x509.ExtKeyUsage) *models.Certificate {
+	t.Helper()
+
+	profileExtendedKeyUsage := make([]models.X509ExtKeyUsage, 0, len(extendedKeyUsage))
+	for _, usage := range extendedKeyUsage {
+		profileExtendedKeyUsage = append(profileExtendedKeyUsage, models.X509ExtKeyUsage(usage))
+	}
+
+	cert, err := caSDK.CreateCertificate(context.Background(), services.CreateCertificateInput{
+		CAID: caID,
+		KeySpec: services.CertificateKeySpec{
+			Type: models.KeyType(x509.RSA),
+			Bits: 2048,
+		},
+		Subject: models.Subject{CommonName: commonName},
+		IssuanceProfile: &models.IssuanceProfile{
+			Validity: models.Validity{Type: models.Duration, Duration: models.TimeDuration(12 * time.Hour)},
+
+			HonorSubject: true,
+
+			HonorKeyUsage: false,
+			KeyUsage:      models.X509KeyUsage(keyUsage),
+
+			HonorExtendedKeyUsages: false,
+			ExtendedKeyUsages:      profileExtendedKeyUsage,
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create certificate %s: %s", commonName, err)
+	}
+
+	return cert
+}
+
 func TestGetCertificatesFilterBySubjectKeyID(t *testing.T) {
 	serverTest, err := tests.TestServiceBuilder{}.WithDatabase("ca", "kms").Build(t)
 	if err != nil {
@@ -532,5 +566,131 @@ func TestGetCertificatesFilterBySubjectKeyIDNotInIgnoreCase(t *testing.T) {
 
 	if !foundCert3 {
 		t.Fatalf("expected to find cert3 with subject_key_id %s in not-in-ignorecase filtered results", cert3.SubjectKeyID)
+	}
+}
+
+func TestGetCertificatesFilterByExtensionKeyUsage(t *testing.T) {
+	serverTest, err := tests.TestServiceBuilder{}.WithDatabase("ca", "kms").Build(t)
+	if err != nil {
+		t.Fatalf("could not create CA test server: %s", err)
+	}
+
+	caTest := serverTest.CA
+
+	if err := serverTest.BeforeEach(); err != nil {
+		t.Fatalf("failed running BeforeEach: %s", err)
+	}
+
+	ca := createActiveCA(t, caTest.HttpCASDK)
+
+	cert1 := createCertificateWithExtensions(t, caTest.HttpCASDK, ca.ID, "ku-digital-signature", x509.KeyUsageDigitalSignature, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth})
+	cert2 := createCertificateWithExtensions(t, caTest.HttpCASDK, ca.ID, "ku-key-encipherment", x509.KeyUsageKeyEncipherment, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth})
+	cert3 := createCertificateWithExtensions(t, caTest.HttpCASDK, ca.ID, "ku-both", x509.KeyUsageDigitalSignature|x509.KeyUsageKeyEncipherment, []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning})
+
+	found := []*models.Certificate{}
+	qp := &resources.QueryParameters{
+		PageSize: 25,
+		Filters: []resources.FilterOption{
+			{
+				Field:           "extensions.key_usage",
+				Value:           "DigitalSignature",
+				FilterOperation: resources.StringArrayContains,
+			},
+		},
+	}
+
+	_, err = caTest.HttpCASDK.GetCertificates(context.Background(), services.GetCertificatesInput{
+		ListInput: resources.ListInput[models.Certificate]{
+			QueryParameters: qp,
+			ExhaustiveRun:   true,
+			ApplyFunc: func(elem models.Certificate) {
+				found = append(found, &elem)
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("GetCertificates returned error: %s", err)
+	}
+
+	if len(found) != 2 {
+		t.Fatalf("expected 2 certificates filtered by key usage, got %d", len(found))
+	}
+
+	foundSerials := map[string]bool{}
+	for _, cert := range found {
+		foundSerials[cert.SerialNumber] = true
+	}
+
+	if !foundSerials[cert1.SerialNumber] {
+		t.Fatalf("expected certificate %s to be returned when filtering by DigitalSignature", cert1.SerialNumber)
+	}
+	if !foundSerials[cert3.SerialNumber] {
+		t.Fatalf("expected certificate %s to be returned when filtering by DigitalSignature", cert3.SerialNumber)
+	}
+	if foundSerials[cert2.SerialNumber] {
+		t.Fatalf("did not expect certificate %s to be returned when filtering by DigitalSignature", cert2.SerialNumber)
+	}
+}
+
+func TestGetCertificatesFilterByExtensionExtendedKeyUsageIgnoreCase(t *testing.T) {
+	serverTest, err := tests.TestServiceBuilder{}.WithDatabase("ca", "kms").Build(t)
+	if err != nil {
+		t.Fatalf("could not create CA test server: %s", err)
+	}
+
+	caTest := serverTest.CA
+
+	if err := serverTest.BeforeEach(); err != nil {
+		t.Fatalf("failed running BeforeEach: %s", err)
+	}
+
+	ca := createActiveCA(t, caTest.HttpCASDK)
+
+	cert1 := createCertificateWithExtensions(t, caTest.HttpCASDK, ca.ID, "eku-client-auth", x509.KeyUsageDigitalSignature, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth})
+	cert2 := createCertificateWithExtensions(t, caTest.HttpCASDK, ca.ID, "eku-server-auth", x509.KeyUsageDigitalSignature, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth})
+	cert3 := createCertificateWithExtensions(t, caTest.HttpCASDK, ca.ID, "eku-both", x509.KeyUsageDigitalSignature, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageCodeSigning})
+
+	found := []*models.Certificate{}
+	qp := &resources.QueryParameters{
+		PageSize: 25,
+		Filters: []resources.FilterOption{
+			{
+				Field:           "extensions.extended_key_usage",
+				Value:           "clientauth",
+				FilterOperation: resources.StringArrayContainsIgnoreCase,
+			},
+		},
+	}
+
+	_, err = caTest.HttpCASDK.GetCertificates(context.Background(), services.GetCertificatesInput{
+		ListInput: resources.ListInput[models.Certificate]{
+			QueryParameters: qp,
+			ExhaustiveRun:   true,
+			ApplyFunc: func(elem models.Certificate) {
+				found = append(found, &elem)
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("GetCertificates returned error: %s", err)
+	}
+
+	if len(found) != 2 {
+		t.Fatalf("expected 2 certificates filtered by extended key usage, got %d", len(found))
+	}
+
+	foundSerials := map[string]bool{}
+	for _, cert := range found {
+		foundSerials[cert.SerialNumber] = true
+	}
+
+	if !foundSerials[cert1.SerialNumber] {
+		t.Fatalf("expected certificate %s to be returned when filtering by ClientAuth", cert1.SerialNumber)
+	}
+	if !foundSerials[cert3.SerialNumber] {
+		t.Fatalf("expected certificate %s to be returned when filtering by ClientAuth", cert3.SerialNumber)
+	}
+	if foundSerials[cert2.SerialNumber] {
+		t.Fatalf("did not expect certificate %s to be returned when filtering by ClientAuth", cert2.SerialNumber)
 	}
 }

--- a/backend/pkg/assemblers/tests/kms/stats_test.go
+++ b/backend/pkg/assemblers/tests/kms/stats_test.go
@@ -2,10 +2,12 @@ package kms
 
 import (
 	"context"
+	"sort"
 	"strings"
 	"testing"
 
 	"github.com/lamassuiot/lamassuiot/backend/v3/pkg/assemblers/tests"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/resources"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/services"
 	"github.com/stretchr/testify/assert"
@@ -59,6 +61,28 @@ func TestGetKeyStatsFiltered(t *testing.T) {
 	})
 }
 
+func getDeterministicDefaultEngineID(t *testing.T, engines []*models.CryptoEngineProvider) string {
+	t.Helper()
+
+	if len(engines) == 0 {
+		t.Fatal("no crypto engines available for testing")
+	}
+
+	for _, engine := range engines {
+		if engine.Default {
+			return engine.ID
+		}
+	}
+
+	// Fall back to a stable order if the default flag is unavailable.
+	engineIDs := make([]string, 0, len(engines))
+	for _, engine := range engines {
+		engineIDs = append(engineIDs, engine.ID)
+	}
+	sort.Strings(engineIDs)
+	return engineIDs[0]
+}
+
 // setupStatsTestData creates all test keys with various properties across engines and algorithms
 func setupStatsTestData(t *testing.T, ctx context.Context, kmsTest *tests.KMSTestServer) {
 	// Get available engines
@@ -71,12 +95,9 @@ func setupStatsTestData(t *testing.T, ctx context.Context, kmsTest *tests.KMSTes
 		t.Fatal("no crypto engines available for testing")
 	}
 
-	defaultEngine := ""
+	defaultEngine := getDeterministicDefaultEngineID(t, engines)
 	vaultEngine := ""
 	for _, engine := range engines {
-		if defaultEngine == "" {
-			defaultEngine = engine.ID
-		}
 		if strings.HasPrefix(engine.ID, "vault") {
 			vaultEngine = engine.ID
 		}
@@ -259,7 +280,7 @@ func testStatsEngineFiltering(t *testing.T, ctx context.Context, kmsTest *tests.
 	assert.NoError(t, err)
 	assert.NotEmpty(t, engines, "Should have at least one engine")
 
-	targetEngine := engines[0].ID
+	targetEngine := getDeterministicDefaultEngineID(t, engines)
 
 	// Get stats filtered by specific engine
 	queryParams := &resources.QueryParameters{
@@ -392,7 +413,7 @@ func testStatsCombinedFilters(t *testing.T, ctx context.Context, kmsTest *tests.
 	// Get available engines first
 	engines, err := kmsTest.Service.GetCryptoEngineProvider(ctx)
 	assert.NoError(t, err)
-	targetEngine := engines[0].ID
+	targetEngine := getDeterministicDefaultEngineID(t, engines)
 
 	// Combine engine filter + algorithm filter
 	queryParams := &resources.QueryParameters{
@@ -563,7 +584,7 @@ func testStatsAlgorithmDistribution(t *testing.T, ctx context.Context, kmsTest *
 				{
 					Field:           "engine_id",
 					FilterOperation: resources.StringEqual,
-					Value:           availableEngines[0].ID,
+					Value:           getDeterministicDefaultEngineID(t, availableEngines),
 				},
 			},
 		}

--- a/backend/pkg/controllers/ca.go
+++ b/backend/pkg/controllers/ca.go
@@ -1200,7 +1200,7 @@ func (r *caHttpRoutes) ImportCertificate(ctx *gin.Context) {
 }
 
 func (r *caHttpRoutes) GetIssuanceProfiles(ctx *gin.Context) {
-	queryParams, err := FilterQuery(ctx.Request, resources.IssuanceProfileFiltrableFields)
+	queryParams, err := FilterQuery(ctx.Request, resources.IssuanceProfileFilterableFields)
 	if err != nil {
 		ctx.JSON(400, gin.H{"err": err.Error()})
 		return

--- a/backend/pkg/controllers/utils.go
+++ b/backend/pkg/controllers/utils.go
@@ -234,10 +234,13 @@ func parseFilterOperand(operand string, fieldType resources.FilterFieldType) res
 		}
 
 	case resources.StringArrayFilterFieldType:
-		if strings.Contains(operand, "ignorecase") {
+		switch operand {
+		case "ct_ic", "contains_ignorecase":
 			return resources.StringArrayContainsIgnoreCase
+		case "ct", "contains":
+			return resources.StringArrayContains
 		}
-		return resources.StringArrayContains
+		return resources.UnspecifiedFilter
 
 	case resources.DateFilterFieldType:
 		switch operand {

--- a/backend/pkg/controllers/utils_test.go
+++ b/backend/pkg/controllers/utils_test.go
@@ -101,6 +101,37 @@ func TestFilterQuery_StringInIgnoreCase(t *testing.T) {
 	}
 }
 
+func TestFilterQuery_StringArrayContainsIgnoreCase(t *testing.T) {
+	req := &http.Request{}
+	req.URL = &url.URL{}
+	q := req.URL.Query()
+	q.Add("filter", "extensions.extended_key_usage[ct_ic]clientauth")
+	req.URL.RawQuery = q.Encode()
+
+	qp, err := FilterQuery(req, resources.CertificateFilterableFields)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if qp == nil {
+		t.Fatalf("expected QueryParameters, got nil")
+	}
+
+	if len(qp.Filters) != 1 {
+		t.Fatalf("expected 1 filter, got %d", len(qp.Filters))
+	}
+
+	f := qp.Filters[0]
+	if f.Field != "extensions.extended_key_usage" {
+		t.Fatalf("expected field 'extensions.extended_key_usage', got '%s'", f.Field)
+	}
+	if f.Value != "clientauth" {
+		t.Fatalf("expected value 'clientauth', got '%s'", f.Value)
+	}
+	if f.FilterOperation != resources.StringArrayContainsIgnoreCase {
+		t.Fatalf("expected operation StringArrayContainsIgnoreCase, got %v", f.FilterOperation)
+	}
+}
+
 func TestFilterQuery_StringNotIn(t *testing.T) {
 	req := &http.Request{}
 	req.URL = &url.URL{}

--- a/backend/pkg/services/ca.go
+++ b/backend/pkg/services/ca.go
@@ -2179,8 +2179,10 @@ func (svc *CAServiceBackend) CreateCertificate(ctx context.Context, input servic
 	// Resolve issuance profile: inline > referenced > CA default
 	var profile *models.IssuanceProfile
 	if input.IssuanceProfile != nil {
-		profile = input.IssuanceProfile
-		profile.HonorExtendedKeyUsages = false // For CreateCertificate, we want to ignore EKUs in the profile and only use the KeyUsage and ExtKeyUsage fields
+		profileCopy := *input.IssuanceProfile
+		profile = &profileCopy
+		// For CreateCertificate, override the Honor* flags so this operation uses the provided KeyUsage and ExtKeyUsage fields.
+		profile.HonorExtendedKeyUsages = false
 		profile.HonorKeyUsage = false
 	} else if input.IssuanceProfileID != "" {
 		profile, err = svc.service.GetIssuanceProfileByID(ctx, services.GetIssuanceProfileByIDInput{

--- a/backend/pkg/services/ca.go
+++ b/backend/pkg/services/ca.go
@@ -80,6 +80,25 @@ func (svc *CAServiceBackend) SetService(service services.CAService) {
 	svc.service = service
 }
 
+func certificateExtensionsFromX509(cert *x509.Certificate) models.CertificateExtensions {
+	if cert == nil {
+		return models.CertificateExtensions{
+			KeyUsage:         models.X509KeyUsage(0),
+			ExtendedKeyUsage: []models.X509ExtKeyUsage{},
+		}
+	}
+
+	extendedKeyUsage := make([]models.X509ExtKeyUsage, 0, len(cert.ExtKeyUsage))
+	for _, usage := range cert.ExtKeyUsage {
+		extendedKeyUsage = append(extendedKeyUsage, models.X509ExtKeyUsage(usage))
+	}
+
+	return models.CertificateExtensions{
+		KeyUsage:         models.X509KeyUsage(cert.KeyUsage),
+		ExtendedKeyUsage: extendedKeyUsage,
+	}
+}
+
 func (svc *CAServiceBackend) GetStats(ctx context.Context, input services.GetStatsInput) (*models.CAStats, error) {
 	lFunc := chelpers.ConfigureLogger(ctx, svc.logger)
 
@@ -456,10 +475,10 @@ func (svc *CAServiceBackend) ImportCA(ctx context.Context, input services.Import
 		CreationTS: time.Now(),
 		Level:      level,
 		Certificate: models.Certificate{
-			VersionSchema:       "unknown",
 			SubjectKeyID:        skid,
 			AuthorityKeyID:      akid,
 			Certificate:         input.CACertificate,
+			Extensions:          certificateExtensionsFromX509((*x509.Certificate)(caCert)),
 			Status:              models.StatusActive,
 			SerialNumber:        helpers.SerialNumberToHexString(caCert.SerialNumber),
 			KeyMetadata:         helpers.KeyStrengthMetadataFromCertificate((*x509.Certificate)(caCert)),
@@ -777,10 +796,10 @@ func (svc *CAServiceBackend) CreateCA(ctx context.Context, input services.Create
 		CreationTS: time.Now(),
 		Level:      caLevel,
 		Certificate: models.Certificate{
-			VersionSchema:  "1.0",
 			SubjectKeyID:   skid,
 			AuthorityKeyID: akid,
 			Certificate:    (*models.X509Certificate)(ca),
+			Extensions:     certificateExtensionsFromX509(ca),
 			Status:         models.StatusActive,
 			SerialNumber:   helpers.SerialNumberToHexString(ca.SerialNumber),
 			KeyMetadata: models.KeyStrengthMetadata{
@@ -1399,12 +1418,12 @@ func (svc *CAServiceBackend) ReissueCA(ctx context.Context, input services.Reiss
 	// Create the new certificate record
 	newCertificateRecord := models.Certificate{
 		SerialNumber:     helpers.SerialNumberToHexString(newCert.SerialNumber),
-		VersionSchema:    "1.0",
 		SubjectKeyID:     newSKID,
 		AuthorityKeyID:   newAKID,
 		Metadata:         newMetadata,
 		Status:           models.StatusActive,
 		Certificate:      (*models.X509Certificate)(newCert),
+		Extensions:       certificateExtensionsFromX509(newCert),
 		KeyMetadata:      ca.Certificate.KeyMetadata,
 		Subject:          ca.Certificate.Subject,
 		Issuer:           ca.Certificate.Issuer,
@@ -1572,10 +1591,10 @@ func (svc *CAServiceBackend) SignCertificate(ctx context.Context, input services
 	}
 
 	cert := models.Certificate{
-		VersionSchema: "1.0",
-		Metadata:      map[string]interface{}{},
-		Type:          certType,
-		Certificate:   (*models.X509Certificate)(x509Cert),
+		Metadata:    map[string]interface{}{},
+		Type:        certType,
+		Certificate: (*models.X509Certificate)(x509Cert),
+		Extensions:  certificateExtensionsFromX509(x509Cert),
 		IssuerCAMetadata: models.IssuerCAMetadata{
 			SN: helpers.SerialNumberToHexString(caCert.SerialNumber),
 			ID: ca.ID,
@@ -1619,10 +1638,10 @@ func (svc *CAServiceBackend) ImportCertificate(ctx context.Context, input servic
 	}
 
 	newCert := models.Certificate{
-		VersionSchema:       "unknown",
 		Metadata:            input.Metadata,
 		Type:                models.CertificateTypeImportedWithoutKey,
 		Certificate:         (*models.X509Certificate)(input.Certificate),
+		Extensions:          certificateExtensionsFromX509(x509Cert),
 		Status:              status,
 		KeyMetadata:         helpers.KeyStrengthMetadataFromCertificate(x509Cert),
 		Subject:             chelpers.PkixNameToSubject(input.Certificate.Subject),
@@ -2161,6 +2180,8 @@ func (svc *CAServiceBackend) CreateCertificate(ctx context.Context, input servic
 	var profile *models.IssuanceProfile
 	if input.IssuanceProfile != nil {
 		profile = input.IssuanceProfile
+		profile.HonorExtendedKeyUsages = false // For CreateCertificate, we want to ignore EKUs in the profile and only use the KeyUsage and ExtKeyUsage fields
+		profile.HonorKeyUsage = false
 	} else if input.IssuanceProfileID != "" {
 		profile, err = svc.service.GetIssuanceProfileByID(ctx, services.GetIssuanceProfileByIDInput{
 			ProfileID: input.IssuanceProfileID,

--- a/core/pkg/models/ca.go
+++ b/core/pkg/models/ca.go
@@ -30,7 +30,6 @@ const (
 
 type Certificate struct {
 	SerialNumber        string                 `json:"serial_number" gorm:"primaryKey"`
-	VersionSchema       string                 `json:"version_schema"` // Indicates the lamassu schema when codifying the certificate. If some property is changed (added, removed, or changed), then it should change.
 	SubjectKeyID        string                 `json:"subject_key_id"`
 	AuthorityKeyID      string                 `json:"authority_key_id"`
 	Metadata            map[string]interface{} `json:"metadata" gorm:"serializer:json"`
@@ -40,6 +39,7 @@ type Certificate struct {
 	Subject             Subject                `json:"subject" gorm:"embedded;embeddedPrefix:subject_"`
 	Issuer              Subject                `json:"issuer" gorm:"embedded;embeddedPrefix:issuer_"`
 	ValidFrom           time.Time              `json:"valid_from"`
+	Extensions          CertificateExtensions  `json:"extensions" gorm:"embedded;embeddedPrefix:extensions_"`
 	IssuerCAMetadata    IssuerCAMetadata       `json:"issuer_metadata" gorm:"embedded;embeddedPrefix:issuer_meta_"`
 	ValidTo             time.Time              `json:"valid_to"`
 	RevocationTimestamp time.Time              `json:"revocation_timestamp"`
@@ -47,6 +47,16 @@ type Certificate struct {
 	Type                CertificateType        `json:"type"`
 	EngineID            string                 `json:"engine_id"`
 	IsCA                bool                   `json:"is_ca"`
+}
+
+type CertificateExtensions struct {
+	KeyUsage         X509KeyUsage      `json:"key_usage" gorm:"type:jsonb;serializer:json"`
+	ExtendedKeyUsage []X509ExtKeyUsage `json:"extended_key_usage" gorm:"type:jsonb;serializer:json"`
+}
+
+type MetadataResourceLink struct {
+	ResourceType string `json:"resource_type"`
+	ResourceID   string `json:"resource_id"`
 }
 
 type Validity struct {

--- a/core/pkg/models/x509_keyusage.go
+++ b/core/pkg/models/x509_keyusage.go
@@ -116,6 +116,7 @@ var X509ExtKeyUsageMap = map[x509.ExtKeyUsage]string{
 	x509.ExtKeyUsageMicrosoftServerGatedCrypto:     "MicrosoftServerGatedCrypto",
 	x509.ExtKeyUsageNetscapeServerGatedCrypto:      "NetscapeServerGatedCrypto",
 	x509.ExtKeyUsageMicrosoftCommercialCodeSigning: "MicrosoftCommercialCodeSigning",
+	x509.ExtKeyUsageMicrosoftKernelCodeSigning:     "MicrosoftKernelCodeSigning",
 }
 
 func (p X509ExtKeyUsage) MarshalText() ([]byte, error) {

--- a/core/pkg/models/x509_keyusage_test.go
+++ b/core/pkg/models/x509_keyusage_test.go
@@ -193,6 +193,11 @@ func TestExtendedKeyUsageMarshal(t *testing.T) {
 			keyUsage:       X509ExtKeyUsage(x509.ExtKeyUsageTimeStamping),
 			expectedString: "TimeStamping",
 		},
+		{
+			name:           "OK/MicrosoftKernelCodeSigning",
+			keyUsage:       X509ExtKeyUsage(x509.ExtKeyUsageMicrosoftKernelCodeSigning),
+			expectedString: "MicrosoftKernelCodeSigning",
+		},
 	}
 
 	for _, tc := range testcases {
@@ -274,6 +279,12 @@ func TestExtendedKeyUsageUnmarshal(t *testing.T) {
 			name:             "OK/TimeStamping",
 			keyUsage:         "TimeStamping",
 			expectedKeyUsage: X509ExtKeyUsage(x509.ExtKeyUsageTimeStamping),
+			expectedErr:      nil,
+		},
+		{
+			name:             "OK/MicrosoftKernelCodeSigning",
+			keyUsage:         "MicrosoftKernelCodeSigning",
+			expectedKeyUsage: X509ExtKeyUsage(x509.ExtKeyUsageMicrosoftKernelCodeSigning),
 			expectedErr:      nil,
 		},
 		{

--- a/core/pkg/resources/careq.go
+++ b/core/pkg/resources/careq.go
@@ -6,41 +6,6 @@ import (
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
 )
 
-var CAFilterableFields = map[string]FilterFieldType{
-	"id":                   StringFilterFieldType,
-	"level":                NumberFilterFieldType,
-	"type":                 EnumFilterFieldType,
-	"serial_number":        StringFilterFieldType,
-	"status":               EnumFilterFieldType,
-	"engine_id":            StringFilterFieldType,
-	"valid_to":             DateFilterFieldType,
-	"valid_from":           DateFilterFieldType,
-	"revocation_timestamp": DateFilterFieldType,
-	"revocation_reason":    EnumFilterFieldType,
-	"subject.common_name":  StringFilterFieldType,
-	"subject_key_id":       StringFilterFieldType,
-	"profile_id":           StringFilterFieldType,
-}
-
-var KMSFilterableFields = map[string]FilterFieldType{
-	"key_id":          StringFilterFieldType,
-	"engine_id":       StringFilterFieldType,
-	"has_private_key": EnumFilterFieldType,
-	"algorithm":       StringFilterFieldType,
-	"size":            NumberFilterFieldType,
-	"public_key":      StringFilterFieldType,
-	"status":          StringFilterFieldType,
-	"creation_ts":     DateFilterFieldType,
-	"name":            StringFilterFieldType,
-	"tags":            StringArrayFilterFieldType,
-	"metadata":        JsonFilterFieldType,
-}
-
-var IssuanceProfileFiltrableFields = map[string]FilterFieldType{
-	"id":   StringFilterFieldType,
-	"name": StringFilterFieldType,
-}
-
 type CreateCABody struct {
 	ID                  string                  `json:"id"`
 	ParentID            string                  `json:"parent_id"`

--- a/core/pkg/resources/fields.go
+++ b/core/pkg/resources/fields.go
@@ -1,5 +1,62 @@
 package resources
 
+var CertificateFilterableFields = map[string]FilterFieldType{
+	"type":                          EnumFilterFieldType,
+	"serial_number":                 StringFilterFieldType,
+	"subject.common_name":           StringFilterFieldType,
+	"subject_key_id":                StringFilterFieldType,
+	"issuer_meta.id":                StringFilterFieldType,
+	"status":                        EnumFilterFieldType,
+	"engine_id":                     StringFilterFieldType,
+	"valid_to":                      DateFilterFieldType,
+	"valid_from":                    DateFilterFieldType,
+	"revocation_timestamp":          DateFilterFieldType,
+	"revocation_reason":             EnumFilterFieldType,
+	"metadata":                      JsonFilterFieldType,
+	"extensions.key_usage":          StringArrayFilterFieldType,
+	"extensions.extended_key_usage": StringArrayFilterFieldType,
+	"is_ca":                         EnumFilterFieldType,
+}
+
+var CAFilterableFields = map[string]FilterFieldType{
+	"id":                            StringFilterFieldType,
+	"profile_id":                    StringFilterFieldType,
+	"type":                          EnumFilterFieldType,
+	"serial_number":                 StringFilterFieldType,
+	"subject.common_name":           StringFilterFieldType,
+	"subject_key_id":                StringFilterFieldType,
+	"issuer_meta.id":                StringFilterFieldType,
+	"status":                        EnumFilterFieldType,
+	"engine_id":                     StringFilterFieldType,
+	"valid_to":                      DateFilterFieldType,
+	"valid_from":                    DateFilterFieldType,
+	"revocation_timestamp":          DateFilterFieldType,
+	"revocation_reason":             EnumFilterFieldType,
+	"metadata":                      JsonFilterFieldType,
+	"extensions.key_usage":          StringArrayFilterFieldType,
+	"extensions.extended_key_usage": StringArrayFilterFieldType,
+	"is_ca":                         EnumFilterFieldType,
+}
+
+var KMSFilterableFields = map[string]FilterFieldType{
+	"key_id":          StringFilterFieldType,
+	"engine_id":       StringFilterFieldType,
+	"has_private_key": EnumFilterFieldType,
+	"algorithm":       StringFilterFieldType,
+	"size":            NumberFilterFieldType,
+	"public_key":      StringFilterFieldType,
+	"status":          StringFilterFieldType,
+	"creation_ts":     DateFilterFieldType,
+	"name":            StringFilterFieldType,
+	"tags":            StringArrayFilterFieldType,
+	"metadata":        JsonFilterFieldType,
+}
+
+var IssuanceProfileFilterableFields = map[string]FilterFieldType{
+	"id":   StringFilterFieldType,
+	"name": StringFilterFieldType,
+}
+
 var DMSFilterableFields = map[string]FilterFieldType{
 	"id":            StringFilterFieldType,
 	"name":          StringFilterFieldType,
@@ -16,19 +73,4 @@ var DeviceFilterableFields = map[string]FilterFieldType{
 	"tags":               StringArrayFilterFieldType,
 	"metadata":           JsonFilterFieldType,
 	"identity_slot":      JsonFilterFieldType,
-}
-
-var CertificateFilterableFields = map[string]FilterFieldType{
-	"type":                 EnumFilterFieldType,
-	"serial_number":        StringFilterFieldType,
-	"subject.common_name":  StringFilterFieldType,
-	"subject_key_id":       StringFilterFieldType,
-	"issuer_meta.id":       StringFilterFieldType,
-	"status":               EnumFilterFieldType,
-	"engine_id":            StringFilterFieldType,
-	"valid_to":             DateFilterFieldType,
-	"valid_from":           DateFilterFieldType,
-	"revocation_timestamp": DateFilterFieldType,
-	"revocation_reason":    EnumFilterFieldType,
-	"metadata":             JsonFilterFieldType,
 }

--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -8,8 +8,9 @@ The API supports flexible server-side filtering and sorting on list endpoints us
 
 ## Query syntax (HTTP)
 
-- Basic form: `?filter=<field>[<op>]<value>`
+- Basic form: `?filter=<field>[<op>]=<value>`
 - Repeat `filter` to add multiple conditions (combined with AND).
+- The parser also accepts `?filter=<field>[<op>]<value>` and the legacy `:<value>` separator for backward compatibility, but `=` is the canonical form for scalar filters.
 
 Examples:
 
@@ -22,7 +23,7 @@ Note: values must be URL-encoded when required (spaces, quotes, `>` etc.).
 
 ## Supported operators
 
-All operators are specified in the form `field[op]=value`. Accepted operators depend on the field type — see [Operators per field type](#operators-per-field-type) below.
+For scalar filters, operators are specified in the form `field[op]=value`. Accepted operators depend on the field type — see [Operators per field type](#operators-per-field-type) below. JSONPath filters keep the expression immediately after the operator: `field[jsonpath]<expression>`.
 
 | Operator | Applies to type(s) | Meaning | Example (HTTP) |
 |---|---|---|---|
@@ -810,4 +811,3 @@ GET /api/dmsmanager/v1/stats?filter=metadata[jsonpath]$.environment%20==%20%22pr
 | Invalid JSONPath | 400 Bad Request | "invalid JSONPath expression: [details]" |
 
 ---
-

--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -22,29 +22,98 @@ Note: values must be URL-encoded when required (spaces, quotes, `>` etc.).
 
 ## Supported operators
 
-| Operator | Meaning | Example (HTTP) |
-|---|---:|---|
-| `eq` | equal | `status[eq]=ACTIVE` |
-| `eq_ic` | equal (case-insensitive) | `name[eq_ic]=alice` |
-| `ne` | not equal | `status[ne]=REVOKED` |
-| `ne_ic` | not equal (case-insensitive) | `name[ne_ic]=alice` |
-| `ct` | contains (string) | `description[ct]=backup` |
-| `ct_ic` | contains (case-insensitive) | `description[ct_ic]=backup` |
-| `nc` | not contains | `description[nc]=skip` |
-| `nc_ic` | not contains (case-insensitive) | `description[nc_ic]=skip` |
-| `in` | in list | `status[in]=ACTIVE,PENDING` |
-| `in_ic` | in list (case-insensitive) | `name[in_ic]=alice,bob` |
-| `nin` | not in list | `status[nin]=REVOKED,EXPIRED` |
-| `nin_ic` | not in list (case-insensitive) | `name[nin_ic]=alice,bob` |
-| `bf` | date before | `creation_date[bf]=2026-01-01` |
-| `af` | date after | `creation_date[af]=2025-01-01` |
-| `lt` | number less than | `size[lt]=1024` |
-| `le` | number less or equal | `size[le]=1024` |
-| `gt` | number greater than | `size[gt]=1024` |
-| `ge` | number greater or equal | `size[ge]=1024` |
-| `jsonpath` | JSONPath expression on a JSON field | see below |
+All operators are specified in the form `field[op]=value`. Accepted operators depend on the field type — see [Operators per field type](#operators-per-field-type) below.
+
+| Operator | Applies to type(s) | Meaning | Example (HTTP) |
+|---|---|---|---|
+| `eq` | String, Date, Number, Enum | equal | `status[eq]=ACTIVE` |
+| `eq_ic` | String | equal (case-insensitive) | `name[eq_ic]=alice` |
+| `ne` | String, Number, Enum | not equal | `status[ne]=REVOKED` |
+| `ne_ic` | String | not equal (case-insensitive) | `name[ne_ic]=alice` |
+| `ct` | String, StringArray | contains | `description[ct]=backup` |
+| `ct_ic` | String, StringArray | contains (case-insensitive) | `description[ct_ic]=backup` |
+| `nc` | String | not contains | `description[nc]=skip` |
+| `nc_ic` | String | not contains (case-insensitive) | `description[nc_ic]=skip` |
+| `in` | String, Enum | in list (comma-separated) | `status[in]=ACTIVE,PENDING` |
+| `in_ic` | String | in list (case-insensitive) | `name[in_ic]=alice,bob` |
+| `nin` | String | not in list | `status[nin]=REVOKED,EXPIRED` |
+| `nin_ic` | String | not in list (case-insensitive) | `name[nin_ic]=alice,bob` |
+| `bf` | Date | date before | `creation_date[bf]=2026-01-01` |
+| `af` | Date | date after | `creation_date[af]=2025-01-01` |
+| `lt` | Number | less than | `size[lt]=1024` |
+| `le` | Number | less or equal | `size[le]=1024` |
+| `gt` | Number | greater than | `size[gt]=1024` |
+| `ge` | Number | greater or equal | `size[ge]=1024` |
+| `jsonpath` | JSON | JSONPath expression | see below |
 
 These operators map to internal `resources.FilterOperation` values used by the SDK and server (see `core/pkg/resources/query.go`).
+
+---
+
+## Operators per field type
+
+The following tables list every accepted operator for each field type, together with its Go constant and both supported short and long forms.
+
+### String
+
+| Operator | Long form | Go constant | Meaning |
+|---|---|---|---|
+| `eq` | `equal` | `StringEqual` | exact match |
+| `eq_ic` | `equal_ignorecase` | `StringEqualIgnoreCase` | exact match (case-insensitive) |
+| `ne` | `notequal` | `StringNotEqual` | not equal |
+| `ne_ic` | `notequal_ignorecase` | `StringNotEqualIgnoreCase` | not equal (case-insensitive) |
+| `ct` | `contains` | `StringContains` | substring match |
+| `ct_ic` | `contains_ignorecase` | `StringContainsIgnoreCase` | substring match (case-insensitive) |
+| `nc` | `notcontains` | `StringNotContains` | does not contain |
+| `nc_ic` | `notcontains_ignorecase` | `StringNotContainsIgnoreCase` | does not contain (case-insensitive) |
+| `in` | — | `StringIn` | value is one of a comma-separated list |
+| `in_ic` | — | `StringInIgnoreCase` | value is one of a list (case-insensitive) |
+| `nin` | — | `StringNotIn` | value is not in a comma-separated list |
+| `nin_ic` | — | `StringNotInIgnoreCase` | value is not in a list (case-insensitive) |
+
+### StringArray
+
+| Operator | Long form | Go constant | Meaning |
+|---|---|---|---|
+| `ct` | `contains` | `StringArrayContains` | array contains the value |
+| `ct_ic` | `contains_ignorecase` | `StringArrayContainsIgnoreCase` | array contains the value (case-insensitive) |
+
+### Date
+
+Values must be ISO 8601 (`YYYY-MM-DD` or `YYYY-MM-DDTHH:MM:SSZ`).
+
+| Operator | Long form | Go constant | Meaning |
+|---|---|---|---|
+| `eq` | `equal` | `DateEqual` | exact date match |
+| `bf` | `before` | `DateBefore` | before the given date |
+| `af` | `after` | `DateAfter` | after the given date |
+
+### Number
+
+| Operator | Long form | Go constant | Meaning |
+|---|---|---|---|
+| `eq` | `equal` | `NumberEqual` | equal |
+| `ne` | `notequal` | `NumberNotEqual` | not equal |
+| `lt` | `lessthan` | `NumberLessThan` | less than |
+| `le` | `lessequal` / `lessorequal` | `NumberLessOrEqualThan` | less than or equal |
+| `gt` | `greaterthan` | `NumberGreaterThan` | greater than |
+| `ge` | `greaterequal` / `greaterorequal` | `NumberGreaterOrEqualThan` | greater than or equal |
+
+### Enum
+
+| Operator | Long form | Go constant | Meaning |
+|---|---|---|---|
+| `eq` | `equal` | `EnumEqual` | exact value match |
+| `ne` | `notequal` | `EnumNotEqual` | not equal |
+| `in` | — | `EnumIn` | value is one of a comma-separated list |
+
+### JSON
+
+| Operator | Go constant | Meaning |
+|---|---|---|
+| `jsonpath` | `JsonPathExpression` | PostgreSQL JSONPath expression evaluated with `field @@ ?::jsonpath` |
+
+See [JSONPath filtering](#jsonpath-filtering-advanced) for expression syntax.
 
 ---
 
@@ -296,25 +365,29 @@ Below is a concise list of the fields you can filter on for the main resources. 
 ### CA
 
 | Field | Type | Notes |
-|---|---:|---|
+|---|---|---|
 | `id` | String | |
-| `level` | Number | |
+| `profile_id` | String | |
 | `type` | Enum | |
 | `serial_number` | String | |
+| `subject.common_name` | String | dotted path for nested subject fields |
+| `subject_key_id` | String | |
+| `issuer_meta.id` | String | dotted path to issuer metadata |
 | `status` | Enum | |
 | `engine_id` | String | |
 | `valid_to` | Date | |
 | `valid_from` | Date | |
 | `revocation_timestamp` | Date | |
 | `revocation_reason` | Enum | |
-| `subject.common_name` | String | dotted path for nested subject fields |
-| `subject_key_id` | String | |
-| `profile_id` | String | |
+| `is_ca` | Enum | boolean-like enum |
+| `extensions.key_usage` | StringArray | use `ct` / `ct_ic` |
+| `extensions.extended_key_usage` | StringArray | use `ct` / `ct_ic` |
+| `metadata` | JSON | use `[jsonpath]` operator |
 
 ### Certificate
 
 | Field | Type | Notes |
-|---|---:|---|
+|---|---|---|
 | `type` | Enum | |
 | `serial_number` | String | |
 | `subject.common_name` | String | |
@@ -326,33 +399,37 @@ Below is a concise list of the fields you can filter on for the main resources. 
 | `valid_from` | Date | |
 | `revocation_timestamp` | Date | |
 | `revocation_reason` | Enum | |
-| `metadata` | JSON | Use `[jsonpath]` operator for advanced queries |
+| `is_ca` | Enum | boolean-like enum |
+| `extensions.key_usage` | StringArray | use `ct` / `ct_ic` |
+| `extensions.extended_key_usage` | StringArray | use `ct` / `ct_ic` |
+| `metadata` | JSON | use `[jsonpath]` operator |
 
 ### Device
 
 | Field | Type | Notes |
-|---|---:|---|
+|---|---|---|
 | `id` | String | |
 | `dms_owner` | String | |
 | `creation_timestamp` | Date | |
 | `status` | Enum | |
-| `tags` | StringArray | use contains operators (`ct`, `ct_ic`) |
-| `metadata` | JSON | Use `[jsonpath]` operator |
+| `tags` | StringArray | use `ct` / `ct_ic` |
+| `metadata` | JSON | use `[jsonpath]` operator |
+| `identity_slot` | JSON | use `[jsonpath]` operator |
 
 ### DMS
 
 | Field | Type | Notes |
-|---|---:|---|
+|---|---|---|
 | `id` | String | |
 | `name` | String | |
 | `creation_date` | Date | |
-| `metadata` | JSON | Use `[jsonpath]` operator |
-| `settings` | JSON | Use `[jsonpath]` operator |
+| `metadata` | JSON | use `[jsonpath]` operator |
+| `settings` | JSON | use `[jsonpath]` operator |
 
 ### KMS
 
 | Field | Type | Notes |
-|---|---:|---|
+|---|---|---|
 | `key_id` | String | |
 | `engine_id` | String | |
 | `has_private_key` | Enum | boolean-like enum |
@@ -362,13 +439,13 @@ Below is a concise list of the fields you can filter on for the main resources. 
 | `status` | String | |
 | `creation_ts` | Date | |
 | `name` | String | |
-| `tags` | StringArray | |
-| `metadata` | JSON | Use `[jsonpath]` operator |
+| `tags` | StringArray | use `ct` / `ct_ic` |
+| `metadata` | JSON | use `[jsonpath]` operator |
 
 ### Issuance Profile
 
 | Field | Type | Notes |
-|---|---:|---|
+|---|---|---|
 | `id` | String | |
 | `name` | String | |
 

--- a/engines/storage/postgres/migrations/ca/20260331120000_add_certificate_extensions.go
+++ b/engines/storage/postgres/migrations/ca/20260331120000_add_certificate_extensions.go
@@ -11,6 +11,13 @@ import (
 	"github.com/pressly/goose/v3"
 )
 
+const certificateExtensionsBackfillBatchSize = 500
+
+type certificateExtensionsBackfillRow struct {
+	serialNumber      string
+	base64Certificate string
+}
+
 func Register20260331120000AddCertificateExtensions() {
 	goose.AddMigrationContext(upAddCertificateExtensions, downAddCertificateExtensions)
 }
@@ -27,57 +34,80 @@ func upAddCertificateExtensions(ctx context.Context, tx *sql.Tx) error {
 		}
 	}
 
-	rows, err := tx.QueryContext(ctx, "SELECT serial_number, certificate FROM certificates")
-	if err != nil {
-		return err
-	}
-	defer rows.Close()
-
-	result, err := mhelper.RowsToMap(rows)
-	if err != nil {
-		return err
-	}
-
-	for _, row := range result {
-		serialNumber, ok := row["serial_number"].(string)
-		if !ok || serialNumber == "" {
-			return fmt.Errorf("invalid serial number while backfilling certificate extensions")
-		}
-
-		base64Certificate, ok := row["certificate"].(string)
-		if !ok || base64Certificate == "" {
-			continue
-		}
-
-		certificate, err := mhelper.DecodeCertificate(base64Certificate)
+	lastSerialNumber := ""
+	for {
+		rows, err := tx.QueryContext(ctx, `
+			SELECT serial_number, certificate
+			FROM certificates
+			WHERE serial_number > $1
+			ORDER BY serial_number
+			LIMIT $2
+		`, lastSerialNumber, certificateExtensionsBackfillBatchSize)
 		if err != nil {
-			return fmt.Errorf("decode certificate %s: %w", serialNumber, err)
+			return err
 		}
 
-		keyUsageJSON, err := json.Marshal(models.X509KeyUsage(certificate.KeyUsage))
-		if err != nil {
-			return fmt.Errorf("marshal key usage for certificate %s: %w", serialNumber, err)
+		batch := make([]certificateExtensionsBackfillRow, 0, certificateExtensionsBackfillBatchSize)
+		for rows.Next() {
+			var row certificateExtensionsBackfillRow
+			if err := rows.Scan(&row.serialNumber, &row.base64Certificate); err != nil {
+				rows.Close()
+				return fmt.Errorf("scan certificate extensions backfill row: %w", err)
+			}
+
+			batch = append(batch, row)
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return fmt.Errorf("iterate certificate extensions backfill rows: %w", err)
+		}
+		if err := rows.Close(); err != nil {
+			return fmt.Errorf("close certificate extensions backfill rows: %w", err)
+		}
+		if len(batch) == 0 {
+			break
 		}
 
-		extendedKeyUsage := make([]models.X509ExtKeyUsage, 0, len(certificate.ExtKeyUsage))
-		for _, usage := range certificate.ExtKeyUsage {
-			extendedKeyUsage = append(extendedKeyUsage, models.X509ExtKeyUsage(usage))
+		for _, row := range batch {
+			if row.serialNumber == "" {
+				return fmt.Errorf("invalid serial number while backfilling certificate extensions")
+			}
+			if row.base64Certificate == "" {
+				continue
+			}
+
+			certificate, err := mhelper.DecodeCertificate(row.base64Certificate)
+			if err != nil {
+				return fmt.Errorf("decode certificate %s: %w", row.serialNumber, err)
+			}
+
+			keyUsageJSON, err := json.Marshal(models.X509KeyUsage(certificate.KeyUsage))
+			if err != nil {
+				return fmt.Errorf("marshal key usage for certificate %s: %w", row.serialNumber, err)
+			}
+
+			extendedKeyUsage := make([]models.X509ExtKeyUsage, 0, len(certificate.ExtKeyUsage))
+			for _, usage := range certificate.ExtKeyUsage {
+				extendedKeyUsage = append(extendedKeyUsage, models.X509ExtKeyUsage(usage))
+			}
+
+			extendedKeyUsageJSON, err := json.Marshal(extendedKeyUsage)
+			if err != nil {
+				return fmt.Errorf("marshal extended key usage for certificate %s: %w", row.serialNumber, err)
+			}
+
+			if _, err := tx.ExecContext(ctx, `
+				UPDATE certificates
+				SET
+					extensions_key_usage = $1::jsonb,
+					extensions_extended_key_usage = $2::jsonb
+				WHERE serial_number = $3
+			`, string(keyUsageJSON), string(extendedKeyUsageJSON), row.serialNumber); err != nil {
+				return fmt.Errorf("update certificate %s extensions: %w", row.serialNumber, err)
+			}
 		}
 
-		extendedKeyUsageJSON, err := json.Marshal(extendedKeyUsage)
-		if err != nil {
-			return fmt.Errorf("marshal extended key usage for certificate %s: %w", serialNumber, err)
-		}
-
-		if _, err := tx.ExecContext(ctx, `
-			UPDATE certificates
-			SET
-				extensions_key_usage = $1::jsonb,
-				extensions_extended_key_usage = $2::jsonb
-			WHERE serial_number = $3
-		`, string(keyUsageJSON), string(extendedKeyUsageJSON), serialNumber); err != nil {
-			return fmt.Errorf("update certificate %s extensions: %w", serialNumber, err)
-		}
+		lastSerialNumber = batch[len(batch)-1].serialNumber
 	}
 
 	if _, err := tx.ExecContext(ctx, "ALTER TABLE certificates DROP COLUMN version_schema;"); err != nil {

--- a/engines/storage/postgres/migrations/ca/20260331120000_add_certificate_extensions.go
+++ b/engines/storage/postgres/migrations/ca/20260331120000_add_certificate_extensions.go
@@ -80,16 +80,6 @@ func upAddCertificateExtensions(ctx context.Context, tx *sql.Tx) error {
 		}
 	}
 
-	if _, err := tx.ExecContext(ctx, `
-		UPDATE certificates
-		SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
-			$1::text,
-			'[]'::jsonb
-		)
-	`, models.CertificateMetadataLinksKey); err != nil {
-		return err
-	}
-
 	if _, err := tx.ExecContext(ctx, "ALTER TABLE certificates DROP COLUMN version_schema;"); err != nil {
 		return err
 	}
@@ -109,13 +99,6 @@ func downAddCertificateExtensions(ctx context.Context, tx *sql.Tx) error {
 		if _, err := tx.ExecContext(ctx, query); err != nil {
 			return err
 		}
-	}
-
-	if _, err := tx.ExecContext(ctx, `
-		UPDATE certificates
-		SET metadata = COALESCE(metadata, '{}'::jsonb) - $1
-	`, models.CertificateMetadataLinksKey); err != nil {
-		return err
 	}
 
 	return nil

--- a/engines/storage/postgres/migrations/ca/20260331120000_add_certificate_extensions.go
+++ b/engines/storage/postgres/migrations/ca/20260331120000_add_certificate_extensions.go
@@ -1,0 +1,122 @@
+package ca
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
+	mhelper "github.com/lamassuiot/lamassuiot/engines/storage/postgres/v3/migrations/helpers"
+	"github.com/pressly/goose/v3"
+)
+
+func Register20260331120000AddCertificateExtensions() {
+	goose.AddMigrationContext(upAddCertificateExtensions, downAddCertificateExtensions)
+}
+
+func upAddCertificateExtensions(ctx context.Context, tx *sql.Tx) error {
+	queries := []string{
+		"ALTER TABLE certificates ADD COLUMN extensions_key_usage JSONB NOT NULL DEFAULT '[]'::jsonb;",
+		"ALTER TABLE certificates ADD COLUMN extensions_extended_key_usage JSONB NOT NULL DEFAULT '[]'::jsonb;",
+	}
+
+	for _, query := range queries {
+		if _, err := tx.ExecContext(ctx, query); err != nil {
+			return err
+		}
+	}
+
+	rows, err := tx.QueryContext(ctx, "SELECT serial_number, certificate FROM certificates")
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	result, err := mhelper.RowsToMap(rows)
+	if err != nil {
+		return err
+	}
+
+	for _, row := range result {
+		serialNumber, ok := row["serial_number"].(string)
+		if !ok || serialNumber == "" {
+			return fmt.Errorf("invalid serial number while backfilling certificate extensions")
+		}
+
+		base64Certificate, ok := row["certificate"].(string)
+		if !ok || base64Certificate == "" {
+			continue
+		}
+
+		certificate, err := mhelper.DecodeCertificate(base64Certificate)
+		if err != nil {
+			return fmt.Errorf("decode certificate %s: %w", serialNumber, err)
+		}
+
+		keyUsageJSON, err := json.Marshal(models.X509KeyUsage(certificate.KeyUsage))
+		if err != nil {
+			return fmt.Errorf("marshal key usage for certificate %s: %w", serialNumber, err)
+		}
+
+		extendedKeyUsage := make([]models.X509ExtKeyUsage, 0, len(certificate.ExtKeyUsage))
+		for _, usage := range certificate.ExtKeyUsage {
+			extendedKeyUsage = append(extendedKeyUsage, models.X509ExtKeyUsage(usage))
+		}
+
+		extendedKeyUsageJSON, err := json.Marshal(extendedKeyUsage)
+		if err != nil {
+			return fmt.Errorf("marshal extended key usage for certificate %s: %w", serialNumber, err)
+		}
+
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE certificates
+			SET
+				extensions_key_usage = $1::jsonb,
+				extensions_extended_key_usage = $2::jsonb
+			WHERE serial_number = $3
+		`, string(keyUsageJSON), string(extendedKeyUsageJSON), serialNumber); err != nil {
+			return fmt.Errorf("update certificate %s extensions: %w", serialNumber, err)
+		}
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE certificates
+		SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+			$1::text,
+			'[]'::jsonb
+		)
+	`, models.CertificateMetadataLinksKey); err != nil {
+		return err
+	}
+
+	if _, err := tx.ExecContext(ctx, "ALTER TABLE certificates DROP COLUMN version_schema;"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func downAddCertificateExtensions(ctx context.Context, tx *sql.Tx) error {
+	queries := []string{
+		"ALTER TABLE certificates ADD COLUMN version_schema VARCHAR;",
+		"UPDATE certificates SET version_schema = 'unknown' WHERE version_schema IS NULL;",
+		"ALTER TABLE certificates DROP COLUMN extensions_extended_key_usage;",
+		"ALTER TABLE certificates DROP COLUMN extensions_key_usage;",
+	}
+
+	for _, query := range queries {
+		if _, err := tx.ExecContext(ctx, query); err != nil {
+			return err
+		}
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE certificates
+		SET metadata = COALESCE(metadata, '{}'::jsonb) - $1
+	`, models.CertificateMetadataLinksKey); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/engines/storage/postgres/migrations/gomigrations.go
+++ b/engines/storage/postgres/migrations/gomigrations.go
@@ -14,6 +14,7 @@ func RegisterGoMigrations(dbname string) {
 		ca.Register20250226114600CaAddKids()
 		ca.Register20250908074250AddProfileId()
 		ca.Register20250915090500UpdateSkiAki()
+		ca.Register20260331120000AddCertificateExtensions()
 	case "devicemanager":
 		devicemanager.Register20250925120000RemoveSerialHyphens()
 	case "dmsmanager":

--- a/engines/storage/postgres/migrations_test/ca_test.go
+++ b/engines/storage/postgres/migrations_test/ca_test.go
@@ -569,9 +569,7 @@ func MigrationTest_CA_20260331120000_add_certificate_extensions(t *testing.T, lo
 			jsonb_exists(extensions_key_usage, 'CRLSign') AS has_crl_sign,
 			jsonb_exists(extensions_extended_key_usage, 'ClientAuth') AS has_client_auth,
 			jsonb_exists(extensions_extended_key_usage, 'ServerAuth') AS has_server_auth,
-			jsonb_array_length(extensions_extended_key_usage) AS extended_key_usage_length,
-			jsonb_exists(metadata, 'lamassu.io/ca/links') AS has_links_metadata,
-			jsonb_array_length(metadata -> 'lamassu.io/ca/links') AS links_length
+			jsonb_array_length(extensions_extended_key_usage) AS extended_key_usage_length
 		FROM certificates
 		WHERE serial_number = ?
 	`, serial).Scan(&result)
@@ -591,8 +589,6 @@ func MigrationTest_CA_20260331120000_add_certificate_extensions(t *testing.T, lo
 	assert.Equal(t, true, result["has_client_auth"])
 	assert.Equal(t, true, result["has_server_auth"])
 	assert.Equal(t, int32(2), result["extended_key_usage_length"])
-	assert.Equal(t, true, result["has_links_metadata"])
-	assert.Equal(t, int32(0), result["links_length"])
 
 	var versionSchemaColumnCount int64
 	tx = con.Raw(`

--- a/engines/storage/postgres/migrations_test/ca_test.go
+++ b/engines/storage/postgres/migrations_test/ca_test.go
@@ -548,6 +548,66 @@ func MigrationTest_CA_20251217120000_metadata_text_to_jsonb(t *testing.T, logger
 	assert.Equal(t, "value", keyValue)
 }
 
+func MigrationTest_CA_20260331120000_add_certificate_extensions(t *testing.T, logger *logrus.Entry, con *gorm.DB) {
+	const serial = "37-65-cd-86-f0-bf-c5-c8-1b-7f-10-f8-15-4e-4e-35-81-4c-d8-79"
+
+	con.Exec(`INSERT INTO certificates
+		(serial_number, metadata, issuer_meta_serial_number, issuer_meta_id, issuer_meta_level, status, certificate, key_meta_type, key_meta_bits, key_meta_strength, subject_common_name, subject_organization, subject_organization_unit, subject_country, subject_state, subject_locality, valid_from, valid_to, revocation_timestamp, revocation_reason, "type", engine_id, subject_key_id, is_ca)
+		VALUES ('37-65-cd-86-f0-bf-c5-c8-1b-7f-10-f8-15-4e-4e-35-81-4c-d8-79', '{}', '37-65-cd-86-f0-bf-c5-c8-1b-7f-10-f8-15-4e-4e-35-81-4c-d8-79', 'b0db9cc7-2cce-45be-8085-88f7aff40ca2', 0, 'ACTIVE', 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUY5RENDQTl5Z0F3SUJBZ0lSQU85dFIvVGx2Y2pqZ1dkMFlCTEJEMGN3RFFZSktvWklodmNOQVFFTEJRQXcKSERFYU1CZ0dBMVVFQXhNUlJVTlRMVTFoYm5WbVlXTjBkWEpwYm1jd0hoY05NalF4TVRJMU1EazBOVFE0V2hjTgpNalV3T1RJeE1EazBOVFEwV2pBY01Sb3dHQVlEVlFRREV4RkZRMU10VFdGdWRXWmhZM1IxY21sdVp6Q0NBaUl3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dJUEFEQ0NBZ29DZ2dJQkFOQllQKytacmZNY2MzL1BiTXVVYjBVcklMMVEKb2Jtbm41TllWdXJkU1c2ZEhZMEF3ajQzbmhlTndtV3NPbGt5bmR3UGNmVWdpWnlsS1dpVzcxUlFsMGF1bWFZLworczFVcnhjQXhidFFCOGQ3c3dBd2xYZ0xoMk1XR3ppUm4wUjBuNDJkRDdxVFdZWXIwcFRnbkc1WG82LzV1ak5iCmlSVzZaWXA4ZzNuM1BCbWFhbFRRVmxmRWgzNHBIbFU5SThFUExUdmFvMnFXU01RSlY4WDM5Y1VDdjBib0RKVEwKa0daaWpxTVM0dEoyR3NRWHo4UE8yTk83UHlXVndLWlgvSE5tYTA1NWlZV0tzNi9GN2I3bEY3YkNEQVFMalVCdwphWldWOW00VmpwRWpCMEc0WTkzTm5VMFNqVUxzR2ZFYVRlblovVk5zMXBZZ3hJcHRXWFdtZUdBT3RJWi90bFJ0CmwyTitweTVZenFtQ2tYbjZxRlRpb3ZyN1huTjFWSkxRblJKMkhSZUxWVUJ6K21TWmMzSmRXOHd6QmgvWTVtYUgKK1RpZ0dyTnIrcFZVZi9vNTZ6ZS9pblAzWUUvdERoUG5FRk1PSVBCbGdyZktlcFRKOVd6dmtPWHNkb1hwR2RHYQp6QlIwNTl1N05uVFpEQzBsc3ByKzJWMTVGVVhIMXRyelg3Nmk4QSt5bVJRak45U2NhTWlhemlzWUdSU09XNVRTClhJZ0VkSVM0YXg4TWQ1Skd5TStFVVdyQ2pwaHRaamVlQzNvdjY0R25mSWdiL1lOTFNQUi9FeHhwekJwNjN4d3AKdS8wWnZaRTZVNVBNTExwNkF0RzkzY2h2NTFVdE1lVVAzYXlQaUF4OEhZTmp3L0djN2VHKzZ1cnhYMVFnakpHSQp1MWNqU3djTE00dFA4aXdMQWdNQkFBR2pnZ0V2TUlJQkt6QU9CZ05WSFE4QkFmOEVCQU1DQVpZd0hRWURWUjBsCkJCWXdGQVlJS3dZQkJRVUhBd0lHQ0NzR0FRVUZCd01CTUE4R0ExVWRFd0VCL3dRRk1BTUJBZjh3TFFZRFZSME8KQkNZRUpEbGlaV1ZpWXpWaUxXSmhPR1F0Tkdaak1DMDVaVGszTFRVNE1qazVaRE13WVdVNVpqQXZCZ05WSFNNRQpLREFtZ0NRNVltVmxZbU0xWWkxaVlUaGtMVFJtWXpBdE9XVTVOeTAxT0RJNU9XUXpNR0ZsT1dZd053WUlLd1lCCkJRVUhBUUVFS3pBcE1DY0dDQ3NHQVFVRkJ6QUJoaHRvZEhSd2N6b3ZMMnhoWWk1c1lXMWhjM04xTG1sdkwyOWoKYzNBd1VBWURWUjBmQkVrd1J6QkZvRU9nUVlZL2FIUjBjSE02THk5c1lXSXViR0Z0WVhOemRTNXBieTlqY213dgpPV0psWldKak5XSXRZbUU0WkMwMFptTXdMVGxsT1RjdE5UZ3lPVGxrTXpCaFpUbG1NQTBHQ1NxR1NJYjNEUUVCCkN3VUFBNElDQVFDQ1pTOG5pRStxeEdBYjJjSVhVWW4rRHNJVGRwZXFnM3BQRU1EZU5DR29rUUY4cGcwbkpOdjcKZURmaTR3TEp2ZlBRK0lzNjNLYnU4dVBoanpYcnVrWUE3VWgyTmJRZnJHM1d3L3JDUGlJTkVZNktjNmltdnk1RApyK2NIbFJKYkEyaE9yNTd3Tnc0b2RrMERsdkdIbVN6M2hOWXFxcWZJcEYxMEYwdUNTNllOV1AvUHU1VFVaN2V4CkFPTjF2aWZMdFBGcGFnYkxPd3k5K3JicStHUkZET0ZSRjlzYzdBUHdoWVpUZTdHSnFNblZKbklPOU1Qd01idDEKMW1KRHNJTzlqTkhNVkVMbzBGWVRhOE05K29EWE1CaThzRWN5aER0ZlN1ZUU5bU9wWkhFck1Wb2s5aTd6Y2FObwp4OEFBZTNHRFU5MDB1SlB1Y0t3TmprVjZpL21FMk1maXBCYTMxV3NHcUdNbjY3MDBoSjJhS00wcjVIRnhhK3l4CnMzMVArQ1hCZjF4THBaYTBPY3ZTTFJuTzJtSFhnTTlzRGRsdW5WZkEzOGFoU2Zna1ZBK1BQU1EvTTFZTVUxT1YKRTIvdlNvUjR0elF4QU9wU3RjaUxGUFpxczcrY0ZJbzlKSk5aZnNNR2ZKempDbFBlRU91VFJ0YklmR0FEc1VzeQp0MmdtdDZMeDhSc2M1V0NXanNGMjFjR3FKZjB3TlJHcloyb20xTnlRcjhDZTdmQ1Y1dWY0dlNJMEZkVGU3cE5WCjNKKzJwa3ZDV05TVUdyNktmUEw2OGw1YnhiVWl0d294N0doV0dZT2IwaEp5b2V4VC92MmNiQys2WWNDUXZCSFUKeUR6bU1EZVFVQkVJeXhFRk96bE5uZlZxRnNQbmVJT2ZhbWNNaHd1VkdRSUhMdWhIK0gwdDVBPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=', 'RSA', 4096, 'HIGH', 'ECS-Manufacturing', '', '', '', '', '', '2024-11-25 09:45:48+00', '2025-09-21 11:45:44+00', '0001-01-01 00:00:00+00', 'Unspecified', 'MANAGED', 'filesystem-1', '9beebc5b-ba8d-4fc0-9e97-58299d30ae9f', true);
+	`)
+
+	ApplyMigration(t, logger, con, CADBName)
+
+	var result map[string]any
+	tx := con.Raw(`
+		SELECT
+			pg_typeof(extensions_key_usage)::text AS key_usage_type,
+			pg_typeof(extensions_extended_key_usage)::text AS extended_key_usage_type,
+			jsonb_exists(extensions_key_usage, 'DigitalSignature') AS has_digital_signature,
+			jsonb_exists(extensions_key_usage, 'DataEncipherment') AS has_data_encipherment,
+			jsonb_exists(extensions_key_usage, 'CertSign') AS has_cert_sign,
+			jsonb_exists(extensions_key_usage, 'CRLSign') AS has_crl_sign,
+			jsonb_exists(extensions_extended_key_usage, 'ClientAuth') AS has_client_auth,
+			jsonb_exists(extensions_extended_key_usage, 'ServerAuth') AS has_server_auth,
+			jsonb_array_length(extensions_extended_key_usage) AS extended_key_usage_length,
+			jsonb_exists(metadata, 'lamassu.io/ca/links') AS has_links_metadata,
+			jsonb_array_length(metadata -> 'lamassu.io/ca/links') AS links_length
+		FROM certificates
+		WHERE serial_number = ?
+	`, serial).Scan(&result)
+	if tx.Error != nil {
+		t.Fatalf("failed to select certificate extensions: %v", tx.Error)
+	}
+	if tx.RowsAffected != 1 {
+		t.Fatalf("expected 1 row, got %d", tx.RowsAffected)
+	}
+
+	assert.Equal(t, "jsonb", result["key_usage_type"])
+	assert.Equal(t, "jsonb", result["extended_key_usage_type"])
+	assert.Equal(t, true, result["has_digital_signature"])
+	assert.Equal(t, true, result["has_data_encipherment"])
+	assert.Equal(t, true, result["has_cert_sign"])
+	assert.Equal(t, true, result["has_crl_sign"])
+	assert.Equal(t, true, result["has_client_auth"])
+	assert.Equal(t, true, result["has_server_auth"])
+	assert.Equal(t, int32(2), result["extended_key_usage_length"])
+	assert.Equal(t, true, result["has_links_metadata"])
+	assert.Equal(t, int32(0), result["links_length"])
+
+	var versionSchemaColumnCount int64
+	tx = con.Raw(`
+		SELECT COUNT(*)
+		FROM information_schema.columns
+		WHERE table_name = 'certificates'
+			AND column_name = 'version_schema'
+	`).Scan(&versionSchemaColumnCount)
+	if tx.Error != nil {
+		t.Fatalf("failed to check version_schema column: %v", tx.Error)
+	}
+
+	assert.Equal(t, int64(0), versionSchemaColumnCount)
+}
+
 func TestMigrations(t *testing.T) {
 	logger := helpers.SetupLogger(config.Trace, "test", "test")
 	cleanup, con := RunDB(t, logger, CADBName)
@@ -638,5 +698,12 @@ func TestMigrations(t *testing.T) {
 	MigrationTest_CA_20251217120000_metadata_text_to_jsonb(t, logger, con)
 	if t.Failed() {
 		t.Fatalf("failed while running migration v20251217120000_metadata_text_to_jsonb")
+	}
+
+	CleanAllTables(t, logger, con)
+
+	MigrationTest_CA_20260331120000_add_certificate_extensions(t, logger, con)
+	if t.Failed() {
+		t.Fatalf("failed while running migration v20260331120000_add_certificate_extensions")
 	}
 }

--- a/engines/storage/postgres/utils.go
+++ b/engines/storage/postgres/utils.go
@@ -538,7 +538,11 @@ func FilterOperandToWhereClause(filter resources.FilterOption, tx *gorm.DB) *gor
 	case resources.StringContainsIgnoreCase:
 		return tx.Where(fmt.Sprintf("%s %s ?", filter.Field, ilike), fmt.Sprintf("%%%s%%", filter.Value))
 	case resources.StringArrayContains:
-		return tx.Where(fmt.Sprintf("%s @> ?", filter.Field), fmt.Sprintf(`["%s"]`, filter.Value))
+		if isSQLite(tx) {
+			return tx.Where(fmt.Sprintf("%s %s ?", filter.Field, ilike), "%\""+filter.Value+"\"%")
+		}
+		// Arrays serialized into text columns need a cast before using the JSON containment operator.
+		return tx.Where(fmt.Sprintf("%s::jsonb @> ?::jsonb", filter.Field), fmt.Sprintf(`["%s"]`, filter.Value))
 	case resources.StringArrayContainsIgnoreCase:
 		return tx.Where(fmt.Sprintf("%s::text %s ?", filter.Field, ilike), "%\""+filter.Value+"\"%")
 	case resources.StringNotContains:

--- a/engines/storage/postgres/utils.go
+++ b/engines/storage/postgres/utils.go
@@ -538,11 +538,9 @@ func FilterOperandToWhereClause(filter resources.FilterOption, tx *gorm.DB) *gor
 	case resources.StringContainsIgnoreCase:
 		return tx.Where(fmt.Sprintf("%s %s ?", filter.Field, ilike), fmt.Sprintf("%%%s%%", filter.Value))
 	case resources.StringArrayContains:
-		// return tx.Where(fmt.Sprintf("? = ANY(%s)", filter.Field), filter.Value)
-		return tx.Where(fmt.Sprintf("%s LIKE ?", filter.Field), fmt.Sprintf("%%%s%%", filter.Value))
+		return tx.Where(fmt.Sprintf("%s @> ?", filter.Field), fmt.Sprintf(`["%s"]`, filter.Value))
 	case resources.StringArrayContainsIgnoreCase:
-		// return tx.Where(fmt.Sprintf("? = ANY(%s)", filter.Field), filter.Value)
-		return tx.Where(fmt.Sprintf("%s %s ?", filter.Field, ilike), fmt.Sprintf("%%%s%%", filter.Value))
+		return tx.Where(fmt.Sprintf("%s::text %s ?", filter.Field, ilike), "%\""+filter.Value+"\"%")
 	case resources.StringNotContains:
 		return tx.Where(fmt.Sprintf("%s NOT LIKE ?", filter.Field), fmt.Sprintf("%%%s%%", filter.Value))
 	case resources.StringNotContainsIgnoreCase:

--- a/monolithic/pkg/storage/sqlite/schema.go
+++ b/monolithic/pkg/storage/sqlite/schema.go
@@ -32,7 +32,7 @@ func initializeSchema(db *gorm.DB) error {
 		// - 20241223183344_unified_ca_models.sql: Renamed key_strength_meta_* to key_meta_*, changed types
 		// - 20250107164937_add_is_ca.sql: Added is_ca column
 		// - 20250226114600_ca_add_kids.go: Renamed key_id to subject_key_id, added authority_key_id and issuer_* columns
-		// - 20250704101200_add_version_schema.sql: Added version_schema column
+		// - 20260331120000_add_certificate_extensions.go: Added extension_* JSON columns and dropped version_schema
 		`CREATE TABLE IF NOT EXISTS certificates (
 			serial_number TEXT NOT NULL,
 			metadata TEXT NULL,
@@ -65,7 +65,8 @@ func initializeSchema(db *gorm.DB) error {
 			issuer_state TEXT NULL,
 			issuer_locality TEXT NULL,
 			is_ca INTEGER NULL,
-			version_schema TEXT NULL,
+			extensions_key_usage TEXT NOT NULL DEFAULT '[]',
+			extensions_extended_key_usage TEXT NOT NULL DEFAULT '[]',
 			PRIMARY KEY (serial_number)
 		)`,
 


### PR DESCRIPTION
This pull request introduces enhanced support for certificate extensions, specifically enabling storage and filtering of X.509 Key Usage and Extended Key Usage fields on certificates. It also refactors and consolidates filterable fields for various resources, adds missing support for a Microsoft-specific extended key usage, and improves test coverage for these features.

The most important changes are:

**Certificate Extensions Support:**

* Added a new `CertificateExtensions` struct to the `Certificate` model, allowing certificates to store both `KeyUsage` and `ExtendedKeyUsage` fields. The `certificateExtensionsFromX509` helper function extracts these from parsed X.509 certificates and populates the model accordingly. (`core/pkg/models/ca.go` [[1]](diffhunk://#diff-d7c84197a128bb02fdb2f86c24923f368dc245f5d1bd13a0ee997930651ee7bbR42) [[2]](diffhunk://#diff-d7c84197a128bb02fdb2f86c24923f368dc245f5d1bd13a0ee997930651ee7bbR52-R61); `backend/pkg/services/ca.go` [[3]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9R83-R101) [[4]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L459-R481) [[5]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L780-R802) [[6]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L1402-R1426) [[7]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L1575-R1597) [[8]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L1622-R1644)

* Removed the obsolete `VersionSchema` field from the `Certificate` model and related code, as schema versioning is no longer necessary. (`core/pkg/models/ca.go` [[1]](diffhunk://#diff-d7c84197a128bb02fdb2f86c24923f368dc245f5d1bd13a0ee997930651ee7bbL33); `backend/pkg/services/ca.go` [[2]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L459-R481) [[3]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L780-R802) [[4]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L1402-R1426) [[5]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L1575-R1597) [[6]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L1622-R1644)

**Filtering Enhancements and Refactoring:**

* Updated and consolidated filterable fields for certificates, CAs, KMS, issuance profiles, DMS, and devices into `core/pkg/resources/fields.go`, including new fields for filtering by `extensions.key_usage` and `extensions.extended_key_usage`. This enables advanced querying based on certificate extensions. (`core/pkg/resources/fields.go` [[1]](diffhunk://#diff-bd4bf1f0d2d509f12135778fc63693461a03fbd5f8ee9a5e0014679d59b1daffL3-R23) [[2]](diffhunk://#diff-bd4bf1f0d2d509f12135778fc63693461a03fbd5f8ee9a5e0014679d59b1daffR36-R75); `backend/pkg/controllers/ca.go` [[3]](diffhunk://#diff-890029db072b34e676b8be2ad079d4f437a467f848c5b5782a9b07876eb56732L1203-R1203)

**Extended Key Usage Improvements:**

* Added support for the Microsoft Kernel Code Signing extended key usage in both the mapping and marshaling/unmarshaling logic, and extended test coverage to ensure correct handling. (`core/pkg/models/x509_keyusage.go` [[1]](diffhunk://#diff-04a9c7c83f177ea0630c33deb14692b8fd7b4f1167b8fc3ba0261572d2a9f665R119); `core/pkg/models/x509_keyusage_test.go` [[2]](diffhunk://#diff-1b5c9b14b47e695b159b62d6c7219bc58668b9c25282022781b25bb18d0173b3R196-R200) [[3]](diffhunk://#diff-1b5c9b14b47e695b159b62d6c7219bc58668b9c25282022781b25bb18d0173b3R284-R289)

**Testing:**

* Added new and comprehensive tests for certificate creation with extensions and for filtering certificates by key usage and extended key usage, including case-insensitive filtering. (`backend/pkg/assemblers/tests/ca/ca_certificates_test.go` [[1]](diffhunk://#diff-050d93967523f667ac3434727f29ecb1240f40aca6b65e5a5964624cfcbc7a09R310-R343) [[2]](diffhunk://#diff-050d93967523f667ac3434727f29ecb1240f40aca6b65e5a5964624cfcbc7a09R571-R696)

**Code Cleanup:**

* Removed redundant or duplicate filterable field definitions from `core/pkg/resources/careq.go` now that all are centralized in `fields.go`. (`core/pkg/resources/careq.go` [core/pkg/resources/careq.goL9-L43](diffhunk://#diff-7c550d5cf040571fb768e55125a263412c6fed735ca5c2c129e4d0c4dcb87951L9-L43))

These changes collectively improve the flexibility, correctness, and maintainability of certificate management and filtering in the codebase.