### PR TITLE
refactor: standardize and improve logging across backend services

### DIFF
--- a/backend/cmd/alerts/main.go
+++ b/backend/cmd/alerts/main.go
@@ -18,11 +18,11 @@ var (
 
 func main() {
 	log.SetFormatter(helpers.LogFormatter)
-	log.Infof("starting api: version=%s buildTime=%s sha1ver=%s", version, buildTime, sha1ver)
+	log.Infof("starting API service: version=%s buildTime=%s sha1ver=%s", version, buildTime, sha1ver)
 
 	conf, err := cconfig.LoadConfig[config.AlertsConfig](nil)
 	if err != nil {
-		log.Fatalf("something went wrong while loading config. Exiting: %s", err)
+		log.Fatalf("failed to load config, exiting: %s", err)
 	}
 
 	globalLogLevel, err := log.ParseLevel(string(conf.Logs.Level))

--- a/backend/cmd/ca/main.go
+++ b/backend/cmd/ca/main.go
@@ -21,11 +21,11 @@ var (
 
 func main() {
 	log.SetFormatter(helpers.LogFormatter)
-	log.Infof("starting api: version=%s buildTime=%s sha1ver=%s", version, buildTime, sha1ver)
+	log.Infof("starting API service: version=%s buildTime=%s sha1ver=%s", version, buildTime, sha1ver)
 
 	conf, err := cconfig.LoadConfig[config.CAConfig](nil)
 	if err != nil {
-		log.Fatalf("something went wrong while loading config. Exiting: %s", err)
+		log.Fatalf("failed to load config, exiting: %s", err)
 	}
 
 	globalLogLevel, err := log.ParseLevel(string(conf.Logs.Level))

--- a/backend/cmd/device-manager/main.go
+++ b/backend/cmd/device-manager/main.go
@@ -21,7 +21,7 @@ var (
 
 func main() {
 	log.SetFormatter(helpers.LogFormatter)
-	log.Infof("starting api: version=%s buildTime=%s sha1ver=%s", version, buildTime, sha1ver)
+	log.Infof("starting API service: version=%s buildTime=%s sha1ver=%s", version, buildTime, sha1ver)
 
 	conf, err := cconfig.LoadConfig[config.DeviceManagerConfig](nil)
 	if err != nil {

--- a/backend/cmd/dms-manager/main.go
+++ b/backend/cmd/dms-manager/main.go
@@ -21,7 +21,7 @@ var (
 
 func main() {
 	log.SetFormatter(helpers.LogFormatter)
-	log.Infof("starting api: version=%s buildTime=%s sha1ver=%s", version, buildTime, sha1ver)
+	log.Infof("starting API service: version=%s buildTime=%s sha1ver=%s", version, buildTime, sha1ver)
 
 	conf, err := cconfig.LoadConfig[config.DMSconfig](nil)
 	if err != nil {

--- a/backend/cmd/kms/main.go
+++ b/backend/cmd/kms/main.go
@@ -18,11 +18,11 @@ var (
 
 func main() {
 	log.SetFormatter(helpers.LogFormatter)
-	log.Infof("starting api: version=%s buildTime=%s sha1ver=%s", version, buildTime, sha1ver)
+	log.Infof("starting API service: version=%s buildTime=%s sha1ver=%s", version, buildTime, sha1ver)
 
 	conf, err := cconfig.LoadConfig[config.KMSConfig](nil)
 	if err != nil {
-		log.Fatalf("something went wrong while loading config. Exiting: %s", err)
+		log.Fatalf("failed to load config, exiting: %s", err)
 	}
 
 	globalLogLevel, err := log.ParseLevel(string(conf.Logs.Level))

--- a/backend/cmd/va/main.go
+++ b/backend/cmd/va/main.go
@@ -21,7 +21,7 @@ var (
 
 func main() {
 	log.SetFormatter(helpers.LogFormatter)
-	log.Infof("starting api: version=%s buildTime=%s sha1ver=%s", version, buildTime, sha1ver)
+	log.Infof("starting API service: version=%s buildTime=%s sha1ver=%s", version, buildTime, sha1ver)
 
 	conf, err := cconfig.LoadConfig[config.VAconfig](nil)
 	if err != nil {

--- a/backend/pkg/assemblers/alerts.go
+++ b/backend/pkg/assemblers/alerts.go
@@ -62,7 +62,7 @@ func AssembleAlertsService(conf config.AlertsConfig) (*services.AlertsService, e
 		if !conf.SubscriberDLQEventBus.Enabled {
 			lMessaging.Fatalf("Subscriber Event Bus is enabled but DLQ is not enabled. This is not supported. Exiting")
 		} else {
-			log.Infof("Event Bus is enabled")
+			log.Infof("event bus subscription enabled for Alerts service")
 
 			dlqPublisher, err := eventbus.NewEventBusPublisher(conf.SubscriberDLQEventBus, "alerts", lMessaging)
 			if err != nil {

--- a/backend/pkg/assemblers/ca.go
+++ b/backend/pkg/assemblers/ca.go
@@ -76,7 +76,7 @@ func AssembleCAService(conf config.CAConfig, kmsSDK services.KMSService) (*servi
 	caSvc.SetService(svc)
 
 	if conf.PublisherEventBus.Enabled {
-		log.Infof("Event Bus is enabled")
+		log.Infof("event bus publishing enabled for CA service")
 		pub, err := eventbus.NewEventBusPublisher(conf.PublisherEventBus, "ca", lMessage)
 		if err != nil {
 			return nil, nil, fmt.Errorf("could not create Event Bus publisher: %s", err)
@@ -103,7 +103,7 @@ func AssembleCAService(conf config.CAConfig, kmsSDK services.KMSService) (*servi
 
 	var scheduler *jobs.JobScheduler
 	if conf.CertificateMonitoringJob.Enabled {
-		log.Infof("Crypto Monitoring is enabled")
+		log.Infof("certificate expiry monitoring enabled")
 		monitorJob := jobs.NewCryptoMonitor(svc, lMonitor)
 		scheduler = jobs.NewJobScheduler(lMonitor, conf.CertificateMonitoringJob.Frequency, monitorJob)
 		scheduler.Start()

--- a/backend/pkg/assemblers/device-manager.go
+++ b/backend/pkg/assemblers/device-manager.go
@@ -61,9 +61,9 @@ func AssembleDeviceManagerService(conf config.DeviceManagerConfig, caService ser
 	deviceSvc := svc.(*lservices.DeviceManagerServiceBackend)
 
 	lMessaging := helpers.SetupLogger(conf.PublisherEventBus.LogLevel, "Device Manager", "Event Bus")
-	lMessaging.Infof("Publisher Event Bus is enabled")
 
 	if conf.PublisherEventBus.Enabled {
+		lMessaging.Infof("event bus publishing enabled for Device Manager service")
 		pub, err := eventbus.NewEventBusPublisher(conf.PublisherEventBus, serviceID, lMessaging)
 		if err != nil {
 			return nil, fmt.Errorf("could not create Event Bus publisher: %s", err)
@@ -89,7 +89,7 @@ func AssembleDeviceManagerService(conf config.DeviceManagerConfig, caService ser
 			}
 
 			lMessaging := helpers.SetupLogger(conf.SubscriberEventBus.LogLevel, "Device Manager", "Event Bus")
-			lMessaging.Infof("Subscriber Event Bus is enabled")
+			lMessaging.Infof("event bus subscription enabled for Device Manager service")
 
 			subscriber, err := eventbus.NewEventBusSubscriber(conf.SubscriberEventBus, serviceID, lMessaging)
 			if err != nil {

--- a/backend/pkg/assemblers/dms-manager.go
+++ b/backend/pkg/assemblers/dms-manager.go
@@ -66,7 +66,7 @@ func AssembleDMSManagerService(conf config.DMSconfig, caService services.CAServi
 	dmsSvc := svc.(*lservices.DMSManagerServiceBackend)
 
 	if conf.PublisherEventBus.Enabled {
-		log.Infof("Event Bus is enabled")
+		log.Infof("event bus publishing enabled for DMS Manager service")
 		pub, err := eventbus.NewEventBusPublisher(conf.PublisherEventBus, "dms-manager", lMessaging)
 		if err != nil {
 			return nil, fmt.Errorf("could not create Event Bus publisher: %s", err)

--- a/backend/pkg/assemblers/kms.go
+++ b/backend/pkg/assemblers/kms.go
@@ -96,7 +96,7 @@ func AssembleKMSService(conf config.KMSConfig) (*services.KMSService, error) {
 	kmsSvc.SetService(svc)
 
 	if conf.PublisherEventBus.Enabled {
-		log.Infof("Event Bus is enabled")
+		log.Infof("event bus publishing enabled for KMS service")
 		pub, err := eventbus.NewEventBusPublisher(conf.PublisherEventBus, "kms", lMessage)
 		if err != nil {
 			return nil, fmt.Errorf("could not create Event Bus publisher: %s", err)
@@ -165,7 +165,7 @@ func migrateKeysToV2Format(logger *log.Entry, engine *lservices.Engine, engineID
 	}
 	keyMigLog := logger.WithField("engine", engineID)
 	softCrypto := software.NewSoftwareCryptoEngine(keyMigLog)
-	keyMigLog.Infof("checking engine keys format")
+	keyMigLog.Debugf("checking key ID format for engine '%s'", engineID)
 
 	// Iter over all keys and rename if not in sha256 hex format
 	for _, keyID := range keyIDs {
@@ -181,7 +181,7 @@ func migrateKeysToV2Format(logger *log.Entry, engine *lservices.Engine, engineID
 
 		// only rename if different
 		if newKeyID != keyID {
-			keyMigLog.Debugf("renaming key %s to %s", keyID, newKeyID)
+			keyMigLog.Debugf("renaming key '%s' to canonical format '%s'", keyID, newKeyID)
 			err = engine.Service.RenameKey(keyID, newKeyID)
 			if err != nil {
 				return fmt.Errorf("could not rename key %s: %w", keyID, err)
@@ -200,7 +200,7 @@ func migrateKeysToV3Format(logger *log.Entry, caCertsRepo storage.CACertificates
 
 	keyMigLog := logger.WithField("engine", engineID)
 	softCrypto := software.NewSoftwareCryptoEngine(keyMigLog)
-	keyMigLog.Infof("checking engine keys format")
+	keyMigLog.Debugf("checking key ID format for engine '%s'", engineID)
 
 	for _, keyID := range keyIDs {
 		key, err := engine.Service.GetPrivateKeyByID(keyID)
@@ -232,7 +232,7 @@ func migrateKeysToV3Format(logger *log.Entry, caCertsRepo storage.CACertificates
 			certSkiInHex := hex.EncodeToString(x509.SubjectKeyId)
 
 			if oldKeyID, ok := mapKeyIDToSha256Hex[certPubKeySha256Hex]; ok && certSkiInHex != oldKeyID {
-				keyMigLog.Infof("migrating cert %s from keyID %s to %s", certSN, oldKeyID, certSkiInHex)
+				keyMigLog.Infof("migrating CA cert '%s' key ID from '%s' to SKID '%s'", certSN, oldKeyID, certSkiInHex)
 				err = engine.Service.RenameKey(oldKeyID, certSkiInHex)
 				if err != nil {
 					keyMigLog.Errorf("could not rename key %s to %s: %s", oldKeyID, certSkiInHex, err)

--- a/backend/pkg/assemblers/va.go
+++ b/backend/pkg/assemblers/va.go
@@ -119,7 +119,7 @@ func AssembleVAService(conf config.VAconfig, caService services.CAService, kmsSe
 func createPublisherEventBus(conf config.VAconfig, crl services.CRLService) (services.CRLService, error) {
 
 	lMessaging := helpers.SetupLogger(conf.PublisherEventBus.LogLevel, "VA", "Event Bus")
-	lMessaging.Infof("Publisher Event Bus is enabled")
+	lMessaging.Infof("event bus publishing enabled for VA service")
 	pub, err := eventbus.NewEventBusPublisher(conf.PublisherEventBus, serviceID, lMessaging)
 	if err != nil {
 		return nil, fmt.Errorf("could not create Event Bus publisher: %s", err)
@@ -142,7 +142,7 @@ func createSubscriberEventBus(conf config.VAconfig, crlSvc *beService.CRLService
 	}
 
 	if conf.SubscriberEventBus.Enabled && conf.SubscriberDLQEventBus.Enabled {
-		lMessaging.Infof("Subscriber Event Bus is enabled")
+		lMessaging.Infof("event bus subscription enabled for VA service")
 
 		dlqPublisher, err := eventbus.NewEventBusPublisher(conf.SubscriberDLQEventBus, serviceID, lMessaging)
 		if err != nil {
@@ -173,7 +173,7 @@ func createSubscriberEventBus(conf config.VAconfig, crlSvc *beService.CRLService
 
 func createCRLMonitoringJob(conf config.VAconfig, crl services.CRLService) error {
 
-	log.Infof("VA CRL Monitoring is enabled")
+	log.Infof("CRL monitoring enabled, scheduling job with frequency '%s'", conf.CRLMonitoringJob.Frequency)
 	lJob := helpers.SetupLogger(conf.Logs.Level, "VA", "Service")
 
 	frequency := conf.CRLMonitoringJob.Frequency

--- a/backend/pkg/controllers/va.go
+++ b/backend/pkg/controllers/va.go
@@ -88,7 +88,7 @@ func (r *vaHttpRoutes) Verify(ctx *gin.Context) {
 
 	response, err := r.ocsp.Verify(ctx.Request.Context(), ocsp)
 	if err != nil {
-		r.logger.Errorf("something went wrong while verifying ocsp request: %s", err)
+		r.logger.Errorf("failed to verify OCSP request: %s", err)
 		ctx.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}
@@ -112,7 +112,7 @@ func (r *vaHttpRoutes) CRL(ctx *gin.Context) {
 		CASubjectKeyID: params.CASubjectKeyID,
 	})
 	if err != nil {
-		r.logger.Errorf("something went wrong while getting crl list: %s", err)
+		r.logger.Errorf("failed to get CRL for CA '%s': %s", params.CASubjectKeyID, err)
 		r.handleError(ctx, err)
 		return
 	}
@@ -135,7 +135,7 @@ func (r *vaHttpRoutes) GetRoleByID(ctx *gin.Context) {
 		CASubjectKeyID: params.CASubjectKeyID,
 	})
 	if err != nil {
-		r.logger.Errorf("something went wrong while getting va role: %s", err)
+		r.logger.Errorf("failed to get VA role for CA '%s': %s", params.CASubjectKeyID, err)
 		r.handleError(ctx, err)
 		return
 	}
@@ -165,7 +165,7 @@ func (r *vaHttpRoutes) UpdateRole(ctx *gin.Context) {
 		CRLRole:        requestBody.VACRLRole,
 	})
 	if err != nil {
-		r.logger.Errorf("something went wrong while updating va role: %s", err)
+		r.logger.Errorf("failed to update VA role for CA '%s': %s", params.CASubjectKeyID, err)
 		r.handleError(ctx, err)
 		return
 	}

--- a/backend/pkg/cryptoengines/builder/registrar_aws.go
+++ b/backend/pkg/cryptoengines/builder/registrar_aws.go
@@ -9,7 +9,7 @@ import (
 )
 
 func init() {
-	log.Info("Registering AWS crypto engines")
+	log.Debug("registering AWS crypto engine provider")
 	aws.RegisterAWSKMS()
 	aws.RegisterAWSSecrets()
 	aws_subsystem.Register()

--- a/backend/pkg/cryptoengines/builder/registrar_pkcs11.go
+++ b/backend/pkg/cryptoengines/builder/registrar_pkcs11.go
@@ -9,7 +9,7 @@ import (
 )
 
 func init() {
-	log.Info("Registering PKCS11 crypto engine")
+	log.Debug("registering PKCS11 crypto engine provider")
 	pkcs11.Register()
 	pkcs11_subsystem.Register()
 }

--- a/backend/pkg/cryptoengines/builder/registrar_vault.go
+++ b/backend/pkg/cryptoengines/builder/registrar_vault.go
@@ -9,7 +9,7 @@ import (
 )
 
 func init() {
-	log.Info("Registering VaultKV crypto engine")
+	log.Debug("registering Vault KV crypto engine provider")
 	vaultkv2.Register()
 	vault_subsystem.Register()
 }

--- a/backend/pkg/jobs/ca-crypto-monitor-job.go
+++ b/backend/pkg/jobs/ca-crypto-monitor-job.go
@@ -31,13 +31,13 @@ func (svc *CryptoMonitor) Run() {
 	lFunc := helpers.ConfigureLogger(ctx, svc.logger)
 
 	now := time.Now()
-	lFunc.Info("starting periodic CAs and Certificate check for expired certificates")
+	lFunc.Info("scanning CAs and certificates for expiry")
 
 	svc.scanCAsForUpdate(ctx, now)
 	svc.scanCertificatesForUpdate(ctx, now)
 
 	end := time.Now()
-	lFunc.Infof("ending check. Took %v", end.Sub(now))
+	lFunc.Infof("expiry scan completed in %v", end.Sub(now))
 }
 
 func (svc *CryptoMonitor) scanCertificatesForUpdate(ctx context.Context, now time.Time) {

--- a/backend/pkg/jobs/job-scheduler.go
+++ b/backend/pkg/jobs/job-scheduler.go
@@ -20,11 +20,11 @@ func NewJobScheduler(logger *logrus.Entry, frequency string, job cron.Job) *JobS
 	var err error
 	var jobId cron.EntryID
 
-	logger.Infof("enabling periodic monitoring with cron expression: '%s'", frequency)
+	logger.Infof("scheduling periodic job with frequency '%s'", frequency)
 	f, err := GetSchedulerPeriod(frequency)
 	if err != nil {
 		f = time.Duration(30 * time.Minute)
-		logger.Warnf("could not parse frequency. defaulting to %s: %v", err, f)
+		logger.Warnf("could not parse frequency '%s', defaulting to %s: %v", frequency, f, err)
 	}
 
 	if f < time.Minute {

--- a/backend/pkg/jobs/va-crl-job.go
+++ b/backend/pkg/jobs/va-crl-job.go
@@ -28,7 +28,7 @@ func NewVACrlMonitorJob(logger *logrus.Entry, service services.CRLService, blind
 func (svc *VACrlMonitor) Run() {
 	ctx := helpers.InitContext()
 	lFunc := helpers.ConfigureLogger(ctx, svc.logger)
-	lFunc.Info("starting periodic VA CRL check")
+	lFunc.Info("checking VA CRL validity")
 	svc.processVARoles(ctx, lFunc)
 }
 
@@ -38,23 +38,23 @@ func (svc *VACrlMonitor) processVARoles(ctx context.Context, lFunc *logrus.Entry
 		QueryParameters: &resources.QueryParameters{},
 		ExhaustiveRun:   true,
 		ApplyFunc: func(v models.VARole) {
-			lFunc.Infof("checking VA Role %s", v.CASubjectKeyID)
+			lFunc.Debugf("checking CRL validity for CA '%s'", v.CASubjectKeyID)
 			// Check if CRL is still valid
 			crlRemainDuration := v.LatestCRL.ValidUntil.Sub(now)
 
 			if crlRemainDuration < svc.blindPeriod {
 				// CRL is not valid anymore or will expire during the validityWindow, calculate new CRL
-				lFunc.Infof("CRL for CA %s expired at %s (%s)", v.CASubjectKeyID, v.LatestCRL.ValidUntil, v.LatestCRL.ValidUntil.Sub(now))
+				lFunc.Infof("CRL for CA '%s' expiring at %s (in %s), regenerating", v.CASubjectKeyID, v.LatestCRL.ValidUntil, v.LatestCRL.ValidUntil.Sub(now))
 				input := services.CalculateCRLInput{
 					CASubjectKeyID: v.CASubjectKeyID,
 				}
 
 				_, err := svc.service.CalculateCRL(context.Background(), input)
 				if err != nil {
-					lFunc.Warnf("something went wrong while calculating CRL for CA %s: %s", v.CASubjectKeyID, err)
+					lFunc.Warnf("failed to regenerate CRL for CA '%s': %s", v.CASubjectKeyID, err)
 				}
 			} else {
-				lFunc.Infof("CRL for CA %s is valid until %s (%s)", v.CASubjectKeyID, v.LatestCRL.ValidUntil, v.LatestCRL.ValidUntil.Sub(now))
+				lFunc.Debugf("CRL for CA '%s' is valid until %s (%s remaining)", v.CASubjectKeyID, v.LatestCRL.ValidUntil, v.LatestCRL.ValidUntil.Sub(now))
 			}
 		},
 	})

--- a/backend/pkg/routes/middlewares/identity-extractors/client-certificate.go
+++ b/backend/pkg/routes/middlewares/identity-extractors/client-certificate.go
@@ -23,7 +23,7 @@ func (extractor ClientCertificateExtractor) ExtractAuthentication(ctx *gin.Conte
 
 	crt, err = extractor.getCertificateFromHeader(req.Header)
 	if err != nil {
-		extractor.logger.Tracef("something went wrong while processing headers: %s", err)
+		extractor.logger.Tracef("failed to extract client certificate from headers: %s", err)
 	} else if crt != nil {
 		ctx.Set(string(IdentityExtractorClientCertificate), crt)
 		return

--- a/backend/pkg/services/ca.go
+++ b/backend/pkg/services/ca.go
@@ -311,10 +311,10 @@ func (svc *CAServiceBackend) ImportCA(ctx context.Context, input services.Import
 			Identifier: skid,
 		})
 		if err != nil {
-			lFunc.Infof("could not find key with SKID %s for CA %s: %s. Assuming key does not exist", skid, caCertSN, err)
+			lFunc.Infof("key with SKID '%s' not found for CA %s, treating as external import without key: %s", skid, caCertSN, err)
 			importType = models.CertificateTypeImportedWithoutKey
 		} else {
-			lFunc.Infof("found key with SKID %s for CA %s in KMS", skid, caCertSN)
+			lFunc.Infof("found matching key with SKID '%s' for CA %s in KMS", skid, caCertSN)
 			importType = models.CertificateTypeManaged
 		}
 	}
@@ -475,7 +475,7 @@ func (svc *CAServiceBackend) ImportCA(ctx context.Context, input services.Import
 		},
 	}
 
-	lFunc.Debugf("insert CA %s in storage engine", caID)
+	lFunc.Debugf("inserting CA '%s' into storage", caID)
 	cert, err := svc.caStorage.Insert(ctx, ca)
 
 	// Flag to check if it's the first iteration
@@ -799,7 +799,7 @@ func (svc *CAServiceBackend) CreateCA(ctx context.Context, input services.Create
 		},
 	}
 
-	lFunc.Debugf("insert CA %s in storage engine", caID)
+	lFunc.Debugf("inserting CA '%s' into storage", caID)
 	return svc.caStorage.Insert(ctx, &caCert)
 }
 
@@ -811,12 +811,12 @@ func (svc *CAServiceBackend) getCACertificateIfExists(ctx context.Context, caID 
 	lFunc.Debugf("checking if CA '%s' exists", caID)
 	exists, ca, err := svc.caStorage.SelectExistsByID(ctx, caID)
 	if err != nil {
-		lFunc.Errorf("something went wrong while checking if CA '%s' exists in storage engine: %s", caID, err)
+		lFunc.Errorf("failed to look up CA '%s' in storage: %s", caID, err)
 		return nil, err
 	}
 
 	if !exists {
-		lFunc.Errorf("CA %s can not be found in storage engine", caID)
+		lFunc.Errorf("CA '%s' not found", caID)
 		return nil, errs.ErrCANotFound
 	}
 
@@ -855,7 +855,7 @@ func (svc *CAServiceBackend) GetCAs(ctx context.Context, input services.GetCAsIn
 		ExtraOpts:     nil,
 	})
 	if err != nil {
-		lFunc.Errorf("something went wrong while reading all CAs from storage engine: %s", err)
+		lFunc.Errorf("failed to list CAs from storage: %s", err)
 		return "", err
 	}
 
@@ -874,12 +874,12 @@ func (svc *CAServiceBackend) GetCABySerialNumber(ctx context.Context, input serv
 	lFunc.Debugf("checking if CA '%s' exists", input.SerialNumber)
 	exists, ca, err := svc.caStorage.SelectExistsBySerialNumber(ctx, input.SerialNumber)
 	if err != nil {
-		lFunc.Errorf("something went wrong while checking if CA '%s' exists in storage engine: %s", input.SerialNumber, err)
+		lFunc.Errorf("failed to look up CA '%s' in storage: %s", input.SerialNumber, err)
 		return nil, err
 	}
 
 	if !exists {
-		lFunc.Errorf("CA %s can not be found in storage engine", input.SerialNumber)
+		lFunc.Errorf("CA with serial number '%s' not found", input.SerialNumber)
 		return nil, errs.ErrCANotFound
 	}
 
@@ -897,7 +897,7 @@ func (svc *CAServiceBackend) GetCAsByCommonName(ctx context.Context, input servi
 		ExtraOpts:     nil,
 	})
 	if err != nil {
-		lFunc.Errorf("something went wrong while reading all CAs by Common name %s from storage engine: %s", input.CommonName, err)
+		lFunc.Errorf("failed to list CAs by common name '%s' from storage: %s", input.CommonName, err)
 		return "", err
 	}
 
@@ -974,7 +974,7 @@ func (svc *CAServiceBackend) UpdateCAStatus(ctx context.Context, input services.
 
 		ctr := 0
 		revokeCertFunc := func(c models.Certificate) {
-			lFunc.Infof("\n\n%d - %s\n\n", ctr, c.SerialNumber)
+			lFunc.Infof("revoking certificate %s issued by CA %s", c.SerialNumber, c.IssuerCAMetadata.ID)
 			ctr++
 			_, err := svc.service.UpdateCertificateStatus(ctx, services.UpdateCertificateStatusInput{
 				SerialNumber:     c.SerialNumber,
@@ -1062,12 +1062,12 @@ func (svc *CAServiceBackend) UpdateCAMetadata(ctx context.Context, input service
 // caValidatorCADeletionEligibility checks if a CA can be deleted based on its type and status
 func (svc *CAServiceBackend) caValidatorCADeletionEligibility(ca *models.CACertificate, lFunc *logrus.Entry) error {
 	if ca.Certificate.Type == models.CertificateTypeImportedWithoutKey {
-		lFunc.Debugf("ImportedWithoutKey CA can be deleted. Proceeding")
+		lFunc.Debugf("CA '%s' is ImportedWithoutKey type, eligible for deletion", ca.ID)
 		return nil
 	}
 
 	if ca.Certificate.Status == models.StatusExpired || ca.Certificate.Status == models.StatusRevoked {
-		lFunc.Debugf("Expired or revoked CA can be deleted. Proceeding")
+		lFunc.Debugf("CA '%s' is expired or revoked, eligible for deletion", ca.ID)
 		return nil
 	}
 
@@ -1079,7 +1079,7 @@ func (svc *CAServiceBackend) caValidatorCADeletionEligibility(ca *models.CACerti
 func (svc *CAServiceBackend) deleteChildCAs(ctx context.Context, ca *models.CACertificate, lFunc *logrus.Entry) error {
 
 	deleteChildCAFunc := func(childCA models.CACertificate) {
-		lFunc.Infof("Deleting child CA %s (%s) issued by CA %s", childCA.ID, childCA.Certificate.Subject.CommonName, ca.ID)
+		lFunc.Infof("deleting child CA %s (CN=%s) issued by CA %s", childCA.ID, childCA.Certificate.Subject.CommonName, ca.ID)
 		err := svc.service.DeleteCA(ctx, services.DeleteCAInput{
 			CAID:          childCA.ID,
 			CascadeDelete: true,
@@ -1107,7 +1107,7 @@ func (svc *CAServiceBackend) deleteChildCAs(ctx context.Context, ca *models.CACe
 func (svc *CAServiceBackend) revokeChildCAs(ctx context.Context, ca *models.CACertificate, lFunc *logrus.Entry) error {
 
 	revokeChildCAFunc := func(childCA models.CACertificate) {
-		lFunc.Infof("Revoking child CA %s (%s) issued by CA %s", childCA.ID, childCA.Certificate.Subject.CommonName, ca.ID)
+		lFunc.Infof("revoking child CA %s (CN=%s) issued by CA %s", childCA.ID, childCA.Certificate.Subject.CommonName, ca.ID)
 		_, err := svc.service.UpdateCAStatus(ctx, services.UpdateCAStatusInput{
 			CAID:             childCA.ID,
 			Status:           models.StatusRevoked,
@@ -1137,7 +1137,7 @@ func (svc *CAServiceBackend) deleteCertificatesIssuedByCA(ctx context.Context, c
 
 	ctr := 0
 	deleteCertFunc := func(c models.Certificate) {
-		lFunc.Infof("Deleting certificate %d - %s", ctr, c.SerialNumber)
+		lFunc.Infof("deleting certificate %s issued by CA %s", c.SerialNumber, c.IssuerCAMetadata.ID)
 		ctr++
 		err := svc.service.DeleteCertificate(ctx, services.DeleteCertificateInput{
 			SerialNumber: c.SerialNumber,
@@ -1162,7 +1162,7 @@ func (svc *CAServiceBackend) revokeCertificatesIssuedByCA(ctx context.Context, c
 
 	ctr := 0
 	revokeCertFunc := func(c models.Certificate) {
-		lFunc.Infof("Revoking certificate %d - %s", ctr, c.SerialNumber)
+		lFunc.Infof("revoking certificate %s issued by CA %s", c.SerialNumber, c.IssuerCAMetadata.ID)
 		ctr++
 		_, err := svc.service.UpdateCertificateStatus(ctx, services.UpdateCertificateStatusInput{
 			SerialNumber:     c.SerialNumber,
@@ -1196,7 +1196,7 @@ func (svc *CAServiceBackend) handleCascadeOperations(ctx context.Context, ca *mo
 			return errs.ErrCascadeDeleteNotAllowed
 		}
 
-		lFunc.Debugf("cascade delete is enabled and allowed, proceeding with child CA and certificate deletion")
+		lFunc.Debugf("cascade delete enabled for CA '%s', deleting child CAs and certificates", ca.ID)
 
 		// Delete child CAs recursively
 		if err := svc.deleteChildCAs(ctx, ca, lFunc); err != nil {
@@ -1207,7 +1207,7 @@ func (svc *CAServiceBackend) handleCascadeOperations(ctx context.Context, ca *mo
 		return svc.deleteCertificatesIssuedByCA(ctx, ca, lFunc)
 	}
 
-	lFunc.Debugf("cascade delete is disabled, proceeding with child CA and certificate revocation")
+	lFunc.Debugf("cascade delete disabled for CA '%s', revoking child CAs and certificates", ca.ID)
 
 	// Revoke child CAs issued by the CA
 	if err := svc.revokeChildCAs(ctx, ca, lFunc); err != nil {
@@ -1238,7 +1238,7 @@ func (svc *CAServiceBackend) deleteCAPrivateKey(ctx context.Context, ca *models.
 	if err != nil {
 		lFunc.Warnf("could not delete private key for CA %s from crypto engine %s: %s", ca.ID, ca.Certificate.EngineID, err)
 	} else {
-		lFunc.Debugf("successfully deleted private key for CA %s from crypto engine %s", ca.ID, ca.Certificate.EngineID)
+		lFunc.Debugf("deleted private key for CA '%s' from crypto engine '%s'", ca.ID, ca.Certificate.EngineID)
 	}
 }
 
@@ -1303,7 +1303,7 @@ func (svc *CAServiceBackend) ReissueCA(ctx context.Context, input services.Reiss
 	// Override validity to preserve the original CA's validity duration only if not set
 	if profile.Validity.Type == "" {
 		profile.Validity = validity
-		lFunc.Debugf("Duration is not provided. Preserved current CA validity duration")
+		lFunc.Debugf("no validity duration specified, preserving current CA validity duration")
 	}
 
 	var newCert *x509.Certificate
@@ -1433,7 +1433,7 @@ func (svc *CAServiceBackend) ReissueCA(ctx context.Context, input services.Reiss
 		return nil, err
 	}
 
-	lFunc.Debugf("successfully reissued CA %s. New serial number: %s", input.CAID, newCertificateRecord.SerialNumber)
+	lFunc.Debugf("CA '%s' reissued with new serial number %s", input.CAID, newCertificateRecord.SerialNumber)
 
 	return updatedCA, nil
 }
@@ -1472,7 +1472,7 @@ func (svc *CAServiceBackend) DeleteCA(ctx context.Context, input services.Delete
 	// Delete the CA
 	err = svc.caStorage.Delete(ctx, input.CAID)
 	if err != nil {
-		lFunc.Errorf("something went wrong while deleting the CA %s %s", input.CAID, err)
+		lFunc.Errorf("failed to delete CA '%s' from storage: %s", input.CAID, err)
 		return err
 	}
 
@@ -1576,7 +1576,7 @@ func (svc *CAServiceBackend) SignCertificate(ctx context.Context, input services
 
 	// CAs get inserted into the CA storage engine by the CreateCA method. Don't insert them here.
 	if !x509Cert.IsCA {
-		lFunc.Debugf("insert Certificate %s in storage engine", cert.SerialNumber)
+		lFunc.Debugf("inserting certificate '%s' into storage", cert.SerialNumber)
 		return svc.certStorage.Insert(ctx, &cert)
 	}
 
@@ -1661,18 +1661,18 @@ func (svc *CAServiceBackend) SignatureSign(ctx context.Context, input services.S
 	lFunc.Debugf("checking if CA '%s' exists", input.CAID)
 	exists, ca, err := svc.caStorage.SelectExistsByID(ctx, input.CAID)
 	if err != nil {
-		lFunc.Errorf("something went wrong while checking if CA '%s' exists in storage engine: %s", input.CAID, err)
+		lFunc.Errorf("failed to look up CA '%s' in storage: %s", input.CAID, err)
 		return nil, err
 	}
 
 	if !exists {
-		lFunc.Errorf("CA %s can not be found in storage engine", input.CAID)
+		lFunc.Errorf("CA '%s' not found", input.CAID)
 		return nil, errs.ErrCANotFound
 	}
 
 	certSigner := NewCertificateSigner(ctx, &ca.Certificate, svc.kmsService)
 
-	lFunc.Debugf("sign signature with %s Certificate", ca.Certificate.SerialNumber)
+	lFunc.Debugf("verifying signature using CA certificate %s", ca.Certificate.SerialNumber)
 
 	var opts crypto.SignerOpts
 	hash := crypto.SHA256
@@ -1728,12 +1728,12 @@ func (svc *CAServiceBackend) SignatureVerify(ctx context.Context, input services
 	lFunc.Debugf("checking if CA '%s' exists", input.CAID)
 	exists, ca, err := svc.caStorage.SelectExistsByID(ctx, input.CAID)
 	if err != nil {
-		lFunc.Errorf("something went wrong while checking if CA '%s' exists in storage engine: %s", input.CAID, err)
+		lFunc.Errorf("failed to look up CA '%s' in storage: %s", input.CAID, err)
 		return false, err
 	}
 
 	if !exists {
-		lFunc.Errorf("CA %s can not be found in storage engine", input.CAID)
+		lFunc.Errorf("CA '%s' not found", input.CAID)
 		return false, errs.ErrCANotFound
 	}
 
@@ -1769,12 +1769,12 @@ func (svc *CAServiceBackend) GetCertificateBySerialNumber(ctx context.Context, i
 	lFunc.Debugf("checking if Certificate '%s' exists", input.SerialNumber)
 	exists, cert, err := svc.certStorage.SelectExistsBySerialNumber(ctx, input.SerialNumber)
 	if err != nil {
-		lFunc.Errorf("something went wrong while checking if Certificate '%s' exists in storage engine: %s", input.SerialNumber, err)
+		lFunc.Errorf("failed to look up certificate '%s' in storage: %s", input.SerialNumber, err)
 		return nil, err
 	}
 
 	if !exists {
-		lFunc.Errorf("certificate %s can not be found in storage engine", input.SerialNumber)
+		lFunc.Errorf("certificate '%s' not found", input.SerialNumber)
 		return nil, errs.ErrCertificateNotFound
 	}
 
@@ -1807,12 +1807,12 @@ func (svc *CAServiceBackend) GetCertificatesByCA(ctx context.Context, input serv
 	lFunc.Debugf("checking if CA '%s' exists", input.CAID)
 	exists, _, err := svc.caStorage.SelectExistsByID(ctx, input.CAID)
 	if err != nil {
-		lFunc.Errorf("something went wrong while checking if CA '%s' exists in storage engine: %s", input.CAID, err)
+		lFunc.Errorf("failed to look up CA '%s' in storage: %s", input.CAID, err)
 		return "", err
 	}
 
 	if !exists {
-		lFunc.Errorf("CA %s can not be found in storage engine", input.CAID)
+		lFunc.Errorf("CA '%s' not found", input.CAID)
 		return "", errs.ErrCANotFound
 	}
 
@@ -1876,7 +1876,7 @@ func (svc *CAServiceBackend) UpdateCertificateStatus(ctx context.Context, input 
 		SerialNumber: input.SerialNumber,
 	})
 	if err != nil {
-		lFunc.Errorf("something went wrong while checking if certificate '%s' exists in storage engine: %s", input.SerialNumber, err)
+		lFunc.Errorf("failed to look up certificate '%s' in storage: %s", input.SerialNumber, err)
 		return nil, err
 	}
 
@@ -1925,7 +1925,7 @@ func (svc *CAServiceBackend) UpdateCertificateMetadata(ctx context.Context, inpu
 		SerialNumber: input.SerialNumber,
 	})
 	if err != nil {
-		lFunc.Errorf("something went wrong while checking if certificate '%s' exists in storage engine: %s", input.SerialNumber, err)
+		lFunc.Errorf("failed to look up certificate '%s' in storage: %s", input.SerialNumber, err)
 		return nil, err
 	}
 
@@ -1962,7 +1962,7 @@ func (svc *CAServiceBackend) DeleteCertificate(ctx context.Context, input servic
 		SerialNumber: input.SerialNumber,
 	})
 	if err != nil {
-		lFunc.Errorf("something went wrong while checking if certificate '%s' exists in storage engine: %s", input.SerialNumber, err)
+		lFunc.Errorf("failed to look up certificate '%s' in storage: %s", input.SerialNumber, err)
 		return err
 	}
 
@@ -1981,10 +1981,10 @@ func (svc *CAServiceBackend) DeleteCertificate(ctx context.Context, input servic
 
 	// Issuer CA does not exist, proceed with deletion
 	lFunc.Debugf("issuer CA '%s' not found, proceeding with certificate deletion", cert.IssuerCAMetadata.ID)
-	lFunc.Debugf("deleting certificate %s from storage engine", input.SerialNumber)
+	lFunc.Debugf("deleting certificate '%s' from storage", input.SerialNumber)
 	err = svc.certStorage.Delete(ctx, input.SerialNumber)
 	if err != nil {
-		lFunc.Errorf("something went wrong while deleting certificate '%s' from storage engine: %s", input.SerialNumber, err)
+		lFunc.Errorf("failed to delete certificate '%s' from storage: %s", input.SerialNumber, err)
 		return err
 	}
 
@@ -2040,7 +2040,7 @@ func (svc *CAServiceBackend) CreateIssuanceProfile(ctx context.Context, input se
 		return nil, err
 	}
 
-	lFunc.Infof("issuance profile '%s' with ID '%s' created successfully", input.Profile.Name, id)
+	lFunc.Infof("issuance profile '%s' created with ID '%s'", input.Profile.Name, id)
 	return p, nil
 }
 

--- a/backend/pkg/services/crl.go
+++ b/backend/pkg/services/crl.go
@@ -85,7 +85,7 @@ func (svc CRLServiceBackend) GetCRL(ctx context.Context, input services.GetCRLIn
 	if input.CRLVersion.Cmp(big.NewInt(0)) == 0 {
 		exists, role, err := svc.vaRepo.Get(ctx, input.CASubjectKeyID)
 		if err != nil {
-			lFunc.Errorf("something went wrong while reading VA role: %s", err)
+			lFunc.Errorf("failed to get VA role for CA '%s': %s", input.CASubjectKeyID, err)
 			return nil, err
 		}
 
@@ -99,7 +99,7 @@ func (svc CRLServiceBackend) GetCRL(ctx context.Context, input services.GetCRLIn
 
 	crlPem, err := svc.bucket.ReadAll(ctx, fmt.Sprintf("pki/va/crl/%s/%s.crl", input.CASubjectKeyID, versionStr))
 	if err != nil {
-		lFunc.Errorf("something went wrong while reading CRL: %s", err)
+		lFunc.Errorf("failed to read CRL for CA '%s' version %s: %s", input.CASubjectKeyID, versionStr, err)
 		return nil, err
 	}
 
@@ -107,7 +107,7 @@ func (svc CRLServiceBackend) GetCRL(ctx context.Context, input services.GetCRLIn
 
 	crl, err := x509.ParseRevocationList(crlDer.Bytes)
 	if err != nil {
-		lFunc.Errorf("something went wrong while parsing CRL: %s", err)
+		lFunc.Errorf("failed to parse CRL for CA '%s': %s", input.CASubjectKeyID, err)
 		return nil, err
 	}
 
@@ -162,7 +162,7 @@ func (svc CRLServiceBackend) InitCRLRole(ctx context.Context, caSki string) (*mo
 		CASubjectKeyID: caSki,
 	})
 	if err != nil {
-		lFunc.Errorf("something went wrong while calculating first CRL: %s", err)
+		lFunc.Errorf("failed to calculate initial CRL for CA '%s': %s", caSki, err)
 		return nil, err
 	}
 
@@ -183,7 +183,7 @@ func (svc CRLServiceBackend) CalculateCRL(ctx context.Context, input services.Ca
 
 	exists, vaRole, err := svc.vaRepo.Get(ctx, input.CASubjectKeyID)
 	if err != nil {
-		lFunc.Errorf("something went wrong while reading VA role: %s", err)
+		lFunc.Errorf("failed to get VA role for CA '%s': %s", input.CASubjectKeyID, err)
 		return nil, err
 	}
 
@@ -209,7 +209,7 @@ func (svc CRLServiceBackend) CalculateCRL(ctx context.Context, input services.Ca
 		},
 	})
 	if err != nil {
-		lFunc.Errorf("something went wrong while reading CA %s: %s", input.CASubjectKeyID, err)
+		lFunc.Errorf("failed to look up CA with SKID '%s': %s", input.CASubjectKeyID, err)
 		return nil, err
 	}
 
@@ -219,7 +219,7 @@ func (svc CRLServiceBackend) CalculateCRL(ctx context.Context, input services.Ca
 	}
 
 	certList := []x509.RevocationListEntry{}
-	lFunc.Debugf("reading CA %s certificates", crlCA.ID)
+	lFunc.Debugf("fetching revoked certificates for CA '%s'", crlCA.ID)
 	_, err = svc.caSDK.GetCertificatesByCaAndStatus(ctx, services.GetCertificatesByCaAndStatusInput{
 		CAID:   crlCA.ID,
 		Status: models.StatusRevoked,
@@ -239,7 +239,7 @@ func (svc CRLServiceBackend) CalculateCRL(ctx context.Context, input services.Ca
 		},
 	})
 	if err != nil {
-		lFunc.Errorf("something went wrong while reading CA %s certificates: %s", crlCA.ID, err)
+		lFunc.Errorf("failed to list revoked certificates for CA '%s': %s", crlCA.ID, err)
 		return nil, err
 	}
 
@@ -250,17 +250,18 @@ func (svc CRLServiceBackend) CalculateCRL(ctx context.Context, input services.Ca
 
 	idp, err := svc.getDistributionPointExtension(string(crlCA.Certificate.SubjectKeyID))
 	if err != nil {
-		lFunc.Errorf("something went wrong while creating Issuing Distribution Point extension: %s", err)
+		lFunc.Errorf("failed to create Issuing Distribution Point extension for CA '%s': %s", crlCA.ID, err)
 		return nil, err
 	}
 
 	extensions = append(extensions, *idp)
 
-	lFunc.Debugf("creating revocation list. CA %s", crlCA.ID)
 	now := time.Now()
 
 	crlVersion := big.NewInt(0)
 	crlVersion.Add(vaRole.LatestCRL.Version.Int, big.NewInt(1))
+
+	lFunc.Debugf("creating CRL v%s for CA '%s' with %d revoked certificates", crlVersion, crlCA.ID, len(certList))
 
 	entropy := software.NewLamassuEntropy(ctx)
 
@@ -272,20 +273,20 @@ func (svc CRLServiceBackend) CalculateCRL(ctx context.Context, input services.Ca
 		ExtraExtensions:           extensions,
 	}, caCert, crlSigner)
 	if err != nil {
-		lFunc.Errorf("something went wrong while creating revocation list: %s", err)
+		lFunc.Errorf("failed to create revocation list for CA '%s': %s", crlCA.ID, err)
 		return nil, err
 	}
 
 	crl, err := x509.ParseRevocationList(crlDer)
 	if err != nil {
-		lFunc.Errorf("something went wrong while parsing revocation list: %s", err)
+		lFunc.Errorf("failed to parse created revocation list for CA '%s': %s", crlCA.ID, err)
 		return nil, err
 	}
 
 	crlPem := pem.EncodeToMemory(&pem.Block{Type: "X509 CRL", Bytes: crlDer})
 	err = svc.bucket.WriteAll(ctx, fmt.Sprintf("pki/va/crl/%s/%s.crl", input.CASubjectKeyID, crl.Number), crlPem, nil)
 	if err != nil {
-		lFunc.Errorf("something went wrong while saving CRL: %s", err)
+		lFunc.Errorf("failed to save CRL for CA '%s': %s", crlCA.ID, err)
 		return nil, err
 	}
 
@@ -297,7 +298,7 @@ func (svc CRLServiceBackend) CalculateCRL(ctx context.Context, input services.Ca
 
 	_, err = svc.vaRepo.Update(ctx, vaRole)
 	if err != nil {
-		lFunc.Errorf("something went wrong while updating VA role: %s", err)
+		lFunc.Errorf("failed to update VA role for CA '%s': %s", input.CASubjectKeyID, err)
 		return nil, err
 	}
 

--- a/backend/pkg/services/devicemanager.go
+++ b/backend/pkg/services/devicemanager.go
@@ -182,7 +182,7 @@ func (svc DeviceManagerServiceBackend) CreateDevice(ctx context.Context, input s
 
 	dev, err := svc.devicesStorage.Insert(ctx, device)
 	if err != nil {
-		lFunc.Errorf("could not insert device %s in storage engine: %s", input.ID, err)
+		lFunc.Errorf("failed to insert device '%s' into storage: %s", input.ID, err)
 		return nil, err
 	}
 	return dev, nil
@@ -191,14 +191,14 @@ func (svc DeviceManagerServiceBackend) CreateDevice(ctx context.Context, input s
 func (svc DeviceManagerServiceBackend) GetDevices(ctx context.Context, input services.GetDevicesInput) (string, error) {
 	lFunc := chelpers.ConfigureLogger(ctx, svc.logger)
 
-	lFunc.Debugf("getting all devices")
+	lFunc.Debugf("listing all devices")
 	return svc.devicesStorage.SelectAll(ctx, input.ExhaustiveRun, input.ApplyFunc, input.QueryParameters, nil)
 }
 
 func (svc DeviceManagerServiceBackend) GetDeviceByDMS(ctx context.Context, input services.GetDevicesByDMSInput) (string, error) {
 	lFunc := chelpers.ConfigureLogger(ctx, svc.logger)
 
-	lFunc.Debugf("getting all devices owned by DMS with ID=%s", input.DMSID)
+	lFunc.Debugf("listing devices owned by DMS '%s'", input.DMSID)
 	return svc.devicesStorage.SelectByDMS(ctx, input.DMSID, input.ExhaustiveRun, input.ApplyFunc, input.QueryParameters, nil)
 }
 
@@ -213,10 +213,10 @@ func (svc DeviceManagerServiceBackend) GetDeviceByID(ctx context.Context, input 
 	lFunc.Debugf("checking if device '%s' exists", input.ID)
 	exists, device, err := svc.devicesStorage.SelectExists(ctx, input.ID)
 	if err != nil {
-		lFunc.Errorf("something went wrong while checking if device '%s' exists in storage engine: %s", input.ID, err)
+		lFunc.Errorf("failed to look up device '%s' in storage: %s", input.ID, err)
 		return nil, err
 	} else if !exists {
-		lFunc.Errorf("device %s can not be found in storage engine", input.ID)
+		lFunc.Errorf("device '%s' not found", input.ID)
 		return nil, errs.ErrDeviceNotFound
 	}
 
@@ -234,18 +234,18 @@ func (svc DeviceManagerServiceBackend) UpdateDeviceStatus(ctx context.Context, i
 	lFunc.Debugf("checking if device '%s' exists", input.ID)
 	exists, device, err := svc.devicesStorage.SelectExists(ctx, input.ID)
 	if err != nil {
-		lFunc.Errorf("something went wrong while checking if device '%s' exists in storage engine: %s", input.ID, err)
+		lFunc.Errorf("failed to look up device '%s' in storage: %s", input.ID, err)
 		return nil, err
 	} else if !exists {
-		lFunc.Errorf("device %s can not be found in storage engine", input.ID)
+		lFunc.Errorf("device '%s' not found", input.ID)
 		return nil, errs.ErrDeviceNotFound
 	}
 
 	if device.Status == input.NewStatus {
-		lFunc.Warnf("skipping update. Device already in %s status", input.NewStatus)
+		lFunc.Warnf("device '%s' already in '%s' status, skipping update", input.ID, input.NewStatus)
 		return device, nil
 	} else if device.Status == models.DeviceDecommissioned {
-		lFunc.Warnf("skipping update. Device decommissioned")
+		lFunc.Warnf("device '%s' is decommissioned, skipping status update", input.ID)
 		return device, nil
 	}
 
@@ -258,9 +258,9 @@ func (svc DeviceManagerServiceBackend) UpdateDeviceStatus(ctx context.Context, i
 		idSlot := device.IdentitySlot
 		if idSlot != nil {
 			if idSlot.Status == models.SlotExpired {
-				lFunc.Debugf("skipping slot update. Identity slot already expired")
+				lFunc.Debugf("device '%s' identity slot already expired, skipping slot update", input.ID)
 			} else if idSlot.Status == models.SlotRevoke {
-				lFunc.Debugf("skipping slot update. Identity slot already revoked")
+				lFunc.Debugf("device '%s' identity slot already revoked, skipping slot update", input.ID)
 			} else {
 
 				idSlot.Status = models.SlotRevoke
@@ -295,7 +295,7 @@ func (svc DeviceManagerServiceBackend) UpdateDeviceStatus(ctx context.Context, i
 		return nil, err
 	}
 
-	lFunc.Debugf("device %s status updated. new status: %s", input.ID, input.NewStatus)
+	lFunc.Debugf("device '%s' status updated to '%s'", input.ID, input.NewStatus)
 	return device, nil
 }
 
@@ -311,12 +311,12 @@ func (svc DeviceManagerServiceBackend) UpdateDeviceMetadata(ctx context.Context,
 	lFunc.Debugf("checking if device '%s' exists", input.ID)
 	exists, device, err := svc.devicesStorage.SelectExists(ctx, input.ID)
 	if err != nil {
-		lFunc.Errorf("something went wrong while checking if device '%s' exists in storage engine: %s", input.ID, err)
+		lFunc.Errorf("failed to look up device '%s' in storage: %s", input.ID, err)
 		return nil, err
 	}
 
 	if !exists {
-		lFunc.Errorf("device %s can not be found in storage engine", input.ID)
+		lFunc.Errorf("device '%s' not found", input.ID)
 		return nil, errs.ErrDeviceNotFound
 	}
 
@@ -344,10 +344,10 @@ func (svc DeviceManagerServiceBackend) UpdateDeviceIdentitySlot(ctx context.Cont
 	lFunc.Debugf("checking if device '%s' exists", input.ID)
 	exists, device, err := svc.devicesStorage.SelectExists(ctx, input.ID)
 	if err != nil {
-		lFunc.Errorf("something went wrong while checking if device '%s' exists in storage engine: %s", input.ID, err)
+		lFunc.Errorf("failed to look up device '%s' in storage: %s", input.ID, err)
 		return nil, err
 	} else if !exists {
-		lFunc.Errorf("device %s can not be found in storage engine", input.ID)
+		lFunc.Errorf("device '%s' not found", input.ID)
 		return nil, errs.ErrDeviceNotFound
 	}
 
@@ -433,10 +433,10 @@ func (svc DeviceManagerServiceBackend) DeleteDevice(ctx context.Context, input s
 	lFunc.Debugf("checking if device '%s' exists", id)
 	exists, device, err := svc.devicesStorage.SelectExists(ctx, id)
 	if err != nil {
-		lFunc.Errorf("something went wrong while checking if device '%s' exists in storage engine: %s", id, err)
+		lFunc.Errorf("failed to look up device '%s' in storage: %s", id, err)
 		return err
 	} else if !exists {
-		lFunc.Errorf("device '%s' does not exist in storage engine", id)
+		lFunc.Errorf("device '%s' not found", id)
 		return errs.ErrDeviceNotFound
 	}
 
@@ -449,11 +449,11 @@ func (svc DeviceManagerServiceBackend) DeleteDevice(ctx context.Context, input s
 	lFunc.Debugf("deleting device '%s'", id)
 	err = svc.devicesStorage.Delete(ctx, id)
 	if err != nil {
-		lFunc.Errorf("something went wrong while deleting device '%s' from storage engine: %s", id, err)
+		lFunc.Errorf("failed to delete device '%s' from storage: %s", id, err)
 		return err
 	}
 
-	lFunc.Infof("device '%s' deleted successfully", id)
+	lFunc.Infof("device '%s' deleted", id)
 	return nil
 }
 
@@ -497,11 +497,11 @@ func (svc DeviceManagerServiceBackend) CreateDeviceGroup(ctx context.Context, in
 	lFunc.Debugf("creating device group '%s'", input.ID)
 	group, err = svc.devicesStorage.DeviceGroups().Insert(ctx, group)
 	if err != nil {
-		lFunc.Errorf("could not insert device group '%s' in storage engine: %s", input.ID, err)
+		lFunc.Errorf("failed to insert device group '%s' into storage: %s", input.ID, err)
 		return nil, err
 	}
 
-	lFunc.Infof("device group '%s' created successfully", input.ID)
+	lFunc.Infof("device group '%s' created", input.ID)
 
 	// Enrich with ancestor criteria
 	if err := svc.enrichGroupWithAncestorCriteria(ctx, lFunc, group); err != nil {
@@ -555,11 +555,11 @@ func (svc DeviceManagerServiceBackend) UpdateDeviceGroup(ctx context.Context, in
 	lFunc.Debugf("updating device group '%s'", input.ID)
 	group, err = svc.devicesStorage.DeviceGroups().Update(ctx, group)
 	if err != nil {
-		lFunc.Errorf("could not update device group '%s' in storage engine: %s", input.ID, err)
+		lFunc.Errorf("failed to update device group '%s' in storage: %s", input.ID, err)
 		return nil, err
 	}
 
-	lFunc.Infof("device group '%s' updated successfully", input.ID)
+	lFunc.Infof("device group '%s' updated", input.ID)
 
 	// Enrich with ancestor criteria
 	if err := svc.enrichGroupWithAncestorCriteria(ctx, lFunc, group); err != nil {
@@ -586,11 +586,11 @@ func (svc DeviceManagerServiceBackend) DeleteDeviceGroup(ctx context.Context, in
 	lFunc.Debugf("deleting device group '%s'", input.ID)
 	err = svc.devicesStorage.DeviceGroups().Delete(ctx, input.ID)
 	if err != nil {
-		lFunc.Errorf("could not delete device group '%s' from storage engine: %s", input.ID, err)
+		lFunc.Errorf("failed to delete device group '%s' from storage: %s", input.ID, err)
 		return err
 	}
 
-	lFunc.Infof("device group '%s' deleted successfully", input.ID)
+	lFunc.Infof("device group '%s' deleted", input.ID)
 	return nil
 }
 
@@ -604,7 +604,7 @@ func (svc DeviceManagerServiceBackend) GetDeviceGroupByID(ctx context.Context, i
 	}
 
 	// Get device group
-	lFunc.Debugf("getting device group '%s'", input.ID)
+	lFunc.Debugf("fetching device group '%s'", input.ID)
 	group, err := svc.verifyGroupExists(ctx, lFunc, input.ID)
 	if err != nil {
 		return nil, err
@@ -621,7 +621,7 @@ func (svc DeviceManagerServiceBackend) GetDeviceGroupByID(ctx context.Context, i
 func (svc DeviceManagerServiceBackend) GetDeviceGroups(ctx context.Context, input services.GetDeviceGroupsInput) (string, error) {
 	lFunc := chelpers.ConfigureLogger(ctx, svc.logger)
 
-	lFunc.Debugf("getting all device groups")
+	lFunc.Debugf("listing all device groups")
 	return svc.devicesStorage.DeviceGroups().SelectAll(ctx, storage.StorageListRequest[models.DeviceGroup]{
 		ExhaustiveRun: input.ExhaustiveRun,
 		ApplyFunc:     input.ApplyFunc,

--- a/backend/pkg/services/dmsmanager.go
+++ b/backend/pkg/services/dmsmanager.go
@@ -95,10 +95,10 @@ func (svc DMSManagerServiceBackend) CreateDMS(ctx context.Context, input service
 	}
 	lFunc.Debugf("checking if DMS '%s' exists", input.ID)
 	if exists, _, err := svc.dmsStorage.SelectExists(ctx, input.ID); err != nil {
-		lFunc.Errorf("something went wrong while checking if DMS '%s' exists in storage engine: %s", input.ID, err)
+		lFunc.Errorf("failed to look up DMS '%s' in storage: %s", input.ID, err)
 		return nil, err
 	} else if exists {
-		lFunc.Errorf("DMS '%s' already exist in storage engine", input.ID)
+		lFunc.Errorf("DMS '%s' already exists", input.ID)
 		return nil, errs.ErrDMSAlreadyExists
 	}
 
@@ -115,7 +115,7 @@ func (svc DMSManagerServiceBackend) CreateDMS(ctx context.Context, input service
 		lFunc.Errorf("could not insert DMS '%s': %s", dms.ID, err)
 		return nil, err
 	}
-	lFunc.Debugf("DMS '%s' persisted into storage engine", dms.ID)
+	lFunc.Debugf("DMS '%s' persisted to storage", dms.ID)
 
 	return dms, nil
 }
@@ -131,10 +131,10 @@ func (svc DMSManagerServiceBackend) UpdateDMS(ctx context.Context, input service
 	lFunc.Debugf("checking if DMS '%s' exists", input.DMS.ID)
 	exists, dms, err := svc.dmsStorage.SelectExists(ctx, input.DMS.ID)
 	if err != nil {
-		lFunc.Errorf("something went wrong while checking if DMS '%s' exists in storage engine: %s", input.DMS.ID, err)
+		lFunc.Errorf("failed to look up DMS '%s' in storage: %s", input.DMS.ID, err)
 		return nil, err
 	} else if !exists {
-		lFunc.Errorf("DMS '%s' does not exist in storage engine", input.DMS.ID)
+		lFunc.Errorf("DMS '%s' not found", input.DMS.ID)
 		return nil, errs.ErrDMSNotFound
 	}
 
@@ -142,7 +142,7 @@ func (svc DMSManagerServiceBackend) UpdateDMS(ctx context.Context, input service
 	dms.Name = input.DMS.Name
 	dms.Settings = input.DMS.Settings
 
-	lFunc.Debugf("updating DMS %s", input.DMS.ID)
+	lFunc.Debugf("updating DMS '%s'", input.DMS.ID)
 	return svc.dmsStorage.Update(ctx, dms)
 }
 
@@ -151,19 +151,19 @@ func (svc DMSManagerServiceBackend) UpdateDMSMetadata(ctx context.Context, input
 
 	err := deviceValidate.Struct(input)
 	if err != nil {
-		lFunc.Errorf("UpdateDMSMetadata struct validation error: %s", err)
+		lFunc.Errorf("struct validation error: %s", err)
 		return nil, errs.ErrValidateBadRequest
 	}
 
 	lFunc.Debugf("checking if DMS '%s' exists", input.ID)
 	exists, dms, err := svc.dmsStorage.SelectExists(ctx, input.ID)
 	if err != nil {
-		lFunc.Errorf("something went wrong while checking if DMS '%s' exists in storage engine: %s", input.ID, err)
+		lFunc.Errorf("failed to look up DMS '%s' in storage: %s", input.ID, err)
 		return nil, err
 	}
 
 	if !exists {
-		lFunc.Errorf("DMS %s can not be found in storage engine", input.ID)
+		lFunc.Errorf("DMS '%s' not found", input.ID)
 		return nil, errs.ErrDMSNotFound
 	}
 
@@ -175,7 +175,7 @@ func (svc DMSManagerServiceBackend) UpdateDMSMetadata(ctx context.Context, input
 
 	dms.Metadata = *updatedMetadata
 
-	lFunc.Debugf("updating %s DMS metadata", input.ID)
+	lFunc.Debugf("updating DMS '%s' metadata", input.ID)
 	return svc.dmsStorage.Update(ctx, dms)
 }
 
@@ -192,16 +192,16 @@ func (svc DMSManagerServiceBackend) DeleteDMS(ctx context.Context, input service
 	lFunc.Debugf("checking if DMS '%s' exists", id)
 	exists, _, err := svc.dmsStorage.SelectExists(ctx, id)
 	if err != nil {
-		lFunc.Errorf("something went wrong while checking if DMS '%s' exists in storage engine: %s", id, err)
+		lFunc.Errorf("failed to look up DMS '%s' in storage: %s", id, err)
 		return err
 	} else if !exists {
-		lFunc.Errorf("DMS '%s' does not exist in storage engine", id)
+		lFunc.Errorf("DMS '%s' not found", id)
 		return errs.ErrDMSNotFound
 	}
 
 	err = svc.dmsStorage.Delete(ctx, id)
 	if err != nil {
-		lFunc.Errorf("something went wrong while deleting the DMS %s %s", id, err)
+		lFunc.Errorf("failed to delete DMS '%s' from storage: %s", id, err)
 		return err
 	}
 
@@ -219,14 +219,14 @@ func (svc DMSManagerServiceBackend) GetDMSByID(ctx context.Context, input servic
 	lFunc.Debugf("checking if DMS '%s' exists", input.ID)
 	exists, dms, err := svc.dmsStorage.SelectExists(ctx, input.ID)
 	if err != nil {
-		lFunc.Errorf("something went wrong while checking if DMS '%s' exists in storage engine: %s", input.ID, err)
+		lFunc.Errorf("failed to look up DMS '%s' in storage: %s", input.ID, err)
 		return nil, err
 	} else if !exists {
-		lFunc.Errorf("DMS '%s' does not exist in storage engine", input.ID)
+		lFunc.Errorf("DMS '%s' not found", input.ID)
 		return nil, errs.ErrDMSNotFound
 	}
 
-	lFunc.Debugf("read DMS %s", dms.ID)
+	lFunc.Debugf("fetched DMS '%s'", dms.ID)
 
 	return dms, nil
 }
@@ -236,7 +236,7 @@ func (svc DMSManagerServiceBackend) GetAll(ctx context.Context, input services.G
 
 	bookmark, err := svc.dmsStorage.SelectAll(ctx, input.ExhaustiveRun, input.ApplyFunc, input.QueryParameters, nil)
 	if err != nil {
-		lFunc.Errorf("something went wrong while reading all DMSs from storage engine: %s", err)
+		lFunc.Errorf("failed to list DMSs from storage: %s", err)
 		return "", err
 	}
 
@@ -250,10 +250,10 @@ func (svc DMSManagerServiceBackend) CACerts(ctx context.Context, aps string) ([]
 	lFunc.Debugf("checking if DMS '%s' exists", aps)
 	exists, dms, err := svc.dmsStorage.SelectExists(ctx, aps)
 	if err != nil {
-		lFunc.Errorf("something went wrong while checking if DMS '%s' exists in storage engine: %s", aps, err)
+		lFunc.Errorf("failed to look up DMS '%s' in storage: %s", aps, err)
 		return nil, err
 	} else if !exists {
-		lFunc.Errorf("DMS '%s' does not exist in storage engine", aps)
+		lFunc.Errorf("DMS '%s' not found", aps)
 		return nil, errs.ErrDMSNotFound
 	}
 
@@ -280,7 +280,7 @@ func (svc DMSManagerServiceBackend) CACerts(ctx context.Context, aps string) ([]
 			CAID: ca,
 		})
 		if err != nil {
-			lFunc.Errorf("something went wrong while reading CA '%s' by ID: %s", ca, err)
+			lFunc.Errorf("failed to get CA '%s': %s", ca, err)
 			return nil, err
 		}
 
@@ -318,7 +318,7 @@ func (svc DMSManagerServiceBackend) Enroll(ctx context.Context, csr *x509.Certif
 	lFunc = lFunc.WithField("device-cn", csr.Subject.CommonName)
 	lFunc = lFunc.WithField("step", "PreEnroll")
 
-	lFunc.Infof("starting enrollment process for device")
+	lFunc.Infof("enrolling device '%s' via DMS '%s'", csr.Subject.CommonName, aps)
 
 	lFunc.Debugf("checking if DMS '%s' exists", aps)
 	dms, err := svc.service.GetDMSByID(ctx, services.GetDMSByIDInput{
@@ -340,7 +340,7 @@ func (svc DMSManagerServiceBackend) Enroll(ctx context.Context, csr *x509.Certif
 	estAuthOptions := enrollSettings.EnrollmentOptionsESTRFC7030
 
 	lFunc = lFunc.WithField("step", "Authenticating")
-	lFunc.Infof("starting authentication process")
+	lFunc.Infof("authenticating enrollment request")
 	switch estAuthOptions.AuthMode {
 	case models.ESTAuthMode(identityextractors.IdentityExtractorClientCertificate):
 		lFunc = lFunc.WithField("auth-method", identityextractors.IdentityExtractorClientCertificate)
@@ -379,7 +379,7 @@ func (svc DMSManagerServiceBackend) Enroll(ctx context.Context, csr *x509.Certif
 			if err != nil {
 				lFunc.Debugf("invalid validation using CA [%s] with CommonName '%s', SerialNumber '%s'", ca.ID, ca.Certificate.Subject.CommonName, ca.Certificate.SerialNumber)
 			} else {
-				lFunc.Infof("certificate validated. Revocation check will be performed next")
+				lFunc.Infof("client certificate validated by CA '%s', checking revocation", ca.ID)
 				validCertificate = true
 				validationCA = ca
 				break
@@ -406,13 +406,13 @@ func (svc DMSManagerServiceBackend) Enroll(ctx context.Context, csr *x509.Certif
 				lFunc.Errorf("aborting enrollment. certificate is revoked")
 				return nil, fmt.Errorf("certificate is revoked")
 			}
-			lFunc.Infof("certificate is not revoked")
+			lFunc.Infof("client certificate is not revoked")
 		} else {
-			lFunc.Warnf("could not verify certificate expiration. Assuming certificate as not-revoked")
+			lFunc.Warnf("could not verify certificate revocation status, assuming not revoked")
 		}
 
 		lFunc = lFunc.WithField("auth-status", "verified")
-		lFunc.Infof("certificate verified")
+		lFunc.Infof("client certificate verified")
 
 	case models.ESTAuthMode(identityextractors.IdentityExtractorNoAuth):
 		lFunc = lFunc.WithField("auth-method", identityextractors.IdentityExtractorNoAuth)
@@ -496,7 +496,7 @@ func (svc DMSManagerServiceBackend) Enroll(ctx context.Context, csr *x509.Certif
 		lFunc.Warn("DMS is configured with no CSR signature verification, allowing enrollment")
 	}
 
-	lFunc.Infof("authentication process completed successfully")
+	lFunc.Infof("enrollment authentication passed")
 	lFunc = lFunc.WithField("step", "DeviceReg")
 
 	var device *models.Device
@@ -523,7 +523,7 @@ func (svc DMSManagerServiceBackend) Enroll(ctx context.Context, csr *x509.Certif
 			//revoke active certificate
 			defer func() {
 				lFunc = lFunc.WithField("step", "PostEnroll")
-				lFunc.Infof("starting PostEnroll process")
+				lFunc.Infof("revoking previous certificate for device '%s' (re-enrollment)", csr.Subject.CommonName)
 				if device.IdentitySlot == nil {
 					device.IdentitySlot = &models.Slot[string]{}
 				}
@@ -535,13 +535,11 @@ func (svc DMSManagerServiceBackend) Enroll(ctx context.Context, csr *x509.Certif
 				if err != nil {
 					lFunc.Warnf("could not revoke certificate %s: %s", device.IdentitySlot.Secrets[device.IdentitySlot.ActiveVersion], err)
 				} else {
-					lFunc.Infof("revoked certificate %s successfully", device.IdentitySlot.Secrets[device.IdentitySlot.ActiveVersion])
+					lFunc.Infof("revoked superseded certificate %s", device.IdentitySlot.Secrets[device.IdentitySlot.ActiveVersion])
 				}
-
-				lFunc.Infof("PostEnroll process completed successfully")
 			}()
 		} else {
-			lFunc.Debugf("aborting enrollment. DMS forbids new enrollments. consider switching NewEnrollment option ON in the DMS")
+			lFunc.Debugf("aborting enrollment. DMS '%s' forbids new enrollments for already-registered devices", dms.ID)
 			return nil, fmt.Errorf("forbiddenNewEnrollment")
 		}
 	}
@@ -564,26 +562,26 @@ func (svc DMSManagerServiceBackend) Enroll(ctx context.Context, csr *x509.Certif
 				return nil, err
 			}
 		} else {
-			lFunc.Debugf("skipping device registration since already exists")
+			lFunc.Debugf("device '%s' already registered, skipping JITP creation", csr.Subject.CommonName)
 		}
 	} else if device == nil {
-		lFunc.Errorf("aborting enrollment. DMS doesn't allow JustInTime registration. register the device manually or switch DMS JIT option ON")
+		lFunc.Errorf("aborting enrollment. device '%s' not pre-registered and DMS '%s' has JIT disabled", csr.Subject.CommonName, dms.ID)
 		return nil, fmt.Errorf("device not preregistered")
 	} else {
-		lFunc.Infof("device %s already preregistered. continuing enrollment process", device.ID)
+		lFunc.Infof("device '%s' pre-registered, continuing enrollment", device.ID)
 	}
 
-	lFunc.Infof("device registration process completed successfully")
+	lFunc.Infof("device registration complete for '%s'", device.ID)
 
 	lFunc = lFunc.WithField("step", "Signature")
-	lFunc.Infof("starting signature process")
+	lFunc.Infof("signing certificate for device '%s'", device.ID)
 
 	issuanceProfile, err := svc.resolveIssuanceProfile(ctx, lFunc, dms, enrollSettings.EnrollmentCA)
 	if err != nil {
 		return nil, err
 	}
 
-	lFunc.Infof("requesting certificate signature")
+	lFunc.Infof("requesting certificate signature from CA '%s'", enrollSettings.EnrollmentCA)
 	crt, err := svc.caClient.SignCertificate(ctx, services.SignCertificateInput{
 		CAID:            enrollSettings.EnrollmentCA,
 		CertRequest:     (*models.X509CertificateRequest)(csr),
@@ -601,7 +599,7 @@ func (svc DMSManagerServiceBackend) Enroll(ctx context.Context, csr *x509.Certif
 		bindMode = models.DeviceEventTypeReProvisioned
 	}
 
-	lFunc.Infof("assigning certificate to device")
+	lFunc.Infof("binding certificate '%s' to device '%s'", crt.SerialNumber, device.ID)
 	_, err = svc.service.BindIdentityToDevice(ctx, services.BindIdentityToDeviceInput{
 		DeviceID:                device.ID,
 		CertificateSerialNumber: crt.SerialNumber,
@@ -612,10 +610,7 @@ func (svc DMSManagerServiceBackend) Enroll(ctx context.Context, csr *x509.Certif
 		return nil, err
 	}
 
-	lFunc.Infof("certificate signing process completed successfully")
-
-	lFunc = lFunc.WithField("step", "")
-	lFunc.Infof("enrollment process completed successfully")
+	lFunc.Infof("certificate '%s' issued and bound to device '%s'", crt.SerialNumber, device.ID)
 
 	return (*x509.Certificate)(crt.Certificate), nil
 }
@@ -630,7 +625,7 @@ func (svc DMSManagerServiceBackend) Reenroll(ctx context.Context, csr *x509.Cert
 	lFunc = lFunc.WithField("device-cn", csr.Subject.CommonName)
 	lFunc = lFunc.WithField("step", "PreReEnroll")
 
-	lFunc.Infof("starting reenrollment process for device")
+	lFunc.Infof("reenrolling device '%s' via DMS '%s'", csr.Subject.CommonName, aps)
 
 	if csr.Subject.CommonName == "" {
 		lFunc.Errorf("aborting reenrollment. No CommonName in CSR")
@@ -684,7 +679,7 @@ func (svc DMSManagerServiceBackend) Reenroll(ctx context.Context, csr *x509.Cert
 		if err != nil {
 			lFunc.Warnf("invalid validation using enroll CA: %s", err)
 		} else {
-			lFunc.Infof("certificate validated. Revocation and Expiration (if needed) check will be performed next")
+			lFunc.Infof("client certificate validated by enroll CA '%s', checking revocation", enrollCAID)
 			validationCA = (*x509.Certificate)(enrollCA.Certificate.Certificate)
 			validCertificate = true
 		}
@@ -693,9 +688,8 @@ func (svc DMSManagerServiceBackend) Reenroll(ctx context.Context, csr *x509.Cert
 		if !validCertificate {
 
 			aValCAsCtr := len(reEnrollSettings.AdditionalValidationCAs)
-			lFunc.Debugf("could not validate client certificate using enroll CA. Will try validating using Additional Validation CAs")
-			lFunc.Debugf("DMS has %d additional validation CAs", aValCAsCtr)
-
+			lFunc.Debugf("client certificate not validated by enroll CA, trying %d additional validation CAs", aValCAsCtr)
+	
 			//check if certificate is a certificate issued by Extra Val CAs
 			for idx, caID := range reEnrollSettings.AdditionalValidationCAs {
 				lFunc.Debugf("[%d/%d] obtaining validation with ID %s", idx, aValCAsCtr, caID)
@@ -747,12 +741,11 @@ func (svc DMSManagerServiceBackend) Reenroll(ctx context.Context, csr *x509.Cert
 		}
 
 		//checks against Lamassu, external OCSP or CRL
-		lFunc.Infof("checking certificate revocation status")
+		lFunc.Infof("checking revocation status of client certificate")
 		couldCheckRevocation, isRevoked, err := svc.checkCertificateRevocation(ctx, clientCert, (*x509.Certificate)(validationCA))
 		if err != nil {
 			lFunc = lFunc.WithField("auth-status", "failed")
-			lFunc.Errorf("aborting reenrollment. could not check certificate revocation status: %s", err)
-			lFunc.Errorf("error while checking certificate revocation status: %s", err)
+			lFunc.Errorf("aborting reenrollment. failed to check certificate revocation status: %s", err)
 			return nil, err
 		}
 
@@ -762,16 +755,16 @@ func (svc DMSManagerServiceBackend) Reenroll(ctx context.Context, csr *x509.Cert
 				lFunc.Errorf("aborting enrollment. certificate is revoked")
 				return nil, fmt.Errorf("certificate is revoked")
 			}
-			lFunc.Infof("certificate is not revoked")
+			lFunc.Infof("client certificate is not revoked")
 		} else {
-			lFunc.Infof("could not verify certificate expiration. Assuming certificate as not-revoked")
+			lFunc.Warnf("could not verify certificate revocation status, assuming not revoked")
 		}
 	} else {
 		lFunc.Warnf("allowing reenroll: using NO AUTH mode")
 	}
 
 	lFunc = lFunc.WithField("auth-status", "verified")
-	lFunc.Infof("certificate verified")
+	lFunc.Infof("reenrollment authentication passed")
 
 	lFunc = lFunc.WithField("step", "DeviceCheck")
 	var device *models.Device
@@ -781,14 +774,14 @@ func (svc DMSManagerServiceBackend) Reenroll(ctx context.Context, csr *x509.Cert
 	if err != nil {
 		switch err {
 		case errs.ErrDeviceNotFound:
-			lFunc.Debugf("device doesn't exist")
+			lFunc.Debugf("device '%s' not found", csr.Subject.CommonName)
 			return nil, err
 		default:
-			lFunc.Errorf("could not get device: %s", err)
+			lFunc.Errorf("failed to get device '%s': %s", csr.Subject.CommonName, err)
 			return nil, err
 		}
 	} else {
-		lFunc.Debugf("device found")
+		lFunc.Debugf("device '%s' found", csr.Subject.CommonName)
 	}
 
 	lFunc = lFunc.WithField("step", "CSRCheck")
@@ -929,12 +922,12 @@ func (svc DMSManagerServiceBackend) Reenroll(ctx context.Context, csr *x509.Cert
 
 func checkCSRSignature(lFunc *logrus.Entry, csr *x509.CertificateRequest, operation string) error {
 
-	lFunc.Info("checking CSR signature")
+	lFunc.Debugf("checking CSR signature for %s", operation)
 	if err := csr.CheckSignature(); err != nil {
 		lFunc.Errorf("aborting %s. Invalid CSR signature: %v", operation, err)
 		return err
 	}
-	lFunc.Info("Valid CSR signature")
+	lFunc.Debugf("CSR signature valid")
 
 	return nil
 }
@@ -1046,17 +1039,16 @@ func (svc DMSManagerServiceBackend) checkCertificateRevocation(ctx context.Conte
 			for _, ocspInstance := range cert.OCSPServer {
 				ocspResp, err := external_clients.GetOCSPResponsePost(ocspInstance, cert, validationCA, nil, true)
 				if err != nil {
-					lFunc.Warnf("could not get or validate ocsp response from server %s specified in the presented client certificate: %s", err, clientSN)
-					lFunc.Warnf("checking with next ocsp server")
+					lFunc.Warnf("OCSP check failed for server '%s' (cert %s): %s, trying next", ocspInstance, clientSN, err)
 					continue
 				}
 
-				lFunc.Infof("successfully validated OCSP response with external %s OCSP server. Checking OCSP response status for %s certificate", ocspInstance, clientSN)
+				lFunc.Infof("OCSP response validated via '%s', checking revocation status for cert %s", ocspInstance, clientSN)
 				if ocspResp.Status == ocsp.Revoked {
-					lFunc.Warnf("certificate was revoked at %s with %s revocation reason", ocspResp.RevokedAt.String(), models.RevocationReasonMap[ocspResp.RevocationReason])
+					lFunc.Warnf("certificate %s was revoked at %s with reason %s", clientSN, ocspResp.RevokedAt.String(), models.RevocationReasonMap[ocspResp.RevocationReason])
 					return true, true, nil
 				} else {
-					lFunc.Infof("certificate is not revoked")
+					lFunc.Infof("certificate %s is not revoked", clientSN)
 					return true, false, nil
 				}
 			}
@@ -1067,8 +1059,7 @@ func (svc DMSManagerServiceBackend) checkCertificateRevocation(ctx context.Conte
 			for _, crlDP := range cert.CRLDistributionPoints {
 				crl, err := external_clients.GetCRLResponse(crlDP, validationCA, nil, true)
 				if err != nil {
-					lFunc.Warnf("could not get or validate crl response from server %s specified in the presented client certificate: %s", err, clientSN)
-					lFunc.Warnf("checking with next crl server")
+						lFunc.Warnf("CRL check failed for server '%s' (cert %s): %s, trying next", crlDP, clientSN, err)
 					continue
 				}
 
@@ -1078,10 +1069,10 @@ func (svc DMSManagerServiceBackend) checkCertificateRevocation(ctx context.Conte
 
 				if idxClientCrt >= 0 {
 					entry := crl.RevokedCertificateEntries[idxClientCrt]
-					lFunc.Warnf("certificate was revoked at %s with %s revocation reason", entry.RevocationTime.String(), models.RevocationReasonMap[entry.ReasonCode])
+					lFunc.Warnf("certificate %s was revoked at %s with reason %s", clientSN, entry.RevocationTime.String(), models.RevocationReasonMap[entry.ReasonCode])
 					return true, true, nil
 				} else {
-					lFunc.Infof("certificate not revoked. Client certificate not in CRL: %s", clientSN)
+					lFunc.Infof("certificate %s not found in CRL", clientSN)
 					revocationChecked = true
 					revoked = false
 					//don't return, check other CRLs
@@ -1090,7 +1081,7 @@ func (svc DMSManagerServiceBackend) checkCertificateRevocation(ctx context.Conte
 		}
 	} else {
 		if lmsCrt.Status == models.StatusRevoked {
-			lFunc.Errorf("Client certificate %s is revoked", clientSN)
+			lFunc.Errorf("client certificate %s is revoked in Lamassu", clientSN)
 			return true, true, nil
 		} else {
 			return true, false, nil

--- a/backend/pkg/services/kms.go
+++ b/backend/pkg/services/kms.go
@@ -262,7 +262,7 @@ func (svc *KMSServiceBackend) GetKeys(ctx context.Context, input services.GetKey
 		ExtraOpts:     nil,
 	})
 	if err != nil {
-		lFunc.Errorf("something went wrong while reading all Requests from storage engine: %s", err)
+		lFunc.Errorf("failed to list keys from storage: %s", err)
 		return "", err
 	}
 
@@ -279,46 +279,45 @@ func (svc *KMSServiceBackend) GetKey(ctx context.Context, input services.GetKeyI
 	}
 
 	if strings.HasPrefix(input.Identifier, "pkcs11:") {
-		lFunc.Debugf("checking if Key '%s' exists via PKCS11URI", input.Identifier)
+		lFunc.Debugf("resolving key '%s' via PKCS11 URI", input.Identifier)
 		_, keyID, _, err := parsePKCS11ID(input.Identifier)
 		if err != nil {
 			lFunc.Errorf("failed to parse PKCS11 ID: %s", err)
 			return nil, err
 		}
 
-		lFunc.Debugf("checking if Key '%s' exists via KeyID", keyID)
+		lFunc.Debugf("looking up key '%s' by keyID", keyID)
 		exists, key, err := svc.kmsStorage.SelectExistsByKeyID(ctx, keyID)
 		if err != nil {
-			lFunc.Errorf("something went wrong while checking if key '%s' exists in storage engine: %s", keyID, err)
+			lFunc.Errorf("failed to look up key '%s' in storage: %s", keyID, err)
 			return nil, err
 		}
 
 		if !exists {
-			lFunc.Infof("key %s can not be found in storage engine via keyID", keyID)
+			lFunc.Infof("key '%s' not found by keyID", keyID)
 			return nil, fmt.Errorf("key not found")
 		}
 
 		return key, nil
 	} else {
 
-		lFunc.Debugf("checking if Key '%s' exists via KeyID", input.Identifier)
+		lFunc.Debugf("looking up key '%s' by keyID", input.Identifier)
 		exists, key, err := svc.kmsStorage.SelectExistsByKeyID(ctx, input.Identifier)
 		if err != nil {
-			lFunc.Errorf("something went wrong while checking if key '%s' exists in storage engine: %s", input.Identifier, err)
+			lFunc.Errorf("failed to look up key '%s' in storage: %s", input.Identifier, err)
 			return nil, err
 		}
 
 		if !exists {
-			lFunc.Infof("key %s can not be found in storage engine via keyID", input.Identifier)
-			lFunc.Debugf("checking if Key '%s' exists via Alias", input.Identifier)
+			lFunc.Debugf("key '%s' not found by keyID, retrying by alias", input.Identifier)
 			exists, key, err = svc.kmsStorage.SelectExistsByAlias(ctx, input.Identifier)
 			if err != nil {
-				lFunc.Errorf("something went wrong while checking if key '%s' exists in storage engine: %s", input.Identifier, err)
+				lFunc.Errorf("failed to look up key '%s' in storage: %s", input.Identifier, err)
 				return nil, err
 			}
 
 			if !exists {
-				lFunc.Infof("key %s can not be found in storage engine via alias", input.Identifier)
+				lFunc.Infof("key '%s' not found by alias", input.Identifier)
 				return nil, fmt.Errorf("key not found")
 			}
 		}
@@ -638,7 +637,7 @@ func (svc *KMSServiceBackend) UpdateKeyMetadata(ctx context.Context, input servi
 		Identifier: input.ID,
 	})
 	if err != nil {
-		lFunc.Errorf("something went wrong while checking if key '%s' exists in storage engine: %s", input.ID, err)
+		lFunc.Errorf("failed to look up key '%s' in storage: %s", input.ID, err)
 		return nil, err
 	}
 
@@ -672,7 +671,7 @@ func (svc *KMSServiceBackend) UpdateKeyAliases(ctx context.Context, input servic
 		Identifier: input.ID,
 	})
 	if err != nil {
-		lFunc.Errorf("something went wrong while checking if key '%s' exists in storage engine: %s", input.ID, err)
+		lFunc.Errorf("failed to look up key '%s' in storage: %s", input.ID, err)
 		return nil, err
 	}
 
@@ -728,7 +727,7 @@ func (svc *KMSServiceBackend) UpdateKeyName(ctx context.Context, input services.
 		Identifier: input.ID,
 	})
 	if err != nil {
-		lFunc.Errorf("something went wrong while checking if key '%s' exists in storage engine: %s", input.ID, err)
+		lFunc.Errorf("failed to look up key '%s' in storage: %s", input.ID, err)
 		return nil, err
 	}
 
@@ -755,7 +754,7 @@ func (svc *KMSServiceBackend) UpdateKeyTags(ctx context.Context, input services.
 		Identifier: input.ID,
 	})
 	if err != nil {
-		lFunc.Errorf("something went wrong while checking if key '%s' exists in storage engine: %s", input.ID, err)
+		lFunc.Errorf("failed to look up key '%s' in storage: %s", input.ID, err)
 		return nil, err
 	}
 
@@ -782,7 +781,7 @@ func (svc *KMSServiceBackend) DeleteKeyByID(ctx context.Context, input services.
 		Identifier: input.Identifier,
 	})
 	if err != nil {
-		lFunc.Errorf("something went wrong while checking if key '%s' exists in storage engine: %s", input.Identifier, err)
+		lFunc.Errorf("failed to look up key '%s' in storage: %s", input.Identifier, err)
 		return err
 	}
 
@@ -800,18 +799,18 @@ func (svc *KMSServiceBackend) DeleteKeyByID(ctx context.Context, input services.
 
 	err = engineInstance.DeleteKey(key.KeyID)
 	if err != nil {
-		lFunc.Errorf("delete key error: %s", err)
+		lFunc.Errorf("failed to delete key '%s' from crypto engine: %s", key.KeyID, err)
 		return err
 	}
 
-	lFunc.Debugf("deleting key %s from storage engine", key.KeyID)
+	lFunc.Debugf("deleting key '%s' from storage", key.KeyID)
 	err = svc.kmsStorage.Delete(ctx, key.KeyID)
 	if err != nil {
-		lFunc.Errorf("delete by ID error: %s", err)
+		lFunc.Errorf("failed to delete key '%s' from storage: %s", key.KeyID, err)
 		return fmt.Errorf("failed to delete key from storage: %w", err)
 	}
 
-	lFunc.Infof("key %s deleted successfully", key.KeyID)
+	lFunc.Infof("key '%s' deleted", key.KeyID)
 
 	return nil
 }


### PR DESCRIPTION
This pull request focuses on improving the clarity and consistency of log messages across multiple backend services. The changes primarily standardize log output, making it more descriptive and easier to interpret, especially during service startup, event bus operations, job scheduling, and error handling. Additionally, log levels have been adjusted in some places to better reflect the importance of the messages.

**Logging improvements and standardization:**

* Updated startup log messages in all main service entrypoints (such as `main.go` files for Alerts, CA, Device Manager, DMS Manager, KMS, and VA) to use a consistent, descriptive format (e.g., "starting API service...") and improved error messages for configuration loading failures. [[1]](diffhunk://#diff-26a48413691057f95cbfe39e3161e870cda768b5430745aa66826bac0cc39898L21-R25) [[2]](diffhunk://#diff-c4336b064c0e94b882e8f0afd927f5fcbded4c1fa19ed1a7aec952a7cfafd4e8L24-R28) [[3]](diffhunk://#diff-c1126ca1b4381eb27781cd4db91768b9aadcc7bb967efbfeffa4fe826465200cL24-R24) [[4]](diffhunk://#diff-384f5f7ffc01395de628933cab6357bd0e1fb6397c5f59144f1ab8ed81146746L24-R24) [[5]](diffhunk://#diff-b96c41d29408fe44fff925ba8a911cb3d21d7ff57ba7e11b329140f71b31f170L21-R25) [[6]](diffhunk://#diff-ef9b33d7c62432edd7113bfc489a12052fd5d0076d4e1faf350fc78d93fe4664L24-R24)
* Standardized event bus-related log messages in service assemblers to specify whether the service is publishing or subscribing, and clarified which service the log refers to. [[1]](diffhunk://#diff-e0488f21e2d46e56fa26c644921d4dbb4c5321e466fb3c37f2e6c31e98e9b864L65-R65) [[2]](diffhunk://#diff-b87f82107570fc7f691218a78e530d765a3d9469c0206a3acbf3fd9316ee690dL79-R79) [[3]](diffhunk://#diff-b87f82107570fc7f691218a78e530d765a3d9469c0206a3acbf3fd9316ee690dL106-R106) [[4]](diffhunk://#diff-9ba6840212bfa0dec6d05be4b7cbad7b8e17cf25620dc8f41e104c7cf8e384e9L64-R66) [[5]](diffhunk://#diff-9ba6840212bfa0dec6d05be4b7cbad7b8e17cf25620dc8f41e104c7cf8e384e9L92-R92) [[6]](diffhunk://#diff-0c1c50ff50048efa2fa25b6db1638d3363426b47d8e6f49b8d28682e12599096L69-R69) [[7]](diffhunk://#diff-b6294bce217fab92fc30fbe84b4d91b6e8de882be4a1b1139b8c1ed2971f8189L99-R99) [[8]](diffhunk://#diff-8fe0cfe52a16a3428bd5e2d7acc13d21907c0208a6c3195e4942df5de462af8cL122-R122) [[9]](diffhunk://#diff-8fe0cfe52a16a3428bd5e2d7acc13d21907c0208a6c3195e4942df5de462af8cL145-R145)
* Improved job scheduling and monitoring logs to clearly indicate job type, frequency, and result, and provided more context in case of scheduling errors. [[1]](diffhunk://#diff-e7cffe18278fb58ff541d80f3ca8e9e61f99dbfcc49154b8df860330659bc18dL34-R40) [[2]](diffhunk://#diff-a4efd8a3fd407a1a30112cc432c082eaf4089a321609aa4a7b23a7511d51bf18L23-R27) [[3]](diffhunk://#diff-8fe0cfe52a16a3428bd5e2d7acc13d21907c0208a6c3195e4942df5de462af8cL176-R176) [[4]](diffhunk://#diff-ca8ef19256eae3de61b69e6d1c1a8fa4e55cfa358847dd6e7c90f738c04c1ec8L31-R31) [[5]](diffhunk://#diff-ca8ef19256eae3de61b69e6d1c1a8fa4e55cfa358847dd6e7c90f738c04c1ec8L41-R57)

**Error and status message clarity:**

* Enhanced error log messages in the VA controller to include more context, such as the CA subject key ID, and to use clearer, action-oriented language. [[1]](diffhunk://#diff-72422b356d2d1383f1f89514ecc890e9ddc48ab1e6cce2c8d94cd76efa7d1b2cL91-R91) [[2]](diffhunk://#diff-72422b356d2d1383f1f89514ecc890e9ddc48ab1e6cce2c8d94cd76efa7d1b2cL115-R115) [[3]](diffhunk://#diff-72422b356d2d1383f1f89514ecc890e9ddc48ab1e6cce2c8d94cd76efa7d1b2cL138-R138) [[4]](diffhunk://#diff-72422b356d2d1383f1f89514ecc890e9ddc48ab1e6cce2c8d94cd76efa7d1b2cL168-R168)
* Improved key migration logs in the KMS assembler to provide more detailed information about the migration process and use appropriate log levels. [[1]](diffhunk://#diff-b6294bce217fab92fc30fbe84b4d91b6e8de882be4a1b1139b8c1ed2971f8189L168-R168) [[2]](diffhunk://#diff-b6294bce217fab92fc30fbe84b4d91b6e8de882be4a1b1139b8c1ed2971f8189L184-R184) [[3]](diffhunk://#diff-b6294bce217fab92fc30fbe84b4d91b6e8de882be4a1b1139b8c1ed2971f8189L203-R203) [[4]](diffhunk://#diff-b6294bce217fab92fc30fbe84b4d91b6e8de882be4a1b1139b8c1ed2971f8189L235-R235)

**Crypto engine provider registration logs:**

* Changed log messages for crypto engine provider registration (AWS, PKCS11, Vault) from `Info` to `Debug` level and made the messages more descriptive. [[1]](diffhunk://#diff-c9c8e85b8649196fc41a66ab55caff6b3d2bccd47c995d5b4bc5d28e6cbb0c42L12-R12) [[2]](diffhunk://#diff-2a438fe2ffb586963c635116a6cef84002bcb33f0604c0ec2ec8bccc6854ec3eL12-R12) [[3]](diffhunk://#diff-8d596743d9792b0e4a66ffa6c2b4e43e0a1592697d2f1b1076e5c1aebb7fb466L12-R12)