### PR TITLE
fix: add grace period to delta monitoring test to prevent race condition

### DIFF
--- a/backend/pkg/assemblers/tests/ca/ca_main_test.go
+++ b/backend/pkg/assemblers/tests/ca/ca_main_test.go
@@ -6565,7 +6565,7 @@ func TestCAsAdditionalDeltasMonitoring(t *testing.T) {
 					// test loop also ticks every 1s; at the exact second the threshold
 					// is first crossed both may run concurrently, causing the test to
 					// read triggered=false before the monitoring's DB write completes.
-					if time.Duration(definedDelta.Delta) > caExpFromNow+3*time.Second {
+					if time.Duration(definedDelta.Delta) > 3*time.Second+caExpFromNow {
 						if definedDelta.Triggered == false {
 							t.Fatalf("delta '%s' should've been triggered by now. CA expires in %ds and delta was defined with %ds", definedDelta.Name, int(caExpFromNow.Seconds()), int(time.Duration(definedDelta.Delta).Seconds()))
 						} else {

--- a/backend/pkg/assemblers/tests/ca/ca_main_test.go
+++ b/backend/pkg/assemblers/tests/ca/ca_main_test.go
@@ -6560,7 +6560,12 @@ func TestCAsAdditionalDeltasMonitoring(t *testing.T) {
 				var updatedCADeltas models.CAMetadataMonitoringExpirationDeltas
 				helpers.GetMetadataToStruct(updatedCA.Metadata, models.CAMetadataMonitoringExpirationDeltasKey, &updatedCADeltas)
 				for _, definedDelta := range updatedCADeltas {
-					if definedDelta.Delta > models.TimeDuration(caExpFromNow) {
+					// Add a 3-second grace period beyond the delta threshold before
+					// asserting the trigger. The monitoring job runs every 1s and the
+					// test loop also ticks every 1s; at the exact second the threshold
+					// is first crossed both may run concurrently, causing the test to
+					// read triggered=false before the monitoring's DB write completes.
+					if time.Duration(definedDelta.Delta) > caExpFromNow+3*time.Second {
 						if definedDelta.Triggered == false {
 							t.Fatalf("delta '%s' should've been triggered by now. CA expires in %ds and delta was defined with %ds", definedDelta.Name, int(caExpFromNow.Seconds()), int(time.Duration(definedDelta.Delta).Seconds()))
 						} else {


### PR DESCRIPTION
This pull request makes a small but important adjustment to a test in the CA monitoring logic. The change adds a 3-second grace period to the assertion that checks whether a delta should have been triggered. This helps prevent test flakiness caused by timing issues between the monitoring job and the test loop.

* Added a 3-second grace period to the delta trigger assertion in `TestCAsAdditionalDeltasMonitoring` to reduce test flakiness due to race conditions between the monitoring job and test execution (`backend/pkg/assemblers/tests/ca/ca_main_test.go`).