### PR TITLE
chore: update Go version from 1.24.x to 1.26.2 across all modules

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -308,7 +308,7 @@ Use `monolithic/cmd/development/main.go` for local development:
 ### Dockerfile Pattern
 Each service has a Dockerfile in `ci/` with multi-stage build:
 ```dockerfile
-# Build stage: golang:1.24.3-bullseye with workspace context
+# Build stage: golang:1.26.2-bookworm with workspace context
 COPY go.work go.work
 COPY {all modules} ...
 RUN go work vendor && go build -ldflags="-X main.version=..."

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -313,7 +313,7 @@ COPY go.work go.work
 COPY {all modules} ...
 RUN go work vendor && go build -ldflags="-X main.version=..."
 
-# Runtime stage: ubuntu:26.04 with non-root user (1000:1000)
+# Runtime stage: ubuntu:26.04 with non-root lamassu system user
 USER lamassu
 CMD ["/app/service"]
 ```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -313,7 +313,7 @@ COPY go.work go.work
 COPY {all modules} ...
 RUN go work vendor && go build -ldflags="-X main.version=..."
 
-# Runtime stage: ubuntu:20.04 with non-root user (1000:1000)
+# Runtime stage: ubuntu:26.04 with non-root user (1000:1000)
 USER lamassu
 CMD ["/app/service"]
 ```

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.24.3' # The Go version to download (if necessary) and use.
+          go-version: '^1.26.2' # The Go version to download (if necessary) and use.
           cache-dependency-path: "**/*.sum"
  
       - name: Install Dependencies
@@ -86,7 +86,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.24.3' # The Go version to download (if necessary) and use.
+          go-version: '^1.26.2' # The Go version to download (if necessary) and use.
           cache-dependency-path: "**/*.sum"
       
       - name: Install PKCS11 Proxy Dependencies
@@ -155,7 +155,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.24.3'
+          go-version: '^1.26.2'
           cache-dependency-path: "**/*.sum"
  
       - name: Install Dependencies
@@ -189,7 +189,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.24.3'
+          go-version: '^1.26.2'
           cache-dependency-path: "**/*.sum"
  
       - name: Install Dependencies

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -5,9 +5,23 @@ on:
 
 jobs:
   build_docker_image:
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
-        service: [kms, ca, devmanager, dmsmanager, va, alerts, aws-connector, lamassu-db-migration]
+        service:
+          [
+            kms,
+            ca,
+            devmanager,
+            dmsmanager,
+            va,
+            alerts,
+            aws-connector,
+            lamassu-db-migration,
+            monolithic,
+          ]
     name: ${{ matrix.service }} - Release docker images
     runs-on: ubuntu-latest
     environment: release

--- a/.github/workflows/release_finalize.yaml
+++ b/.github/workflows/release_finalize.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "^1.24.3"
+          go-version: "^1.26.2"
 
       - name: Bump versions in go.mod files
         run: |
@@ -170,7 +170,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "^1.24.3" # The Go version to download (if necessary) and use.
+          go-version: "^1.26.2" # The Go version to download (if necessary) and use.
       - name: Build release assets # This would actually build your project, using zip for an example artifact
         run: |
           go work vendor

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ There are 3 main repositories to consider when developing Lamassu
 
 ### Prerequisites
 
-- [Go 1.24+](https://go.dev/doc/install)
+- [Go 1.26+](https://go.dev/doc/install)
 - Docker (for running dependencies such as PostgreSQL, Vault, or message brokers)
 - Kubernetes cluster (optional, recommended for production deployments)
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/lamassuiot/lamassuiot/backend/v3
 
-go 1.24.0
+go 1.26.2
 
 
 

--- a/backend/pkg/test/subsystems/pest-test/dockerfile
+++ b/backend/pkg/test/subsystems/pest-test/dockerfile
@@ -1,4 +1,4 @@
-from ubuntu:20.04
+from ubuntu:26.04
 
 RUN apt-get update && \
     apt-get install -y \

--- a/ci/alerts.dockerfile
+++ b/ci/alerts.dockerfile
@@ -25,27 +25,12 @@ RUN now=$(TZ=GMT date +"%Y-%m-%dT%H:%M:%SZ")&& \
 
 FROM ubuntu:26.04
 
-ARG USERNAME=lamassu
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-
 RUN apt-get update && apt-get --no-install-recommends install -y ca-certificates \
     && apt-get clean
-RUN set -eux; \
-    if getent group "$USER_GID" >/dev/null; then \
-        existing_group="$(getent group "$USER_GID" | cut -d: -f1)"; \
-        [ "$existing_group" = "$USERNAME" ] || groupmod -n "$USERNAME" "$existing_group"; \
-    else \
-        groupadd --gid "$USER_GID" "$USERNAME"; \
-    fi; \
-    if getent passwd "$USER_UID" >/dev/null; then \
-        existing_user="$(getent passwd "$USER_UID" | cut -d: -f1)"; \
-        [ "$existing_user" = "$USERNAME" ] || usermod -l "$USERNAME" -d "/home/$USERNAME" -m "$existing_user"; \
-        usermod -g "$USER_GID" "$USERNAME"; \
-    else \
-        useradd --uid "$USER_UID" --gid "$USER_GID" -m "$USERNAME"; \
-    fi
 
-USER $USERNAME
+RUN groupadd --system lamassu && \
+    useradd --system --gid lamassu --no-create-home --shell /usr/sbin/nologin lamassu
+
 COPY --from=0 /app/alerts /
+USER lamassu
 CMD ["/alerts"]

--- a/ci/alerts.dockerfile
+++ b/ci/alerts.dockerfile
@@ -31,8 +31,20 @@ ARG USER_GID=$USER_UID
 
 RUN apt-get update && apt-get --no-install-recommends install -y ca-certificates \
     && apt-get clean
-RUN groupadd --gid "$USER_GID" "$USERNAME" \
-    && useradd --uid "$USER_UID" --gid "$USER_GID" -m "$USERNAME" 
+RUN set -eux; \
+    if getent group "$USER_GID" >/dev/null; then \
+        existing_group="$(getent group "$USER_GID" | cut -d: -f1)"; \
+        [ "$existing_group" = "$USERNAME" ] || groupmod -n "$USERNAME" "$existing_group"; \
+    else \
+        groupadd --gid "$USER_GID" "$USERNAME"; \
+    fi; \
+    if getent passwd "$USER_UID" >/dev/null; then \
+        existing_user="$(getent passwd "$USER_UID" | cut -d: -f1)"; \
+        [ "$existing_user" = "$USERNAME" ] || usermod -l "$USERNAME" -d "/home/$USERNAME" -m "$existing_user"; \
+        usermod -g "$USER_GID" "$USERNAME"; \
+    else \
+        useradd --uid "$USER_UID" --gid "$USER_GID" -m "$USERNAME"; \
+    fi
 
 USER $USERNAME
 COPY --from=0 /app/alerts /

--- a/ci/alerts.dockerfile
+++ b/ci/alerts.dockerfile
@@ -23,7 +23,7 @@ ENV GOSUMDB=off
 RUN now=$(TZ=GMT date +"%Y-%m-%dT%H:%M:%SZ")&& \
     go build -ldflags "-X main.version=$VERSION -X main.sha1ver=$SHA1VER -X main.buildTime=$now" -mod vendor -o alerts backend/cmd/alerts/main.go 
 
-FROM ubuntu:20.04
+FROM ubuntu:26.04
 
 ARG USERNAME=lamassu
 ARG USER_UID=1000

--- a/ci/alerts.dockerfile
+++ b/ci/alerts.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.3-bullseye
+FROM golang:1.26.2-bookworm
 WORKDIR /app
 
 COPY core core

--- a/ci/aws-connector.dockerfile
+++ b/ci/aws-connector.dockerfile
@@ -28,14 +28,7 @@ FROM ubuntu:26.04
 RUN apt-get update && apt-get --no-install-recommends install -y ca-certificates \
     && apt-get clean
 
-ARG USERNAME=lamassu
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
 
-RUN groupadd --gid "$USER_GID" "$USERNAME" \
-    && useradd --uid "$USER_UID" --gid "$USER_GID" -m "$USERNAME" 
-
-USER $USERNAME
 
 COPY --from=0 /app/aws /
 CMD ["/aws"]

--- a/ci/aws-connector.dockerfile
+++ b/ci/aws-connector.dockerfile
@@ -31,7 +31,6 @@ RUN apt-get update && apt-get --no-install-recommends install -y ca-certificates
 RUN groupadd --system lamassu && \
     useradd --system --gid lamassu --no-create-home --shell /usr/sbin/nologin lamassu
 
-
 COPY --from=0 /app/aws /
 USER lamassu
 CMD ["/aws"]

--- a/ci/aws-connector.dockerfile
+++ b/ci/aws-connector.dockerfile
@@ -28,7 +28,10 @@ FROM ubuntu:26.04
 RUN apt-get update && apt-get --no-install-recommends install -y ca-certificates \
     && apt-get clean
 
+RUN groupadd --system lamassu && \
+    useradd --system --gid lamassu --no-create-home --shell /usr/sbin/nologin lamassu
 
 
 COPY --from=0 /app/aws /
+USER lamassu
 CMD ["/aws"]

--- a/ci/aws-connector.dockerfile
+++ b/ci/aws-connector.dockerfile
@@ -24,7 +24,7 @@ RUN now=$(TZ=GMT date +"%Y-%m-%dT%H:%M:%SZ")&& \
     go build -ldflags "-X main.version=$VERSION -X main.sha1ver=$SHA1VER -X main.buildTime=$now" -mod vendor -o aws connectors/awsiot/cmd/main.go 
 
 # cannot use scratch becaue of the ca-certificates & hosntame -i command used by the service
-FROM ubuntu:20.04
+FROM ubuntu:26.04
 RUN apt-get update && apt-get --no-install-recommends install -y ca-certificates \
     && apt-get clean
 

--- a/ci/aws-connector.dockerfile
+++ b/ci/aws-connector.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.3-bullseye
+FROM golang:1.26.2-bookworm
 WORKDIR /app
 
 COPY core core

--- a/ci/ca.dockerfile
+++ b/ci/ca.dockerfile
@@ -25,14 +25,6 @@ RUN now=$(TZ=GMT date +"%Y-%m-%dT%H:%M:%SZ")&& \
 
 FROM ubuntu:26.04
 
-ARG USERNAME=lamassu
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-
-RUN groupadd --gid "$USER_GID" "$USERNAME" \
-    && useradd --uid "$USER_UID" --gid "$USER_GID" -m "$USERNAME" 
-
-USER $USERNAME
 
 COPY --from=0 /app/ca /
 CMD ["/ca"]

--- a/ci/ca.dockerfile
+++ b/ci/ca.dockerfile
@@ -25,6 +25,9 @@ RUN now=$(TZ=GMT date +"%Y-%m-%dT%H:%M:%SZ")&& \
 
 FROM ubuntu:26.04
 
+RUN groupadd --system lamassu && \
+    useradd --system --gid lamassu --no-create-home --shell /usr/sbin/nologin lamassu
 
 COPY --from=0 /app/ca /
+USER lamassu
 CMD ["/ca"]

--- a/ci/ca.dockerfile
+++ b/ci/ca.dockerfile
@@ -23,7 +23,7 @@ ENV GOSUMDB=off
 RUN now=$(TZ=GMT date +"%Y-%m-%dT%H:%M:%SZ")&& \
     go build -ldflags "-X main.version=$VERSION -X main.sha1ver=$SHA1VER -X main.buildTime=$now" -mod vendor -o ca backend/cmd/ca/main.go 
 
-FROM ubuntu:20.04
+FROM ubuntu:26.04
 
 ARG USERNAME=lamassu
 ARG USER_UID=1000

--- a/ci/ca.dockerfile
+++ b/ci/ca.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.3-bullseye
+FROM golang:1.26.2-bookworm
 WORKDIR /app
 
 COPY core core

--- a/ci/devmanager.dockerfile
+++ b/ci/devmanager.dockerfile
@@ -25,7 +25,10 @@ RUN now=$(TZ=GMT date +"%Y-%m-%dT%H:%M:%SZ")&& \
 
 FROM ubuntu:26.04
 
+RUN groupadd --system lamassu && \
+    useradd --system --gid lamassu --no-create-home --shell /usr/sbin/nologin lamassu
 
 
 COPY --from=0 /app/device-manager /
+USER lamassu
 CMD ["/device-manager"]

--- a/ci/devmanager.dockerfile
+++ b/ci/devmanager.dockerfile
@@ -23,7 +23,7 @@ ENV GOSUMDB=off
 RUN now=$(TZ=GMT date +"%Y-%m-%dT%H:%M:%SZ")&& \
     go build -ldflags "-X main.version=$VERSION -X main.sha1ver=$SHA1VER -X main.buildTime=$now" -mod vendor -o device-manager backend/cmd/device-manager/main.go 
 
-FROM ubuntu:20.04
+FROM ubuntu:26.04
 
 ARG USERNAME=lamassu
 ARG USER_UID=1000

--- a/ci/devmanager.dockerfile
+++ b/ci/devmanager.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.3-bullseye
+FROM golang:1.26.2-bookworm
 WORKDIR /app
 
 COPY core core

--- a/ci/devmanager.dockerfile
+++ b/ci/devmanager.dockerfile
@@ -25,14 +25,7 @@ RUN now=$(TZ=GMT date +"%Y-%m-%dT%H:%M:%SZ")&& \
 
 FROM ubuntu:26.04
 
-ARG USERNAME=lamassu
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
 
-RUN groupadd --gid "$USER_GID" "$USERNAME" \
-    && useradd --uid "$USER_UID" --gid "$USER_GID" -m "$USERNAME" 
-
-USER $USERNAME
 
 COPY --from=0 /app/device-manager /
 CMD ["/device-manager"]

--- a/ci/dmsmanager.dockerfile
+++ b/ci/dmsmanager.dockerfile
@@ -23,7 +23,7 @@ ENV GOSUMDB=off
 RUN now=$(TZ=GMT date +"%Y-%m-%dT%H:%M:%SZ")&& \
     go build -ldflags "-X main.version=$VERSION -X main.sha1ver=$SHA1VER -X main.buildTime=$now" -mod vendor -o dms-manager backend/cmd/dms-manager/main.go 
 
-FROM ubuntu:20.04
+FROM ubuntu:26.04
 
 ARG USERNAME=lamassu
 ARG USER_UID=1000

--- a/ci/dmsmanager.dockerfile
+++ b/ci/dmsmanager.dockerfile
@@ -25,14 +25,7 @@ RUN now=$(TZ=GMT date +"%Y-%m-%dT%H:%M:%SZ")&& \
 
 FROM ubuntu:26.04
 
-ARG USERNAME=lamassu
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
 
-RUN groupadd --gid "$USER_GID" "$USERNAME" \
-    && useradd --uid "$USER_UID" --gid "$USER_GID" -m "$USERNAME" 
-
-USER $USERNAME
 
 COPY --from=0 /app/dms-manager /
 CMD ["/dms-manager"]

--- a/ci/dmsmanager.dockerfile
+++ b/ci/dmsmanager.dockerfile
@@ -25,7 +25,10 @@ RUN now=$(TZ=GMT date +"%Y-%m-%dT%H:%M:%SZ")&& \
 
 FROM ubuntu:26.04
 
+RUN groupadd --system lamassu && \
+    useradd --system --gid lamassu --no-create-home --shell /usr/sbin/nologin lamassu
 
 
 COPY --from=0 /app/dms-manager /
+USER lamassu
 CMD ["/dms-manager"]

--- a/ci/dmsmanager.dockerfile
+++ b/ci/dmsmanager.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.3-bullseye
+FROM golang:1.26.2-bookworm
 WORKDIR /app
 
 COPY core core

--- a/ci/kms.dockerfile
+++ b/ci/kms.dockerfile
@@ -24,7 +24,7 @@ RUN now=$(TZ=GMT date +"%Y-%m-%dT%H:%M:%SZ")&& \
     go build -ldflags "-X main.version=$VERSION -X main.sha1ver=$SHA1VER -X main.buildTime=$now" -mod vendor -o kms backend/cmd/kms/main.go 
 
 # Alpine and scartch dont work for this image due to non corss compileable HSM library
-FROM ubuntu:20.04
+FROM ubuntu:26.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Dependencies for pkcs11-proxy and opensc for pkcs11-tool

--- a/ci/kms.dockerfile
+++ b/ci/kms.dockerfile
@@ -46,7 +46,9 @@ RUN apt-get remove -y git-core libc6-dev gcc make cmake libssl-dev libseccomp-de
     apt-get autoremove -y && \
     apt-get clean
 
-
+RUN groupadd --system lamassu && \
+    useradd --system --gid lamassu --no-create-home --shell /usr/sbin/nologin lamassu
 
 COPY --from=0 /app/kms /
+USER lamassu
 CMD ["/kms"]

--- a/ci/kms.dockerfile
+++ b/ci/kms.dockerfile
@@ -43,14 +43,7 @@ RUN apt-get remove -y git-core libc6-dev gcc make cmake libssl-dev libseccomp-de
     apt-get autoremove -y && \
     apt-get clean
 
-ARG USERNAME=lamassu
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
 
-RUN groupadd --gid "$USER_GID" "$USERNAME" \
-    && useradd --uid "$USER_UID" --gid "$USER_GID" -m "$USERNAME" 
-
-USER $USERNAME
 
 COPY --from=0 /app/kms /
 CMD ["/kms"]

--- a/ci/kms.dockerfile
+++ b/ci/kms.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.3-bullseye
+FROM golang:1.26.2-bookworm
 WORKDIR /app
 
 COPY core core

--- a/ci/kms.dockerfile
+++ b/ci/kms.dockerfile
@@ -32,9 +32,12 @@ RUN apt-get update && \
     apt-get --no-install-recommends install -y git-core libc6-dev gcc make cmake libssl-dev libseccomp-dev opensc ca-certificates && \
     apt-get clean
 
+# -DCMAKE_POLICY_VERSION_MINIMUM=3.5 lets CMake 4.x configure pkcs11-proxy's
+# old CMakeLists.txt, and -Wno-error=incompatible-pointer-types keeps GCC 15
+# pointer type diagnostics as warnings instead of build-stopping errors.
 RUN git clone https://github.com/SUNET/pkcs11-proxy && \
     cd pkcs11-proxy && \
-    cmake . && make && make install
+    cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_C_FLAGS="-Wno-error=incompatible-pointer-types" . && make && make install
 
 # Clean build artifacts
 RUN rm -rf /pkcs11-proxy

--- a/ci/lamassu-db-migration.dockerfile
+++ b/ci/lamassu-db-migration.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.3-bullseye AS builder
+FROM golang:1.26.2-bookworm AS builder
 WORKDIR /app
 
 COPY core core

--- a/ci/monolithic.dockerfile
+++ b/ci/monolithic.dockerfile
@@ -21,14 +21,7 @@ RUN go build -mod vendor -o monolithic monolithic/cmd/development/main.go
 
 FROM ubuntu:26.04
 
-ARG USERNAME=lamassu
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
 
-RUN groupadd --gid "$USER_GID" "$USERNAME" \
-    && useradd --uid "$USER_UID" --gid "$USER_GID" -m "$USERNAME" 
-
-USER $USERNAME
 
 COPY --from=0 /app/monolithic /
 CMD ["/monolithic"]

--- a/ci/monolithic.dockerfile
+++ b/ci/monolithic.dockerfile
@@ -21,7 +21,10 @@ RUN go build -mod vendor -o monolithic monolithic/cmd/development/main.go
 
 FROM ubuntu:26.04
 
+RUN groupadd --system lamassu && \
+    useradd --system --gid lamassu --no-create-home --shell /usr/sbin/nologin lamassu
 
 
 COPY --from=0 /app/monolithic /
+USER lamassu
 CMD ["/monolithic"]

--- a/ci/monolithic.dockerfile
+++ b/ci/monolithic.dockerfile
@@ -19,7 +19,7 @@ RUN go work vendor
 
 RUN go build -mod vendor -o monolithic monolithic/cmd/development/main.go 
 
-FROM ubuntu:20.04
+FROM ubuntu:26.04
 
 ARG USERNAME=lamassu
 ARG USER_UID=1000

--- a/ci/monolithic.dockerfile
+++ b/ci/monolithic.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.3-bullseye
+FROM golang:1.26.2-bookworm
 WORKDIR /app
 
 COPY core core

--- a/ci/va.dockerfile
+++ b/ci/va.dockerfile
@@ -23,7 +23,7 @@ ENV GOSUMDB=off
 RUN now=$(TZ=GMT date +"%Y-%m-%dT%H:%M:%SZ")&& \
     go build -ldflags "-X main.version=$VERSION -X main.sha1ver=$SHA1VER -X main.buildTime=$now" -mod vendor -o va backend/cmd/va/main.go 
 
-FROM ubuntu:20.04
+FROM ubuntu:26.04
 
 ARG USERNAME=lamassu
 ARG USER_UID=1000

--- a/ci/va.dockerfile
+++ b/ci/va.dockerfile
@@ -25,14 +25,7 @@ RUN now=$(TZ=GMT date +"%Y-%m-%dT%H:%M:%SZ")&& \
 
 FROM ubuntu:26.04
 
-ARG USERNAME=lamassu
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
 
-RUN groupadd --gid "$USER_GID" "$USERNAME" \
-    && useradd --uid "$USER_UID" --gid "$USER_GID" -m "$USERNAME" 
-
-USER $USERNAME
 
 COPY --from=0 /app/va /
 CMD ["/va"]

--- a/ci/va.dockerfile
+++ b/ci/va.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.3-bullseye
+FROM golang:1.26.2-bookworm
 WORKDIR /app
 
 COPY core core

--- a/ci/va.dockerfile
+++ b/ci/va.dockerfile
@@ -25,7 +25,10 @@ RUN now=$(TZ=GMT date +"%Y-%m-%dT%H:%M:%SZ")&& \
 
 FROM ubuntu:26.04
 
+RUN groupadd --system lamassu && \
+    useradd --system --gid lamassu --no-create-home --shell /usr/sbin/nologin lamassu
 
 
 COPY --from=0 /app/va /
+USER lamassu
 CMD ["/va"]

--- a/connectors/awsiot/go.mod
+++ b/connectors/awsiot/go.mod
@@ -1,6 +1,6 @@
 module github.com/lamassuiot/lamassuiot/connectors/awsiot/v3
 
-go 1.24.0
+go 1.26.2
 
 require (
 	github.com/ThreeDotsLabs/watermill v1.4.6

--- a/core/go.mod
+++ b/core/go.mod
@@ -1,6 +1,6 @@
 module github.com/lamassuiot/lamassuiot/core/v3
 
-go 1.24.0
+go 1.26.2
 
 require (
 	github.com/ThreeDotsLabs/watermill v1.4.6

--- a/engines/crypto/aws/go.mod
+++ b/engines/crypto/aws/go.mod
@@ -1,6 +1,6 @@
 module github.com/lamassuiot/lamassuiot/engines/crypto/aws/v3
 
-go 1.24.0
+go 1.26.2
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.36.3

--- a/engines/crypto/filesystem/go.mod
+++ b/engines/crypto/filesystem/go.mod
@@ -1,6 +1,6 @@
 module github.com/lamassuiot/lamassuiot/engines/crypto/filesystem/v3
 
-go 1.24.0
+go 1.26.2
 
 require (
 	github.com/sirupsen/logrus v1.9.3

--- a/engines/crypto/pkcs11/go.mod
+++ b/engines/crypto/pkcs11/go.mod
@@ -1,6 +1,6 @@
 module github.com/lamassuiot/lamassuiot/engines/crypto/pkcs11/v3
 
-go 1.24.0
+go 1.26.2
 
 require github.com/sirupsen/logrus v1.9.3
 

--- a/engines/crypto/software/go.mod
+++ b/engines/crypto/software/go.mod
@@ -1,6 +1,6 @@
 module github.com/lamassuiot/lamassuiot/engines/crypto/software/v3
 
-go 1.24.0
+go 1.26.2
 
 require (
 	github.com/lamassuiot/lamassuiot/sdk/v3 v3.7.0

--- a/engines/crypto/vaultkv2/go.mod
+++ b/engines/crypto/vaultkv2/go.mod
@@ -1,6 +1,6 @@
 module github.com/lamassuiot/lamassuiot/engines/crypto/vaultkv2/v3
 
-go 1.24.0
+go 1.26.2
 
 require (
 	github.com/hashicorp/vault/api v1.16.0

--- a/engines/eventbus/amqp/go.mod
+++ b/engines/eventbus/amqp/go.mod
@@ -1,6 +1,6 @@
 module github.com/lamassuiot/lamassuiot/engines/eventbus/amqp/v3
 
-go 1.24.0
+go 1.26.2
 
 require (
 	github.com/ThreeDotsLabs/watermill v1.4.6

--- a/engines/eventbus/aws/go.mod
+++ b/engines/eventbus/aws/go.mod
@@ -1,6 +1,6 @@
 module github.com/lamassuiot/lamassuiot/engines/eventbus/aws/v3
 
-go 1.24.0
+go 1.26.2
 
 require (
 	github.com/ThreeDotsLabs/watermill v1.4.6

--- a/engines/fs-storage/localfs/go.mod
+++ b/engines/fs-storage/localfs/go.mod
@@ -1,6 +1,6 @@
 module github.com/lamassuiot/lamassuiot/engines/fs-storage/localfs/v3
 
-go 1.24.0
+go 1.26.2
 
 require (
 	github.com/lamassuiot/lamassuiot/core/v3 v3.7.0

--- a/engines/fs-storage/s3/go.mod
+++ b/engines/fs-storage/s3/go.mod
@@ -1,6 +1,6 @@
 module github.com/lamassuiot/lamassuiot/engines/fs-storage/s3/v3
 
-go 1.24.0
+go 1.26.2
 
 require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.80.0

--- a/engines/storage/postgres/go.mod
+++ b/engines/storage/postgres/go.mod
@@ -1,6 +1,6 @@
 module github.com/lamassuiot/lamassuiot/engines/storage/postgres/v3
 
-go 1.25.0
+go 1.26.2
 
 require (
 	github.com/jakehl/goid v1.1.0

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.24.1
+go 1.26.2
 
-toolchain go1.24.7
+toolchain go1.26.2
 
 replace github.com/ugorji/go v1.1.4 => github.com/ugorji/go/codec v0.0.0-20190204201341-e444a5086c43
 

--- a/monolithic/go.mod
+++ b/monolithic/go.mod
@@ -1,6 +1,6 @@
 module github.com/lamassuiot/lamassuiot/monolithic/v3
 
-go 1.25.0
+go 1.26.2
 
 replace github.com/ugorji/go v1.1.4 => github.com/ugorji/go/codec v0.0.0-20190204201341-e444a5086c43
 

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,6 +1,6 @@
 module github.com/lamassuiot/lamassuiot/sdk/v3
 
-go 1.24.0
+go 1.26.2
 
 require (
 	github.com/lamassuiot/lamassuiot/core/v3 v3.7.0

--- a/shared/aws/go.mod
+++ b/shared/aws/go.mod
@@ -1,6 +1,6 @@
 module github.com/lamassuiot/lamassuiot/shared/aws/v3
 
-go 1.24.0
+go 1.26.2
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.36.3

--- a/shared/http/go.mod
+++ b/shared/http/go.mod
@@ -1,6 +1,6 @@
 module github.com/lamassuiot/lamassuiot/shared/http/v3
 
-go 1.24.0
+go 1.26.2
 
 require (
 	github.com/gin-gonic/gin v1.10.1

--- a/shared/subsystems/go.mod
+++ b/shared/subsystems/go.mod
@@ -1,6 +1,6 @@
 module github.com/lamassuiot/lamassuiot/shared/subsystems/v3
 
-go 1.24.0
+go 1.26.2
 
 require (
 	github.com/ory/dockertest/v3 v3.12.0


### PR DESCRIPTION
This pull request upgrades the Go version used throughout the project from 1.24.x to 1.26.2. The update affects Dockerfiles, GitHub Actions workflows, documentation, and all Go modules to ensure consistency and compatibility with the newer Go release.

**Go version upgrade across the codebase:**

* All `go.mod` files updated to specify Go version 1.26.2 (`backend/go.mod`, `core/go.mod`, `connectors/awsiot/go.mod`, `engines/crypto/aws/go.mod`, `engines/crypto/filesystem/go.mod`, `engines/crypto/pkcs11/go.mod`, `engines/crypto/software/go.mod`) [[1]](diffhunk://#diff-10e03f00c5bf8508d67e327c7a19879247498e8392ec699e9a05afcd36a8ed1fL3-R3) [[2]](diffhunk://#diff-c7cb5d4760a90b6db4c04b5e1a4a1f097bcc7237efa9dc15cc27621508c68a01L3-R3) [[3]](diffhunk://#diff-3dd50cde1274156259e4a812e297cd9bdccdae81fc01144ecfe921f69caf654fL3-R3) [[4]](diffhunk://#diff-6ebbce7a06a9e0a161df181367253b5e34d5ebdfaf7bfa45c8fc70abd9dbe955L3-R3) [[5]](diffhunk://#diff-90420938d8ffe3ace777e7d461773dedc3df778d24c8ec5f559bd394e45b4965L3-R3) [[6]](diffhunk://#diff-1c415e8487b27f924c151704d757f47a3eac1bb7fe4dc0ef61e373410a6c2b7dL3-R3) [[7]](diffhunk://#diff-819bf58fce92d199ec1b6e96136714d8d5103c3ef926446e37a9409f915548a1L3-R3)
* All Dockerfiles in `ci/` updated to use `golang:1.26.2-bookworm` as the base image instead of `golang:1.24.3-bullseye` (`ci/alerts.dockerfile`, `ci/aws-connector.dockerfile`, `ci/ca.dockerfile`, `ci/devmanager.dockerfile`, `ci/dmsmanager.dockerfile`, `ci/kms.dockerfile`, `ci/lamassu-db-migration.dockerfile`, `ci/monolithic.dockerfile`, `ci/va.dockerfile`) [[1]](diffhunk://#diff-d0a71437b0eeb4f449d855e28b0da54868343ed8313c134e58ca8b757c21c09fL1-R1) [[2]](diffhunk://#diff-5a72ab0cae831f20996698f13a7dd0a88bfbc3011b109db7c53bd14fb0d1d01aL1-R1) [[3]](diffhunk://#diff-bb414cc3927ed57a96e43efaf1c0395ba85af99c898ad93634241096108bfc74L1-R1) [[4]](diffhunk://#diff-0bf1190f283901f54428855fda264848bd73235b7859ed74241621f26b4970dcL1-R1) [[5]](diffhunk://#diff-67a90442af26873335b11e0c7d5c9de0d4729ee8bc060d969846ffe010874680L1-R1) [[6]](diffhunk://#diff-79d90cdd16144f72b452702227bad43178ed442c4a21fe09f4d880644866c598L1-R1) [[7]](diffhunk://#diff-05e5189fe0059b6eb7bfd4f2511a90bed6d1cbf42ab265732b09d02d6310723eL1-R1) [[8]](diffhunk://#diff-0e36f9201197554c993475474b746bcb3f02e649d8a1a3e7398b3d1f99855cd8L1-R1) [[9]](diffhunk://#diff-c86e2d0aaebb1f91b8d0f1f67f4706fafd69433ab1a84c30a631e99df7c62c23L1-R1)
* GitHub Actions workflows updated to use Go 1.26.2 for all setup steps in CI and release jobs (`.github/workflows/ci-test.yaml`, `.github/workflows/release_finalize.yaml`) [[1]](diffhunk://#diff-6fb9ca50cf826f8a0f541413a720a29c3f48a21a2bedf47faa244cf0486c9122L58-R58) [[2]](diffhunk://#diff-6fb9ca50cf826f8a0f541413a720a29c3f48a21a2bedf47faa244cf0486c9122L89-R89) [[3]](diffhunk://#diff-6fb9ca50cf826f8a0f541413a720a29c3f48a21a2bedf47faa244cf0486c9122L158-R158) [[4]](diffhunk://#diff-6fb9ca50cf826f8a0f541413a720a29c3f48a21a2bedf47faa244cf0486c9122L192-R192) [[5]](diffhunk://#diff-63d3b52a02115ceb6c7f267b450cad75430b889352daf8c8d16ec38aae43ab0cL68-R68) [[6]](diffhunk://#diff-63d3b52a02115ceb6c7f267b450cad75430b889352daf8c8d16ec38aae43ab0cL173-R173)

**Documentation updates:**

* Updated documentation to reference Go 1.26+ as the required version (`README.md`, `.github/copilot-instructions.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L47-R47) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L311-R311)

These changes ensure the project is aligned with the latest supported Go version, taking advantage of new features and security updates.