### PR TITLE
fix: handle nil revocation reasons and update related logic across services

### DIFF
--- a/backend/pkg/assemblers/tests/ca/ca_main_test.go
+++ b/backend/pkg/assemblers/tests/ca/ca_main_test.go
@@ -2782,8 +2782,8 @@ func TestRevokeCA(t *testing.T) {
 					return fmt.Errorf("CA should have Revoked status but is in %s status", revokedCA.Certificate.Status)
 				}
 
-				if revokedCA.Certificate.RevocationReason != ocsp.AACompromise {
-					return fmt.Errorf("CA should have RevocationReason AACompromise status but is in %s reason", revokedCA.Certificate.RevocationReason)
+				if revokedCA.Certificate.RevocationReason == nil || *revokedCA.Certificate.RevocationReason != models.RevocationReason(ocsp.AACompromise) {
+					return fmt.Errorf("CA should have RevocationReason AACompromise status but is in %s reason", revokedCA.Certificate.RevocationReason.String())
 				}
 
 				return nil

--- a/backend/pkg/assemblers/tests/dms-manager/main_test.go
+++ b/backend/pkg/assemblers/tests/dms-manager/main_test.go
@@ -3503,7 +3503,7 @@ func TestESTReEnroll(t *testing.T) {
 					t.Fatalf("certificate should be revoked")
 				}
 
-				if crt1.RevocationReason != ocsp.Superseded {
+				if crt1.RevocationReason == nil || *crt1.RevocationReason != models.RevocationReason(ocsp.Superseded) {
 					t.Fatalf("certificate should be revoked with reason superseded")
 				}
 

--- a/backend/pkg/services/ca.go
+++ b/backend/pkg/services/ca.go
@@ -950,7 +950,7 @@ func (svc *CAServiceBackend) UpdateCAStatus(ctx context.Context, input services.
 		return nil, errs.ErrCertificateStatusTransitionNotAllowed
 	}
 
-	if ca.Certificate.Status == models.StatusRevoked && ca.Certificate.RevocationReason != ocsp.CertificateHold {
+	if ca.Certificate.Status == models.StatusRevoked && (ca.Certificate.RevocationReason == nil || *ca.Certificate.RevocationReason != ocsp.CertificateHold) {
 		lFunc.Errorf("cannot update a revoke CA certificate in %s status. Only a revoked CA certificate with reason '6 - CertificateHold' can be unrevoked", ca.Certificate.RevocationReason.String())
 		return nil, errs.ErrCertificateStatusTransitionNotAllowed
 	}
@@ -959,8 +959,11 @@ func (svc *CAServiceBackend) UpdateCAStatus(ctx context.Context, input services.
 	if ca.Certificate.Status == models.StatusRevoked {
 		rrb, _ := input.RevocationReason.MarshalText()
 		lFunc.Infof("CA %s is being revoked with revocation reason %d - %s", input.CAID, input.RevocationReason, string(rrb))
-		ca.Certificate.RevocationReason = input.RevocationReason
+		rr := input.RevocationReason
+		ca.Certificate.RevocationReason = &rr
 		ca.Certificate.RevocationTimestamp = time.Now()
+	} else {
+		ca.Certificate.RevocationReason = nil
 	}
 
 	lFunc.Debugf("updating the status of CA %s to %s", input.CAID, input.Status)
@@ -1924,7 +1927,7 @@ func (svc *CAServiceBackend) UpdateCertificateStatus(ctx context.Context, input 
 		return nil, errs.ErrCertificateStatusTransitionNotAllowed
 	}
 
-	if cert.Status == models.StatusRevoked && cert.RevocationReason != ocsp.CertificateHold {
+	if cert.Status == models.StatusRevoked && (cert.RevocationReason == nil || *cert.RevocationReason != ocsp.CertificateHold) {
 		lFunc.Errorf("cannot update a revoke certificate in %s status. Only a revoked certificate with reason '6 - CertificateHold' can be unrevoked", cert.RevocationReason.String())
 		return nil, errs.ErrCertificateStatusTransitionNotAllowed
 	}
@@ -1934,11 +1937,13 @@ func (svc *CAServiceBackend) UpdateCertificateStatus(ctx context.Context, input 
 	if input.NewStatus == models.StatusRevoked {
 		rrb, _ := input.RevocationReason.MarshalText()
 		lFunc.Infof("certificate with SN %s issued by CA with ID %s and CN %s is being revoked with revocation reason %d - %s", input.SerialNumber, cert.IssuerCAMetadata.ID, cert.Certificate.Issuer.CommonName, input.RevocationReason, string(rrb))
-		cert.RevocationReason = input.RevocationReason
+		rr := input.RevocationReason
+		cert.RevocationReason = &rr
 		cert.RevocationTimestamp = time.Now()
 	} else {
 		//Make sure to reset revocation TS in case of reactivation
 		cert.RevocationTimestamp = time.Time{}
+		cert.RevocationReason = nil
 	}
 
 	lFunc.Debugf("updating %s certificate status to %s", input.SerialNumber, input.NewStatus)

--- a/backend/pkg/services/crl.go
+++ b/backend/pkg/services/crl.go
@@ -228,11 +228,15 @@ func (svc CRLServiceBackend) CalculateCRL(ctx context.Context, input services.Ca
 				PageSize: 15,
 			},
 			ApplyFunc: func(cert models.Certificate) {
+				reasonCode := 0
+				if cert.RevocationReason != nil {
+					reasonCode = int(*cert.RevocationReason)
+				}
 				certList = append(certList, x509.RevocationListEntry{
 					SerialNumber:   cert.Certificate.SerialNumber,
 					RevocationTime: cert.RevocationTimestamp,
 					Extensions:     []pkix.Extension{},
-					ReasonCode:     int(cert.RevocationReason),
+					ReasonCode:     reasonCode,
 				})
 			},
 		},

--- a/backend/pkg/services/dmsmanager.go
+++ b/backend/pkg/services/dmsmanager.go
@@ -868,7 +868,7 @@ func (svc DMSManagerServiceBackend) Reenroll(ctx context.Context, csr *x509.Cert
 
 	//Check if current cert is REVOKED
 	if currentDeviceCert.Status == models.StatusRevoked {
-		lFunc.Warnf("aborting reenrollment as certificate %s is revoked with status code %s", currentDeviceCertSN, currentDeviceCert.RevocationReason)
+		lFunc.Warnf("aborting reenrollment as certificate %s is revoked with status code %s", currentDeviceCertSN, currentDeviceCert.RevocationReason.String())
 		return nil, fmt.Errorf("revoked certificate")
 	}
 

--- a/backend/pkg/services/handlers/va-handlers.go
+++ b/backend/pkg/services/handlers/va-handlers.go
@@ -60,7 +60,7 @@ func updateCertificateStatus(ctx context.Context, event *event.Event, crlSvc ser
 
 	// Check if this is a certificate being reactivated from CertificateHold
 	isReactivationFromHold := cert.Previous.Status == models.StatusRevoked &&
-		cert.Previous.RevocationReason == ocsp.CertificateHold &&
+		cert.Previous.RevocationReason != nil && *cert.Previous.RevocationReason == models.RevocationReason(ocsp.CertificateHold) &&
 		cert.Updated.Status == models.StatusActive
 
 	// Check if this is a normal revocation

--- a/backend/pkg/services/ocsp.go
+++ b/backend/pkg/services/ocsp.go
@@ -59,13 +59,18 @@ func (svc ocspResponder) Verify(ctx context.Context, req *ocsp.Request) ([]byte,
 
 	// construct response template
 	rtemplate := ocsp.Response{
-		Status:           status,
-		SerialNumber:     req.SerialNumber,
-		Certificate:      (*x509.Certificate)(ca.Certificate.Certificate),
-		RevocationReason: int(crt.RevocationReason),
-		IssuerHash:       req.HashAlgorithm,
-		RevokedAt:        revokedAt,
-		ThisUpdate:       time.Now().AddDate(0, 0, -1).UTC(),
+		Status:       status,
+		SerialNumber: req.SerialNumber,
+		Certificate:  (*x509.Certificate)(ca.Certificate.Certificate),
+		RevocationReason: func() int {
+			if crt.RevocationReason != nil {
+				return int(*crt.RevocationReason)
+			}
+			return 0
+		}(),
+		IssuerHash: req.HashAlgorithm,
+		RevokedAt:  revokedAt,
+		ThisUpdate: time.Now().AddDate(0, 0, -1).UTC(),
 		//adding 1 day after the current date. This ocsp library sets the default date to epoch which makes ocsp clients freak out.
 		NextUpdate: time.Now().AddDate(0, 0, 1).UTC(),
 	}

--- a/connectors/awsiot/pkg/service.go
+++ b/connectors/awsiot/pkg/service.go
@@ -421,7 +421,7 @@ func (svc *AWSCloudConnectorServiceBackend) UpdateCertificateStatus(ctx context.
 
 	switch input.Certificate.Status {
 	case models.StatusRevoked:
-		if input.Certificate.RevocationReason == ocsp.CertificateHold {
+		if input.Certificate.RevocationReason != nil && *input.Certificate.RevocationReason == ocsp.CertificateHold {
 			status = types.CertificateStatusInactive
 		} else {
 			status = types.CertificateStatusRevoked

--- a/core/pkg/models/ca.go
+++ b/core/pkg/models/ca.go
@@ -43,7 +43,7 @@ type Certificate struct {
 	IssuerCAMetadata    IssuerCAMetadata       `json:"issuer_metadata" gorm:"embedded;embeddedPrefix:issuer_meta_"`
 	ValidTo             time.Time              `json:"valid_to"`
 	RevocationTimestamp time.Time              `json:"revocation_timestamp"`
-	RevocationReason    RevocationReason       `json:"revocation_reason" gorm:"serializer:text"`
+	RevocationReason    *RevocationReason      `json:"revocation_reason,omitempty" gorm:"serializer:text"`
 	Type                CertificateType        `json:"type"`
 	EngineID            string                 `json:"engine_id"`
 	IsCA                bool                   `json:"is_ca"`

--- a/core/pkg/models/revocation_reason.go
+++ b/core/pkg/models/revocation_reason.go
@@ -43,7 +43,10 @@ func (p *RevocationReason) UnmarshalText(text []byte) (err error) {
 	return fmt.Errorf("unsupported revocation code")
 }
 
-func (c RevocationReason) String() string {
+func (c *RevocationReason) String() string {
+	if c == nil {
+		return ""
+	}
 	r, err := c.MarshalText()
 	if err != nil {
 		return "-"

--- a/engines/storage/postgres/migrations/ca/20260421000000_nullable_revocation_reason.go
+++ b/engines/storage/postgres/migrations/ca/20260421000000_nullable_revocation_reason.go
@@ -12,37 +12,19 @@ func Register20260421000000NullableRevocationReason() {
 }
 
 func upNullableRevocationReason(ctx context.Context, tx *sql.Tx) error {
-	// Clear revocation_reason for certificates and CAs that are not revoked.
+	// Clear revocation_reason for certificates that are not revoked.
 	// Previously the zero value (0 = "Unspecified") was stored for all rows,
 	// making it impossible to distinguish "never revoked" from "revoked with Unspecified reason".
 	// After this migration only revoked rows retain their reason; all others are NULL.
-	queries := []string{
-		`UPDATE certificates SET revocation_reason = NULL WHERE status != 'REVOKED';`,
-		`UPDATE ca_certificates SET revocation_reason = NULL WHERE status != 'REVOKED';`,
-	}
-
-	for _, query := range queries {
-		if _, err := tx.ExecContext(ctx, query); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	// CA certificates are also rows in the certificates table (ca_certificates dropped its own
+	// revocation_reason column in 20241223183344_unified_ca_models), so one query covers both.
+	_, err := tx.ExecContext(ctx, `UPDATE certificates SET revocation_reason = NULL WHERE status != 'REVOKED';`)
+	return err
 }
 
 func downNullableRevocationReason(ctx context.Context, tx *sql.Tx) error {
-	// Restore the previous behaviour: set revocation_reason to "Unspecified" (0)
-	// for all non-revoked rows that currently have NULL.
-	queries := []string{
-		`UPDATE certificates SET revocation_reason = 'Unspecified' WHERE revocation_reason IS NULL AND status != 'REVOKED';`,
-		`UPDATE ca_certificates SET revocation_reason = 'Unspecified' WHERE revocation_reason IS NULL AND status != 'REVOKED';`,
-	}
-
-	for _, query := range queries {
-		if _, err := tx.ExecContext(ctx, query); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	// Restore the previous behaviour: set revocation_reason to "Unspecified" for all
+	// non-revoked rows that currently have NULL.
+	_, err := tx.ExecContext(ctx, `UPDATE certificates SET revocation_reason = 'Unspecified' WHERE revocation_reason IS NULL AND status != 'REVOKED';`)
+	return err
 }

--- a/engines/storage/postgres/migrations/ca/20260421000000_nullable_revocation_reason.go
+++ b/engines/storage/postgres/migrations/ca/20260421000000_nullable_revocation_reason.go
@@ -1,0 +1,48 @@
+package ca
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func Register20260421000000NullableRevocationReason() {
+	goose.AddMigrationContext(upNullableRevocationReason, downNullableRevocationReason)
+}
+
+func upNullableRevocationReason(ctx context.Context, tx *sql.Tx) error {
+	// Clear revocation_reason for certificates and CAs that are not revoked.
+	// Previously the zero value (0 = "Unspecified") was stored for all rows,
+	// making it impossible to distinguish "never revoked" from "revoked with Unspecified reason".
+	// After this migration only revoked rows retain their reason; all others are NULL.
+	queries := []string{
+		`UPDATE certificates SET revocation_reason = NULL WHERE status != 'REVOKED';`,
+		`UPDATE ca_certificates SET revocation_reason = NULL WHERE status != 'REVOKED';`,
+	}
+
+	for _, query := range queries {
+		if _, err := tx.ExecContext(ctx, query); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func downNullableRevocationReason(ctx context.Context, tx *sql.Tx) error {
+	// Restore the previous behaviour: set revocation_reason to "Unspecified" (0)
+	// for all non-revoked rows that currently have NULL.
+	queries := []string{
+		`UPDATE certificates SET revocation_reason = 'Unspecified' WHERE revocation_reason IS NULL AND status != 'REVOKED';`,
+		`UPDATE ca_certificates SET revocation_reason = 'Unspecified' WHERE revocation_reason IS NULL AND status != 'REVOKED';`,
+	}
+
+	for _, query := range queries {
+		if _, err := tx.ExecContext(ctx, query); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/engines/storage/postgres/migrations/gomigrations.go
+++ b/engines/storage/postgres/migrations/gomigrations.go
@@ -15,6 +15,7 @@ func RegisterGoMigrations(dbname string) {
 		ca.Register20250908074250AddProfileId()
 		ca.Register20250915090500UpdateSkiAki()
 		ca.Register20260331120000AddCertificateExtensions()
+		ca.Register20260421000000NullableRevocationReason()
 	case "devicemanager":
 		devicemanager.Register20250925120000RemoveSerialHyphens()
 	case "dmsmanager":

--- a/engines/storage/postgres/utils.go
+++ b/engines/storage/postgres/utils.go
@@ -65,6 +65,11 @@ func TableQuery[E any](log *logrus.Entry, db *gorm.DB, tableName string, primary
 type TextSerializer struct{}
 
 func (TextSerializer) Scan(ctx context.Context, field *schema.Field, dst reflect.Value, dbValue interface{}) (err error) {
+	// NULL in database → leave field as its zero value (nil for pointer fields).
+	if dbValue == nil {
+		return nil
+	}
+
 	// Create a new instance of the field type
 	fieldValue := reflect.New(field.FieldType).Interface()
 
@@ -97,6 +102,14 @@ func (TextSerializer) Scan(ctx context.Context, field *schema.Field, dst reflect
 
 // Value implements serializer interface
 func (TextSerializer) Value(ctx context.Context, field *schema.Field, dst reflect.Value, fieldValue interface{}) (interface{}, error) {
+	// Nil pointer → store NULL in the database.
+	if fieldValue == nil {
+		return nil, nil
+	}
+	if rv := reflect.ValueOf(fieldValue); rv.Kind() == reflect.Ptr && rv.IsNil() {
+		return nil, nil
+	}
+
 	// Check if fieldValue implements encoding.TextMarshaler
 	if marshaler, ok := fieldValue.(encoding.TextMarshaler); ok {
 		text, err := marshaler.MarshalText()


### PR DESCRIPTION
This pull request introduces a significant change to how certificate revocation reasons are handled throughout the codebase. The core update is making the `RevocationReason` field in the `Certificate` model nullable, which allows the system to distinguish between certificates that have never been revoked and those revoked for an "Unspecified" reason. The change is accompanied by a database migration and multiple code updates to handle the new nullable logic safely and correctly.

**Database and Model Changes:**

- **Make `RevocationReason` nullable in the `Certificate` model:**  
  The `RevocationReason` field is now a pointer (`*RevocationReason`), allowing `nil` to represent certificates that have never been revoked.

- **Add a migration to update existing data:**  
  A new migration sets `revocation_reason` to `NULL` for all certificates and CAs that are not revoked, and provides a down migration to restore the old behavior.
- **Register the new migration:**  
  The migration is registered in the migration registry.

**Code Logic Updates:**

- **Correctly handle nullable `RevocationReason` in status transitions and revocations:**  
  Updates in `ca.go` ensure that revocation reason checks and assignments account for the field possibly being `nil`, and explicitly set or clear the field as appropriate during status changes. [[1]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L953-R953) [[2]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L962-R966) [[3]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L1927-R1930) [[4]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L1937-R1946)
- **Update test and handler logic to handle nullable field:**  
  Tests and handlers now check for `nil` before comparing revocation reasons. [[1]](diffhunk://#diff-97e08c6496ab6e698f1ed7a9bc85cf87d68a8346c4760560e74bb62e5a12fd62L2785-R2786) [[2]](diffhunk://#diff-9ce3e6346b9ee4ca7958c42d6a80b19925b4e35fb2aff1c8d5847a697bbaa8d2L63-R63)

**Supporting Changes:**

- **Update logging and string conversion:**  
  Logging and string conversion functions now safely handle `nil` values for `RevocationReason`. [[1]](diffhunk://#diff-23d4c4af43f96397c134a3299f77ed31fc20dce780dda0b7f06c97af98e07533L871-R871) [[2]](diffhunk://#diff-6983a58d91be467ebb7ee6bafe8bd12ee030b0990f4ed3497f6409e5d51e483eL46-R49)
- **Update CRL and OCSP logic to handle nullable revocation reasons:**  
  Code that generates CRLs and OCSP responses now checks for `nil` before using the revocation reason, defaulting to zero if not set. [[1]](diffhunk://#diff-36e99b98f94ea1fcc02c595dd54ceba4b61b76aa865f369d6aa3a78fc1170056R231-R239) [[2]](diffhunk://#diff-36bebd47bb67d5fe75f50f887dd86c2d2879649dfa18788080596b3e8c3ac264L65-R70)

---

**Most important changes:**

**Database and Model:**
- Made `RevocationReason` a nullable pointer in the `Certificate` model, allowing `nil` to represent certificates that have never been revoked.
- Added a migration that sets `revocation_reason` to `NULL` for non-revoked certificates and CAs, with a down migration to restore the old behavior.
- Registered the new migration in the migration registry.

**Application Logic:**
- Updated status transition and revocation logic throughout the codebase to handle the nullable `RevocationReason` field, including correct assignment and comparison in `ca.go`. [[1]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L953-R953) [[2]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L962-R966) [[3]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L1927-R1930) [[4]](diffhunk://#diff-1386b19b4548f7f93edc168db32d342723d9df9418234395677633a565bfbce9L1937-R1946)
- Updated string conversion, logging, CRL, and OCSP logic to safely handle `nil` revocation reasons and default appropriately. [[1]](diffhunk://#diff-23d4c4af43f96397c134a3299f77ed31fc20dce780dda0b7f06c97af98e07533L871-R871) [[2]](diffhunk://#diff-6983a58d91be467ebb7ee6bafe8bd12ee030b0990f4ed3497f6409e5d51e483eL46-R49) [[3]](diffhunk://#diff-36e99b98f94ea1fcc02c595dd54ceba4b61b76aa865f369d6aa3a78fc1170056R231-R239) [[4]](diffhunk://#diff-36bebd47bb67d5fe75f50f887dd86c2d2879649dfa18788080596b3e8c3ac264L65-R70)