### PR TITLE
feat: add CA-to-KMS key migration tool

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -20,6 +20,7 @@ jobs:
             alerts,
             aws-connector,
             lamassu-db-migration,
+            ca-to-kms-migration,
             monolithic,
           ]
     name: ${{ matrix.service }} - Release docker images
@@ -30,12 +31,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
-          
+
       - run: |
           echo "SHA1VER=dev-$(git rev-parse HEAD)" >> $GITHUB_ENV
-          
+
       - name: Login to Github Registry
-        uses: docker/login-action@v3 
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/release_finalize.yaml
+++ b/.github/workflows/release_finalize.yaml
@@ -247,6 +247,7 @@ jobs:
             alerts,
             aws-connector,
             lamassu-db-migration,
+            ca-to-kms-migration,
           ]
     name: ${{ matrix.service }} - Release docker images
     runs-on: ubuntu-latest

--- a/backend/cmd/ca-to-kms-migration/README.md
+++ b/backend/cmd/ca-to-kms-migration/README.md
@@ -148,7 +148,7 @@ On the next `helm upgrade` the Job will run automatically before any Deployment 
 ## Running Tests
 
 ```bash
-go test ./backend/cmd/ca-to-kms-migration/...
+go test ./backend/pkg/migration/catokms/...
 ```
 
 The tests use in-memory mock storage implementations and require no external dependencies (no Docker, no database).

--- a/backend/cmd/ca-to-kms-migration/README.md
+++ b/backend/cmd/ca-to-kms-migration/README.md
@@ -28,27 +28,24 @@ The operation is **idempotent**: if a key already exists in the KMS database it 
 
 ## Configuration
 
-The tool uses the same config-loading mechanism as all other Lamassu services. Point the `LAMASSU_CONFIG_FILE` environment variable at a YAML file with the following structure:
+The tool reuses the standard KMS service config layout. Point the `LAMASSU_CONFIG_FILE` environment variable at a YAML file:
 
 ```yaml
-log_level: info   # debug | info | warn | error
+logs:
+  level: info   # debug | info | warn | error
 
-ca_storage:
+storage:
+  log_level: info
   provider: postgres
-  hostname: <ca-db-host>
-  port: 5432
-  username: <user>
-  password: <password>
-
-kms_storage:
-  provider: postgres
-  hostname: <kms-db-host>
+  hostname: <db-host>
   port: 5432
   username: <user>
   password: <password>
 ```
 
-> **Note**: The `hostname` field (not `host`) must be used. The database name is fixed internally: the CA engine always connects to the `ca` database and the KMS engine always connects to the `kms` database.
+The CA and KMS databases are assumed to live on the same Postgres server. The tool connects to each database automatically — `ca` for reading CA certificates and `kms` for writing key records — so only one connection config is needed.
+
+> **Note**: The `hostname` field (not `host`) must be used.
 
 ## Usage
 

--- a/backend/cmd/ca-to-kms-migration/README.md
+++ b/backend/cmd/ca-to-kms-migration/README.md
@@ -1,0 +1,154 @@
+# CA-to-KMS Key Migration Tool
+
+## Motivation
+
+The KMS service was introduced as an independent service in version 3.7.0 of Lamassu IoT. In earlier versions, private keys were managed exclusively by the crypto engine (filesystem, PKCS#11, Vault KV2, AWS KMS, etc.) and there was no separate KMS database table to track them.
+
+When upgrading from an older installation, each CA certificate of type `MANAGED` or `IMPORTED_WITH_KEY` has a private key stored in the crypto engine under its `subject_key_id`. That key has no corresponding row in the `kms_keys` table of the KMS database. As a result:
+
+- The KMS service is unaware of those keys and cannot manage, list, or bind them.
+- The `lamassu.io/kms/binded-resources` metadata — which records which CA certificates are bound to a given key — is absent.
+
+This tool performs a one-shot, idempotent migration that reads the CA database and writes the missing records into the KMS database.
+
+## What It Does
+
+1. Connects to the CA Postgres database (read-only).
+2. Scans all CA certificates of type `MANAGED` and `IMPORTED_WITH_KEY`.
+3. Groups certificates that share the same public key (same `subject_key_id`).
+4. For each unique key not already present in the KMS database:
+   - Derives `algorithm`, `size`, and `public_key` from the X.509 certificate stored in the CA database.
+   - Sets `has_private_key = true` and `engine_id` from the certificate record.
+   - Populates `metadata["lamassu.io/kms/binded-resources"]` with the serial numbers of all CA certificates that use the key.
+5. Inserts the record into the KMS `kms_keys` table.
+
+Certificates of type `IMPORTED_WITHOUT_KEY` are skipped because there is no private key to register.
+
+The operation is **idempotent**: if a key already exists in the KMS database it is skipped, so the tool can be run multiple times safely.
+
+## Configuration
+
+The tool uses the same config-loading mechanism as all other Lamassu services. Point the `LAMASSU_CONFIG_FILE` environment variable at a YAML file with the following structure:
+
+```yaml
+log_level: info   # debug | info | warn | error
+
+ca_storage:
+  provider: postgres
+  hostname: <ca-db-host>
+  port: 5432
+  username: <user>
+  password: <password>
+
+kms_storage:
+  provider: postgres
+  hostname: <kms-db-host>
+  port: 5432
+  username: <user>
+  password: <password>
+```
+
+> **Note**: The `hostname` field (not `host`) must be used. The database name is fixed internally: the CA engine always connects to the `ca` database and the KMS engine always connects to the `kms` database.
+
+## Usage
+
+### Build
+
+```bash
+go build -o ca-to-kms-migration ./backend/cmd/ca-to-kms-migration/
+```
+
+### Dry run (no writes)
+
+Run with `--dry-run` first to inspect what would be migrated without modifying the KMS database:
+
+```bash
+LAMASSU_CONFIG_FILE=migrate.yaml ./ca-to-kms-migration --dry-run
+```
+
+The output reports how many keys *would* be inserted and how many are already present.
+
+### Actual migration
+
+```bash
+LAMASSU_CONFIG_FILE=migrate.yaml ./ca-to-kms-migration
+```
+
+The tool exits with code `0` on success and `1` if any key insertion failed, making it suitable for use as a Helm `pre-upgrade` hook.
+
+### Example output
+
+```
+[INFO] found 3 unique keys across CA certificates
+[INFO] key a3f1... — engine=filesystem-1 alg=RSA bits=2048 binds=1
+[INFO] key 9c2b... — engine=filesystem-1 alg=ECDSA bits=256 binds=2
+[INFO] key 77de... — engine=pkcs11-slot-0 alg=RSA bits=4096 binds=1
+[INFO] migration complete: inserted=3 skipped=0 failed=0
+```
+
+## Running as a Helm Pre-Upgrade Hook
+
+The recommended way to run this migration in a Kubernetes environment is as a Helm `pre-upgrade` hook Job. The Job runs before Helm replaces any existing resources, ensuring the KMS database is populated before the new version of the services starts.
+
+Create a `templates/ca-to-kms-migration-job.yaml` in your Helm chart:
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "lamassu.fullname" . }}-ca-to-kms-migration
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-10"        # run before other pre-upgrade hooks
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      name: ca-to-kms-migration
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: ca-to-kms-migration
+          image: "{{ .Values.migration.image.repository }}:{{ .Values.migration.image.tag }}"
+          imagePullPolicy: {{ .Values.migration.image.pullPolicy | default "IfNotPresent" }}
+          env:
+            - name: LAMASSU_CONFIG_FILE
+              value: /etc/lamassu/migrate.yaml
+          volumeMounts:
+            - name: migration-config
+              mountPath: /etc/lamassu
+              readOnly: true
+      volumes:
+        - name: migration-config
+          secret:
+            secretName: {{ include "lamassu.fullname" . }}-ca-to-kms-migration-config
+```
+
+Store the config file as a Kubernetes Secret (keep the password out of plain-text values files):
+
+```bash
+kubectl create secret generic lamassu-ca-to-kms-migration-config \
+  --from-file=migrate.yaml=./migrate.yaml \
+  --namespace <your-namespace>
+```
+
+Relevant `values.yaml` additions:
+
+```yaml
+migration:
+  image:
+    repository: your-registry/ca-to-kms-migration
+    tag: latest
+    pullPolicy: IfNotPresent
+```
+
+On the next `helm upgrade` the Job will run automatically before any Deployment rollout. If the Job fails (exit code 1), Helm will mark the upgrade as failed and roll back.
+
+## Running Tests
+
+```bash
+go test ./backend/cmd/ca-to-kms-migration/...
+```
+
+The tests use in-memory mock storage implementations and require no external dependencies (no Docker, no database).

--- a/backend/cmd/ca-to-kms-migration/main.go
+++ b/backend/cmd/ca-to-kms-migration/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"os"
 
+	bconfig "github.com/lamassuiot/lamassuiot/backend/v3/pkg/config"
 	"github.com/lamassuiot/lamassuiot/backend/v3/pkg/migration/catokms"
 	cconfig "github.com/lamassuiot/lamassuiot/core/v3/pkg/config"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/helpers"
@@ -17,24 +18,24 @@ func main() {
 
 	log.SetFormatter(helpers.LogFormatter)
 
-	conf, err := cconfig.LoadConfig[catokms.Config](nil)
+	conf, err := cconfig.LoadConfig[bconfig.KMSConfig](nil)
 	if err != nil {
 		log.Fatalf("could not load config: %s", err)
 	}
 
-	lvl, err := log.ParseLevel(string(conf.LogLevel))
+	lvl, err := log.ParseLevel(string(conf.Logs.Level))
 	if err != nil {
 		log.Warn("unknown log level; defaulting to 'info'")
 		lvl = log.InfoLevel
 	}
 	log.SetLevel(lvl)
 
-	logger := helpers.SetupLogger(conf.LogLevel, "Migration", "ca-to-kms")
+	logger := helpers.SetupLogger(conf.Logs.Level, "Migration", "ca-to-kms")
 	if *dryRun {
 		logger.Info("running in DRY-RUN mode — NO WRITES will occur")
 	}
 
-	result, err := catokms.MigrateWithConfig(context.Background(), logger, conf.CAStorage, conf.KMSStorage, *dryRun)
+	result, err := catokms.MigrateWithConfig(context.Background(), logger, conf.Storage, *dryRun)
 	if err != nil {
 		log.Fatalf("migration failed: %s", err)
 	}

--- a/backend/cmd/ca-to-kms-migration/main.go
+++ b/backend/cmd/ca-to-kms-migration/main.go
@@ -2,28 +2,14 @@ package main
 
 import (
 	"context"
-	"crypto/x509"
-	"encoding/base64"
-	"encoding/pem"
 	"flag"
-	"fmt"
 	"os"
-	"time"
 
-	storagebuilder "github.com/lamassuiot/lamassuiot/backend/v3/pkg/storage/builder"
+	"github.com/lamassuiot/lamassuiot/backend/v3/pkg/migration/catokms"
 	cconfig "github.com/lamassuiot/lamassuiot/core/v3/pkg/config"
-	"github.com/lamassuiot/lamassuiot/core/v3/pkg/engines/storage"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/helpers"
-	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
 	log "github.com/sirupsen/logrus"
 )
-
-// MigrationConfig holds the storage configurations for both the CA and KMS databases.
-type MigrationConfig struct {
-	LogLevel   cconfig.LogLevel               `mapstructure:"log_level"`
-	CAStorage  cconfig.PluggableStorageEngine `mapstructure:"ca_storage"`
-	KMSStorage cconfig.PluggableStorageEngine `mapstructure:"kms_storage"`
-}
 
 func main() {
 	dryRun := flag.Bool("dry-run", false, "scan and report without writing to KMS storage")
@@ -31,7 +17,7 @@ func main() {
 
 	log.SetFormatter(helpers.LogFormatter)
 
-	conf, err := cconfig.LoadConfig[MigrationConfig](nil)
+	conf, err := cconfig.LoadConfig[catokms.Config](nil)
 	if err != nil {
 		log.Fatalf("could not load config: %s", err)
 	}
@@ -48,170 +34,11 @@ func main() {
 		logger.Info("running in DRY-RUN mode — NO WRITES will occur")
 	}
 
-	ctx := context.Background()
-
-	// Build CA storage (read-only access required).
-	caEngine, err := storagebuilder.BuildStorageEngine(logger.WithField("db", "ca"), conf.CAStorage)
+	result, err := catokms.MigrateWithConfig(context.Background(), logger, conf.CAStorage, conf.KMSStorage, *dryRun)
 	if err != nil {
-		log.Fatalf("could not build CA storage engine: %s", err)
+		log.Fatalf("migration failed: %s", err)
 	}
-	caStorage, err := caEngine.GetCAStorage()
-	if err != nil {
-		log.Fatalf("could not get CA storage: %s", err)
-	}
-
-	// Build KMS storage (read / write).
-	kmsEngine, err := storagebuilder.BuildStorageEngine(logger.WithField("db", "kms"), conf.KMSStorage)
-	if err != nil {
-		log.Fatalf("could not build KMS storage engine: %s", err)
-	}
-	kmsStorage, err := kmsEngine.GetKMSStorage()
-	if err != nil {
-		log.Fatalf("could not get KMS storage: %s", err)
-	}
-
-	keyMap, err := collectKeys(ctx, logger, caStorage)
-	if err != nil {
-		log.Fatalf("could not collect keys from CA storage: %s", err)
-	}
-	logger.Infof("found %d unique keys across CA certificates", len(keyMap))
-
-	_, _, failed := runMigration(ctx, logger, kmsStorage, keyMap, *dryRun)
-	if failed > 0 {
+	if result.Failed > 0 {
 		os.Exit(1)
 	}
-}
-
-// keyEntry accumulates all data needed to build a models.Key record.
-type keyEntry struct {
-	engineID   string
-	keyID      string // subject_key_id == KMS key_id (SHA-256 hex of PKIX public key)
-	algorithm  string
-	size       int
-	publicKey  string // base64(PEM "PUBLIC KEY")
-	name       string // common name of first CA cert using this key
-	creationTS time.Time
-	serials    []string // serial numbers of all CA certs using this key
-}
-
-// collectKeys scans MANAGED and IMPORTED_WITH_KEY CA certs and groups them by key.
-func collectKeys(ctx context.Context, logger *log.Entry, caStorage storage.CACertificatesRepo) (map[string]*keyEntry, error) {
-	keyMap := map[string]*keyEntry{}
-
-	collect := func(ca models.CACertificate) {
-		cert := ca.Certificate
-		if cert.EngineID == "" || cert.SubjectKeyID == "" {
-			logger.Warnf("skipping CA %s: missing engine_id or subject_key_id", ca.ID)
-			return
-		}
-		if cert.Certificate == nil {
-			logger.Warnf("skipping CA %s: nil certificate blob", ca.ID)
-			return
-		}
-
-		x509Cert := (*x509.Certificate)(cert.Certificate)
-		pubKeyDER, err := x509.MarshalPKIXPublicKey(x509Cert.PublicKey)
-		if err != nil {
-			logger.Errorf("could not marshal public key for CA %s: %s", ca.ID, err)
-			return
-		}
-		pubKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubKeyDER})
-		pubKeyB64 := base64.StdEncoding.EncodeToString(pubKeyPEM)
-
-		keyID := cert.SubjectKeyID
-		if entry, ok := keyMap[keyID]; ok {
-			entry.serials = append(entry.serials, cert.SerialNumber)
-		} else {
-			keyMap[keyID] = &keyEntry{
-				engineID:   cert.EngineID,
-				keyID:      keyID,
-				algorithm:  cert.KeyMetadata.Type.String(),
-				size:       cert.KeyMetadata.Bits,
-				publicKey:  pubKeyB64,
-				name:       cert.Subject.CommonName,
-				creationTS: cert.ValidFrom,
-				serials:    []string{cert.SerialNumber},
-			}
-		}
-	}
-
-	for _, certType := range []models.CertificateType{
-		models.CertificateTypeManaged,
-		models.CertificateTypeImportedWithKey,
-	} {
-		_, err := caStorage.SelectByType(ctx, certType, storage.StorageListRequest[models.CACertificate]{
-			ExhaustiveRun: true,
-			ApplyFunc:     collect,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("could not list CA certs of type %s: %w", certType, err)
-		}
-	}
-
-	return keyMap, nil
-}
-
-// runMigration inserts missing keys into KMS storage (or logs what it would do in dry-run mode).
-// It returns the number of inserted (or would-insert in dry-run), skipped, and failed keys.
-func runMigration(ctx context.Context, logger *log.Entry, kmsStorage storage.KMSKeysRepo, keyMap map[string]*keyEntry, dryRun bool) (inserted, skipped, failed int) {
-
-	for _, entry := range keyMap {
-		exists, _, err := kmsStorage.SelectExistsByKeyID(ctx, entry.keyID)
-		if err != nil {
-			logger.Errorf("could not check key %s in KMS storage: %s", entry.keyID, err)
-			failed++
-			continue
-		}
-		if exists {
-			logger.Debugf("key %s already in KMS storage — skipping", entry.keyID)
-			skipped++
-			continue
-		}
-
-		bindedResources := make([]models.KMSBindResource, len(entry.serials))
-		for i, sn := range entry.serials {
-			bindedResources[i] = models.KMSBindResource{
-				ResourceType: "certificate",
-				ResourceID:   sn,
-			}
-		}
-
-		key := &models.Key{
-			KeyID:         entry.keyID,
-			EngineID:      entry.engineID,
-			Name:          entry.name,
-			Aliases:       []string{},
-			HasPrivateKey: true,
-			Algorithm:     entry.algorithm,
-			Size:          entry.size,
-			PublicKey:     entry.publicKey,
-			CreationTS:    entry.creationTS,
-			Tags:          []string{},
-			Metadata: map[string]any{
-				models.KMSBindResourceKey: bindedResources,
-			},
-		}
-
-		logger.Infof("key %s — engine=%s alg=%s bits=%d binds=%d",
-			entry.keyID, entry.engineID, entry.algorithm, entry.size, len(entry.serials))
-
-		if dryRun {
-			inserted++ // count as "would insert"
-			continue
-		}
-
-		if _, err = kmsStorage.Insert(ctx, key); err != nil {
-			logger.Errorf("could not insert key %s: %s", entry.keyID, err)
-			failed++
-			continue
-		}
-		inserted++
-	}
-
-	action := "inserted"
-	if dryRun {
-		action = "would insert"
-	}
-	logger.Infof("migration complete: %s=%d skipped=%d failed=%d", action, inserted, skipped, failed)
-	return
 }

--- a/backend/cmd/ca-to-kms-migration/main.go
+++ b/backend/cmd/ca-to-kms-migration/main.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"flag"
+	"fmt"
 	"os"
 	"time"
 
@@ -44,7 +45,7 @@ func main() {
 
 	logger := helpers.SetupLogger(conf.LogLevel, "Migration", "ca-to-kms")
 	if *dryRun {
-		logger.Info("running in dry-run mode — no writes will occur")
+		logger.Info("running in DRY-RUN mode — NO WRITES will occur")
 	}
 
 	ctx := context.Background()
@@ -69,10 +70,16 @@ func main() {
 		log.Fatalf("could not get KMS storage: %s", err)
 	}
 
-	keyMap := collectKeys(ctx, logger, caStorage)
+	keyMap, err := collectKeys(ctx, logger, caStorage)
+	if err != nil {
+		log.Fatalf("could not collect keys from CA storage: %s", err)
+	}
 	logger.Infof("found %d unique keys across CA certificates", len(keyMap))
 
-	runMigration(ctx, logger, kmsStorage, keyMap, *dryRun)
+	_, _, failed := runMigration(ctx, logger, kmsStorage, keyMap, *dryRun)
+	if failed > 0 {
+		os.Exit(1)
+	}
 }
 
 // keyEntry accumulates all data needed to build a models.Key record.
@@ -88,7 +95,7 @@ type keyEntry struct {
 }
 
 // collectKeys scans MANAGED and IMPORTED_WITH_KEY CA certs and groups them by key.
-func collectKeys(ctx context.Context, logger *log.Entry, caStorage storage.CACertificatesRepo) map[string]*keyEntry {
+func collectKeys(ctx context.Context, logger *log.Entry, caStorage storage.CACertificatesRepo) (map[string]*keyEntry, error) {
 	keyMap := map[string]*keyEntry{}
 
 	collect := func(ca models.CACertificate) {
@@ -137,16 +144,16 @@ func collectKeys(ctx context.Context, logger *log.Entry, caStorage storage.CACer
 			ApplyFunc:     collect,
 		})
 		if err != nil {
-			log.Fatalf("could not list CA certs of type %s: %s", certType, err)
+			return nil, fmt.Errorf("could not list CA certs of type %s: %w", certType, err)
 		}
 	}
 
-	return keyMap
+	return keyMap, nil
 }
 
 // runMigration inserts missing keys into KMS storage (or logs what it would do in dry-run mode).
-func runMigration(ctx context.Context, logger *log.Entry, kmsStorage storage.KMSKeysRepo, keyMap map[string]*keyEntry, dryRun bool) {
-	inserted, skipped, failed := 0, 0, 0
+// It returns the number of inserted (or would-insert in dry-run), skipped, and failed keys.
+func runMigration(ctx context.Context, logger *log.Entry, kmsStorage storage.KMSKeysRepo, keyMap map[string]*keyEntry, dryRun bool) (inserted, skipped, failed int) {
 
 	for _, entry := range keyMap {
 		exists, _, err := kmsStorage.SelectExistsByKeyID(ctx, entry.keyID)
@@ -206,8 +213,5 @@ func runMigration(ctx context.Context, logger *log.Entry, kmsStorage storage.KMS
 		action = "would insert"
 	}
 	logger.Infof("migration complete: %s=%d skipped=%d failed=%d", action, inserted, skipped, failed)
-
-	if failed > 0 {
-		os.Exit(1)
-	}
+	return
 }

--- a/backend/cmd/ca-to-kms-migration/main.go
+++ b/backend/cmd/ca-to-kms-migration/main.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"flag"
+	"os"
+	"time"
+
+	storagebuilder "github.com/lamassuiot/lamassuiot/backend/v3/pkg/storage/builder"
+	cconfig "github.com/lamassuiot/lamassuiot/core/v3/pkg/config"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/engines/storage"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/helpers"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
+	log "github.com/sirupsen/logrus"
+)
+
+// MigrationConfig holds the storage configurations for both the CA and KMS databases.
+type MigrationConfig struct {
+	LogLevel   cconfig.LogLevel               `mapstructure:"log_level"`
+	CAStorage  cconfig.PluggableStorageEngine `mapstructure:"ca_storage"`
+	KMSStorage cconfig.PluggableStorageEngine `mapstructure:"kms_storage"`
+}
+
+func main() {
+	dryRun := flag.Bool("dry-run", false, "scan and report without writing to KMS storage")
+	flag.Parse()
+
+	log.SetFormatter(helpers.LogFormatter)
+
+	conf, err := cconfig.LoadConfig[MigrationConfig](nil)
+	if err != nil {
+		log.Fatalf("could not load config: %s", err)
+	}
+
+	lvl, err := log.ParseLevel(string(conf.LogLevel))
+	if err != nil {
+		log.Warn("unknown log level; defaulting to 'info'")
+		lvl = log.InfoLevel
+	}
+	log.SetLevel(lvl)
+
+	logger := helpers.SetupLogger(conf.LogLevel, "Migration", "ca-to-kms")
+	if *dryRun {
+		logger.Info("running in dry-run mode — no writes will occur")
+	}
+
+	ctx := context.Background()
+
+	// Build CA storage (read-only access required).
+	caEngine, err := storagebuilder.BuildStorageEngine(logger.WithField("db", "ca"), conf.CAStorage)
+	if err != nil {
+		log.Fatalf("could not build CA storage engine: %s", err)
+	}
+	caStorage, err := caEngine.GetCAStorage()
+	if err != nil {
+		log.Fatalf("could not get CA storage: %s", err)
+	}
+
+	// Build KMS storage (read / write).
+	kmsEngine, err := storagebuilder.BuildStorageEngine(logger.WithField("db", "kms"), conf.KMSStorage)
+	if err != nil {
+		log.Fatalf("could not build KMS storage engine: %s", err)
+	}
+	kmsStorage, err := kmsEngine.GetKMSStorage()
+	if err != nil {
+		log.Fatalf("could not get KMS storage: %s", err)
+	}
+
+	keyMap := collectKeys(ctx, logger, caStorage)
+	logger.Infof("found %d unique keys across CA certificates", len(keyMap))
+
+	runMigration(ctx, logger, kmsStorage, keyMap, *dryRun)
+}
+
+// keyEntry accumulates all data needed to build a models.Key record.
+type keyEntry struct {
+	engineID   string
+	keyID      string // subject_key_id == KMS key_id (SHA-256 hex of PKIX public key)
+	algorithm  string
+	size       int
+	publicKey  string // base64(PEM "PUBLIC KEY")
+	name       string // common name of first CA cert using this key
+	creationTS time.Time
+	serials    []string // serial numbers of all CA certs using this key
+}
+
+// collectKeys scans MANAGED and IMPORTED_WITH_KEY CA certs and groups them by key.
+func collectKeys(ctx context.Context, logger *log.Entry, caStorage storage.CACertificatesRepo) map[string]*keyEntry {
+	keyMap := map[string]*keyEntry{}
+
+	collect := func(ca models.CACertificate) {
+		cert := ca.Certificate
+		if cert.EngineID == "" || cert.SubjectKeyID == "" {
+			logger.Warnf("skipping CA %s: missing engine_id or subject_key_id", ca.ID)
+			return
+		}
+		if cert.Certificate == nil {
+			logger.Warnf("skipping CA %s: nil certificate blob", ca.ID)
+			return
+		}
+
+		x509Cert := (*x509.Certificate)(cert.Certificate)
+		pubKeyDER, err := x509.MarshalPKIXPublicKey(x509Cert.PublicKey)
+		if err != nil {
+			logger.Errorf("could not marshal public key for CA %s: %s", ca.ID, err)
+			return
+		}
+		pubKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubKeyDER})
+		pubKeyB64 := base64.StdEncoding.EncodeToString(pubKeyPEM)
+
+		keyID := cert.SubjectKeyID
+		if entry, ok := keyMap[keyID]; ok {
+			entry.serials = append(entry.serials, cert.SerialNumber)
+		} else {
+			keyMap[keyID] = &keyEntry{
+				engineID:   cert.EngineID,
+				keyID:      keyID,
+				algorithm:  cert.KeyMetadata.Type.String(),
+				size:       cert.KeyMetadata.Bits,
+				publicKey:  pubKeyB64,
+				name:       cert.Subject.CommonName,
+				creationTS: cert.ValidFrom,
+				serials:    []string{cert.SerialNumber},
+			}
+		}
+	}
+
+	for _, certType := range []models.CertificateType{
+		models.CertificateTypeManaged,
+		models.CertificateTypeImportedWithKey,
+	} {
+		_, err := caStorage.SelectByType(ctx, certType, storage.StorageListRequest[models.CACertificate]{
+			ExhaustiveRun: true,
+			ApplyFunc:     collect,
+		})
+		if err != nil {
+			log.Fatalf("could not list CA certs of type %s: %s", certType, err)
+		}
+	}
+
+	return keyMap
+}
+
+// runMigration inserts missing keys into KMS storage (or logs what it would do in dry-run mode).
+func runMigration(ctx context.Context, logger *log.Entry, kmsStorage storage.KMSKeysRepo, keyMap map[string]*keyEntry, dryRun bool) {
+	inserted, skipped, failed := 0, 0, 0
+
+	for _, entry := range keyMap {
+		exists, _, err := kmsStorage.SelectExistsByKeyID(ctx, entry.keyID)
+		if err != nil {
+			logger.Errorf("could not check key %s in KMS storage: %s", entry.keyID, err)
+			failed++
+			continue
+		}
+		if exists {
+			logger.Debugf("key %s already in KMS storage — skipping", entry.keyID)
+			skipped++
+			continue
+		}
+
+		bindedResources := make([]models.KMSBindResource, len(entry.serials))
+		for i, sn := range entry.serials {
+			bindedResources[i] = models.KMSBindResource{
+				ResourceType: "certificate",
+				ResourceID:   sn,
+			}
+		}
+
+		key := &models.Key{
+			KeyID:         entry.keyID,
+			EngineID:      entry.engineID,
+			Name:          entry.name,
+			Aliases:       []string{},
+			HasPrivateKey: true,
+			Algorithm:     entry.algorithm,
+			Size:          entry.size,
+			PublicKey:     entry.publicKey,
+			CreationTS:    entry.creationTS,
+			Tags:          []string{},
+			Metadata: map[string]any{
+				models.KMSBindResourceKey: bindedResources,
+			},
+		}
+
+		logger.Infof("key %s — engine=%s alg=%s bits=%d binds=%d",
+			entry.keyID, entry.engineID, entry.algorithm, entry.size, len(entry.serials))
+
+		if dryRun {
+			inserted++ // count as "would insert"
+			continue
+		}
+
+		if _, err = kmsStorage.Insert(ctx, key); err != nil {
+			logger.Errorf("could not insert key %s: %s", entry.keyID, err)
+			failed++
+			continue
+		}
+		inserted++
+	}
+
+	action := "inserted"
+	if dryRun {
+		action = "would insert"
+	}
+	logger.Infof("migration complete: %s=%d skipped=%d failed=%d", action, inserted, skipped, failed)
+
+	if failed > 0 {
+		os.Exit(1)
+	}
+}

--- a/backend/cmd/ca-to-kms-migration/main_test.go
+++ b/backend/cmd/ca-to-kms-migration/main_test.go
@@ -1,0 +1,698 @@
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/engines/storage"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/resources"
+	log "github.com/sirupsen/logrus"
+)
+
+// ---------------------------------------------------------------------------
+// Package-level signing key (generated once; shared across all test certs)
+// ---------------------------------------------------------------------------
+
+var (
+	testSignerOnce sync.Once
+	testSigner     *rsa.PrivateKey
+)
+
+func getTestSigner() *rsa.PrivateKey {
+	testSignerOnce.Do(func() {
+		var err error
+		testSigner, err = rsa.GenerateKey(rand.Reader, 2048)
+		if err != nil {
+			panic("could not generate test signing key: " + err.Error())
+		}
+	})
+	return testSigner
+}
+
+// ---------------------------------------------------------------------------
+// Mock storage implementations
+// ---------------------------------------------------------------------------
+
+// mockCACertStorage implements storage.CACertificatesRepo.
+// Only SelectByType is used by collectKeys; all other methods are no-ops.
+type mockCACertStorage struct {
+	certs   []models.CACertificate
+	listErr error // optional error returned by SelectByType
+}
+
+func (m *mockCACertStorage) SelectByType(_ context.Context, caType models.CertificateType, req storage.StorageListRequest[models.CACertificate]) (string, error) {
+	if m.listErr != nil {
+		return "", m.listErr
+	}
+	for _, ca := range m.certs {
+		if ca.Certificate.Type == caType {
+			req.ApplyFunc(ca)
+		}
+	}
+	return "", nil
+}
+
+func (m *mockCACertStorage) Count(_ context.Context) (int, error) { return 0, nil }
+func (m *mockCACertStorage) CountWithFilters(_ context.Context, _ *resources.QueryParameters) (int, error) {
+	return 0, nil
+}
+func (m *mockCACertStorage) CountByEngine(_ context.Context, _ string) (int, error) { return 0, nil }
+func (m *mockCACertStorage) CountByEngineWithFilters(_ context.Context, _ string, _ *resources.QueryParameters) (int, error) {
+	return 0, nil
+}
+func (m *mockCACertStorage) CountByStatus(_ context.Context, _ models.CertificateStatus) (int, error) {
+	return 0, nil
+}
+func (m *mockCACertStorage) SelectAll(_ context.Context, _ storage.StorageListRequest[models.CACertificate]) (string, error) {
+	return "", nil
+}
+func (m *mockCACertStorage) SelectExistsByID(_ context.Context, _ string) (bool, *models.CACertificate, error) {
+	return false, nil, nil
+}
+func (m *mockCACertStorage) SelectExistsBySerialNumber(_ context.Context, _ string) (bool, *models.CACertificate, error) {
+	return false, nil, nil
+}
+func (m *mockCACertStorage) SelectByCommonName(_ context.Context, _ string, _ storage.StorageListRequest[models.CACertificate]) (string, error) {
+	return "", nil
+}
+func (m *mockCACertStorage) SelectByParentCA(_ context.Context, _ string, _ storage.StorageListRequest[models.CACertificate]) (string, error) {
+	return "", nil
+}
+func (m *mockCACertStorage) SelectBySubjectAndSubjectKeyID(_ context.Context, _ models.Subject, _ string, _ storage.StorageListRequest[models.CACertificate]) (string, error) {
+	return "", nil
+}
+func (m *mockCACertStorage) SelectByIssuerAndAuthorityKeyID(_ context.Context, _ models.Subject, _ string, _ storage.StorageListRequest[models.CACertificate]) (string, error) {
+	return "", nil
+}
+func (m *mockCACertStorage) Insert(_ context.Context, ca *models.CACertificate) (*models.CACertificate, error) {
+	return ca, nil
+}
+func (m *mockCACertStorage) Update(_ context.Context, ca *models.CACertificate) (*models.CACertificate, error) {
+	return ca, nil
+}
+func (m *mockCACertStorage) Delete(_ context.Context, _ string) error { return nil }
+
+// mockKMSStorage implements storage.KMSKeysRepo.
+// SelectExistsByKeyID and Insert are the only methods exercised by runMigration.
+type mockKMSStorage struct {
+	existing  map[string]*models.Key // pre-populated; simulate already-migrated keys
+	inserted  []*models.Key          // records inserted during test
+	insertErr error                  // optional error returned by Insert
+	existsErr error                  // optional error returned by SelectExistsByKeyID
+}
+
+func newMockKMSStorage() *mockKMSStorage {
+	return &mockKMSStorage{existing: map[string]*models.Key{}}
+}
+
+func (m *mockKMSStorage) SelectExistsByKeyID(_ context.Context, id string) (bool, *models.Key, error) {
+	if m.existsErr != nil {
+		return false, nil, m.existsErr
+	}
+	k, ok := m.existing[id]
+	return ok, k, nil
+}
+
+func (m *mockKMSStorage) Insert(_ context.Context, key *models.Key) (*models.Key, error) {
+	if m.insertErr != nil {
+		return nil, m.insertErr
+	}
+	m.existing[key.KeyID] = key
+	m.inserted = append(m.inserted, key)
+	return key, nil
+}
+
+func (m *mockKMSStorage) Count(_ context.Context) (int, error) { return 0, nil }
+func (m *mockKMSStorage) CountWithFilters(_ context.Context, _ *resources.QueryParameters) (int, error) {
+	return 0, nil
+}
+func (m *mockKMSStorage) CountByEngineWithFilters(_ context.Context, _ string, _ *resources.QueryParameters) (int, error) {
+	return 0, nil
+}
+func (m *mockKMSStorage) SelectAll(_ context.Context, _ storage.StorageListRequest[models.Key]) (string, error) {
+	return "", nil
+}
+func (m *mockKMSStorage) SelectExistsByAlias(_ context.Context, _ string) (bool, *models.Key, error) {
+	return false, nil, nil
+}
+func (m *mockKMSStorage) Update(_ context.Context, key *models.Key) (*models.Key, error) {
+	return key, nil
+}
+func (m *mockKMSStorage) Delete(_ context.Context, _ string) error { return nil }
+
+// controlledKMSStorage wraps mockKMSStorage but fails Insert after failAfter successful calls.
+type controlledKMSStorage struct {
+	inner      *mockKMSStorage
+	failAfter  int // succeed this many times, then fail
+	insertions int
+}
+
+func (c *controlledKMSStorage) SelectExistsByKeyID(ctx context.Context, id string) (bool, *models.Key, error) {
+	return c.inner.SelectExistsByKeyID(ctx, id)
+}
+func (c *controlledKMSStorage) Insert(ctx context.Context, key *models.Key) (*models.Key, error) {
+	c.insertions++
+	if c.insertions > c.failAfter {
+		return nil, errors.New("simulated insert failure")
+	}
+	return c.inner.Insert(ctx, key)
+}
+func (c *controlledKMSStorage) Count(_ context.Context) (int, error) { return 0, nil }
+func (c *controlledKMSStorage) CountWithFilters(_ context.Context, _ *resources.QueryParameters) (int, error) {
+	return 0, nil
+}
+func (c *controlledKMSStorage) CountByEngineWithFilters(_ context.Context, _ string, _ *resources.QueryParameters) (int, error) {
+	return 0, nil
+}
+func (c *controlledKMSStorage) SelectAll(_ context.Context, _ storage.StorageListRequest[models.Key]) (string, error) {
+	return "", nil
+}
+func (c *controlledKMSStorage) SelectExistsByAlias(_ context.Context, _ string) (bool, *models.Key, error) {
+	return false, nil, nil
+}
+func (c *controlledKMSStorage) Update(_ context.Context, key *models.Key) (*models.Key, error) {
+	return key, nil
+}
+func (c *controlledKMSStorage) Delete(_ context.Context, _ string) error { return nil }
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+func silentLogger() *log.Entry {
+	l := log.New()
+	l.SetLevel(log.PanicLevel)
+	return log.NewEntry(l)
+}
+
+// keyIDFromPub computes SHA-256(PKIX(pub)) and hex-encodes it — same as EncodePKIXPublicKeyDigest.
+func keyIDFromPub(t *testing.T, pub any) string {
+	t.Helper()
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatalf("keyIDFromPub: %s", err)
+	}
+	sum := sha256.Sum256(der)
+	return hex.EncodeToString(sum[:])
+}
+
+// pubKeyB64PEM encodes pub as base64(PEM "PUBLIC KEY") — the format stored in kms_keys.
+func pubKeyB64PEM(t *testing.T, pub any) string {
+	t.Helper()
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatalf("pubKeyB64PEM: %s", err)
+	}
+	block := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
+	return base64.StdEncoding.EncodeToString(block)
+}
+
+// makeCACert builds a models.CACertificate for the given public key.
+// The cert is signed with a shared test signer so key generation is O(1) per test.
+// The certificate's PublicKey field is set to pub so collectKeys extracts it correctly.
+func makeCACert(t *testing.T, id, serial, engineID string, certType models.CertificateType, pub any, bits int, keyType models.KeyType, cn string, validFrom time.Time) models.CACertificate {
+	t.Helper()
+
+	skid := keyIDFromPub(t, pub)
+	signer := getTestSigner()
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    validFrom,
+		NotAfter:     validFrom.Add(24 * time.Hour),
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, signer.Public(), signer)
+	if err != nil {
+		t.Fatalf("makeCACert CreateCertificate: %s", err)
+	}
+	parsedCert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		t.Fatalf("makeCACert ParseCertificate: %s", err)
+	}
+	parsedCert.PublicKey = pub // replace with the actual test public key
+
+	return models.CACertificate{
+		ID: id,
+		Certificate: models.Certificate{
+			SerialNumber: serial,
+			EngineID:     engineID,
+			SubjectKeyID: skid,
+			Type:         certType,
+			Certificate:  (*models.X509Certificate)(parsedCert),
+			KeyMetadata:  models.KeyStrengthMetadata{Type: keyType, Bits: bits},
+			Subject:      models.Subject{CommonName: cn},
+			ValidFrom:    validFrom,
+		},
+	}
+}
+
+// newRSACACert generates a fresh RSA key and returns a CACertificate using it.
+func newRSACACert(t *testing.T, id, serial, engineID string, certType models.CertificateType, bits int, cn string, validFrom time.Time) models.CACertificate {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, bits)
+	if err != nil {
+		t.Fatalf("newRSACACert GenerateKey: %s", err)
+	}
+	return makeCACert(t, id, serial, engineID, certType, key.Public(), bits, models.KeyType(x509.RSA), cn, validFrom)
+}
+
+// newECDSACACert generates a fresh ECDSA key and returns a CACertificate using it.
+func newECDSACACert(t *testing.T, id, serial, engineID string, certType models.CertificateType, curve elliptic.Curve, cn string, validFrom time.Time) models.CACertificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(curve, rand.Reader)
+	if err != nil {
+		t.Fatalf("newECDSACACert GenerateKey: %s", err)
+	}
+	return makeCACert(t, id, serial, engineID, certType, key.Public(), curve.Params().BitSize, models.KeyType(x509.ECDSA), cn, validFrom)
+}
+
+// ---------------------------------------------------------------------------
+// collectKeys tests
+// ---------------------------------------------------------------------------
+
+func TestCollectKeys_Empty(t *testing.T) {
+	keyMap, err := collectKeys(context.Background(), silentLogger(), &mockCACertStorage{})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(keyMap) != 0 {
+		t.Fatalf("expected empty map, got %d entries", len(keyMap))
+	}
+}
+
+func TestCollectKeys_ManagedCert(t *testing.T) {
+	ts := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	ca := newRSACACert(t, "ca-1", "serial-1", "engine-a", models.CertificateTypeManaged, 2048, "MyCA", ts)
+
+	keyMap, err := collectKeys(context.Background(), silentLogger(), &mockCACertStorage{certs: []models.CACertificate{ca}})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(keyMap) != 1 {
+		t.Fatalf("expected 1 key, got %d", len(keyMap))
+	}
+
+	entry := keyMap[ca.Certificate.SubjectKeyID]
+	if entry == nil {
+		t.Fatal("key entry not found by subject_key_id")
+	}
+	if entry.engineID != "engine-a" {
+		t.Errorf("engineID: got %q, want engine-a", entry.engineID)
+	}
+	if entry.algorithm != "RSA" {
+		t.Errorf("algorithm: got %q, want RSA", entry.algorithm)
+	}
+	if entry.size != 2048 {
+		t.Errorf("size: got %d, want 2048", entry.size)
+	}
+	if entry.name != "MyCA" {
+		t.Errorf("name: got %q, want MyCA", entry.name)
+	}
+	if !entry.creationTS.Equal(ts) {
+		t.Errorf("creationTS: got %v, want %v", entry.creationTS, ts)
+	}
+	if len(entry.serials) != 1 || entry.serials[0] != "serial-1" {
+		t.Errorf("serials: got %v, want [serial-1]", entry.serials)
+	}
+	if entry.publicKey == "" {
+		t.Error("publicKey should not be empty")
+	}
+	// publicKey should decode to valid base64-encoded PEM
+	raw, err2 := base64.StdEncoding.DecodeString(entry.publicKey)
+	if err2 != nil {
+		t.Errorf("publicKey is not valid base64: %s", err2)
+	}
+	pemBlock, _ := pem.Decode(raw)
+	if pemBlock == nil {
+		t.Error("publicKey base64 does not contain a valid PEM block")
+	}
+}
+
+func TestCollectKeys_ImportedWithKeyCert(t *testing.T) {
+	ca := newECDSACACert(t, "ca-2", "serial-2", "engine-b", models.CertificateTypeImportedWithKey, elliptic.P256(), "ImportedCA", time.Now())
+
+	keyMap, err := collectKeys(context.Background(), silentLogger(), &mockCACertStorage{certs: []models.CACertificate{ca}})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(keyMap) != 1 {
+		t.Fatal("expected 1 key for IMPORTED_WITH_KEY cert")
+	}
+	entry := keyMap[ca.Certificate.SubjectKeyID]
+	if entry.algorithm != "ECDSA" {
+		t.Errorf("algorithm: got %q, want ECDSA", entry.algorithm)
+	}
+	if entry.engineID != "engine-b" {
+		t.Errorf("engineID: got %q, want engine-b", entry.engineID)
+	}
+}
+
+func TestCollectKeys_ImportedWithoutKeyCert_IsSkipped(t *testing.T) {
+	ca := newRSACACert(t, "ca-3", "serial-3", "engine-c", models.CertificateTypeImportedWithoutKey, 2048, "NokeyCA", time.Now())
+
+	keyMap, err := collectKeys(context.Background(), silentLogger(), &mockCACertStorage{certs: []models.CACertificate{ca}})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(keyMap) != 0 {
+		t.Fatal("IMPORTED_WITHOUT_KEY cert should not appear in key map")
+	}
+}
+
+func TestCollectKeys_MissingEngineID_IsSkipped(t *testing.T) {
+	ca := newRSACACert(t, "ca-4", "serial-4", "", models.CertificateTypeManaged, 2048, "NoEngineCA", time.Now())
+
+	keyMap, err := collectKeys(context.Background(), silentLogger(), &mockCACertStorage{certs: []models.CACertificate{ca}})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(keyMap) != 0 {
+		t.Fatal("cert with empty engine_id should be skipped")
+	}
+}
+
+func TestCollectKeys_MissingSubjectKeyID_IsSkipped(t *testing.T) {
+	ca := newRSACACert(t, "ca-5", "serial-5", "engine-a", models.CertificateTypeManaged, 2048, "NoSkidCA", time.Now())
+	ca.Certificate.SubjectKeyID = ""
+
+	keyMap, err := collectKeys(context.Background(), silentLogger(), &mockCACertStorage{certs: []models.CACertificate{ca}})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(keyMap) != 0 {
+		t.Fatal("cert with empty subject_key_id should be skipped")
+	}
+}
+
+func TestCollectKeys_NilCertificateBlob_IsSkipped(t *testing.T) {
+	ca := newRSACACert(t, "ca-6", "serial-6", "engine-a", models.CertificateTypeManaged, 2048, "NilBlobCA", time.Now())
+	ca.Certificate.Certificate = nil
+
+	keyMap, err := collectKeys(context.Background(), silentLogger(), &mockCACertStorage{certs: []models.CACertificate{ca}})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(keyMap) != 0 {
+		t.Fatal("cert with nil certificate blob should be skipped")
+	}
+}
+
+func TestCollectKeys_SharedKey_GroupsBothSerials(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub := key.Public()
+	ts := time.Now()
+
+	ca1 := makeCACert(t, "ca-7a", "serial-7a", "engine-a", models.CertificateTypeManaged, pub, 2048, models.KeyType(x509.RSA), "SharedKeyCA1", ts)
+	ca2 := makeCACert(t, "ca-7b", "serial-7b", "engine-a", models.CertificateTypeManaged, pub, 2048, models.KeyType(x509.RSA), "SharedKeyCA2", ts)
+
+	keyMap, err := collectKeys(context.Background(), silentLogger(), &mockCACertStorage{certs: []models.CACertificate{ca1, ca2}})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(keyMap) != 1 {
+		t.Fatalf("two certs sharing a key should produce 1 entry, got %d", len(keyMap))
+	}
+	entry := keyMap[ca1.Certificate.SubjectKeyID]
+	if len(entry.serials) != 2 {
+		t.Errorf("expected 2 serials for shared key, got %d", len(entry.serials))
+	}
+}
+
+func TestCollectKeys_StorageError_ReturnsError(t *testing.T) {
+	caStore := &mockCACertStorage{listErr: errors.New("db read failure")}
+	_, err := collectKeys(context.Background(), silentLogger(), caStore)
+	if err == nil {
+		t.Fatal("expected error when SelectByType fails, got nil")
+	}
+}
+
+func TestCollectKeys_MixedTypes_OnlyManagedAndImportedWithKey(t *testing.T) {
+	managed := newRSACACert(t, "ca-m", "sn-m", "engine-a", models.CertificateTypeManaged, 2048, "Managed", time.Now())
+	imported := newRSACACert(t, "ca-i", "sn-i", "engine-a", models.CertificateTypeImportedWithKey, 2048, "Imported", time.Now())
+	noKey := newRSACACert(t, "ca-n", "sn-n", "engine-a", models.CertificateTypeImportedWithoutKey, 2048, "NoKey", time.Now())
+
+	keyMap, err := collectKeys(context.Background(), silentLogger(), &mockCACertStorage{certs: []models.CACertificate{managed, imported, noKey}})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(keyMap) != 2 {
+		t.Fatalf("expected 2 keys (managed + imported_with_key), got %d", len(keyMap))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// runMigration tests
+// ---------------------------------------------------------------------------
+
+// newKeyEntryFromRSA builds a keyEntry from a freshly generated RSA key.
+func newKeyEntryFromRSA(t *testing.T, engineID, serial, cn string) *keyEntry {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyID := keyIDFromPub(t, key.Public())
+	return &keyEntry{
+		engineID:   engineID,
+		keyID:      keyID,
+		algorithm:  "RSA",
+		size:       2048,
+		publicKey:  pubKeyB64PEM(t, key.Public()),
+		name:       cn,
+		creationTS: time.Now(),
+		serials:    []string{serial},
+	}
+}
+
+func TestRunMigration_InsertsNewKey(t *testing.T) {
+	entry := newKeyEntryFromRSA(t, "engine-a", "serial-1", "MyCA")
+	kms := newMockKMSStorage()
+
+	ins, skip, fail := runMigration(context.Background(), silentLogger(), kms, map[string]*keyEntry{entry.keyID: entry}, false)
+
+	if ins != 1 || skip != 0 || fail != 0 {
+		t.Errorf("counts: ins=%d skip=%d fail=%d, want 1/0/0", ins, skip, fail)
+	}
+	if len(kms.inserted) != 1 {
+		t.Fatal("expected exactly 1 key inserted")
+	}
+
+	got := kms.inserted[0]
+	if got.KeyID != entry.keyID {
+		t.Errorf("KeyID: got %q, want %q", got.KeyID, entry.keyID)
+	}
+	if got.EngineID != "engine-a" {
+		t.Errorf("EngineID: got %q, want engine-a", got.EngineID)
+	}
+	if got.Algorithm != "RSA" {
+		t.Errorf("Algorithm: got %q, want RSA", got.Algorithm)
+	}
+	if got.Size != 2048 {
+		t.Errorf("Size: got %d, want 2048", got.Size)
+	}
+	if !got.HasPrivateKey {
+		t.Error("HasPrivateKey should be true")
+	}
+	if got.PublicKey != entry.publicKey {
+		t.Error("PublicKey field mismatch")
+	}
+
+	rawBindings, ok := got.Metadata[models.KMSBindResourceKey]
+	if !ok {
+		t.Fatalf("metadata missing key %q", models.KMSBindResourceKey)
+	}
+	bindings, ok := rawBindings.([]models.KMSBindResource)
+	if !ok {
+		t.Fatalf("metadata[%q] has wrong type %T", models.KMSBindResourceKey, rawBindings)
+	}
+	if len(bindings) != 1 || bindings[0].ResourceType != "certificate" || bindings[0].ResourceID != "serial-1" {
+		t.Errorf("unexpected binded-resources: %+v", bindings)
+	}
+}
+
+func TestRunMigration_SkipsExistingKey(t *testing.T) {
+	entry := newKeyEntryFromRSA(t, "engine-a", "serial-1", "MyCA")
+	kms := newMockKMSStorage()
+	kms.existing[entry.keyID] = &models.Key{KeyID: entry.keyID}
+
+	ins, skip, fail := runMigration(context.Background(), silentLogger(), kms, map[string]*keyEntry{entry.keyID: entry}, false)
+
+	if ins != 0 || skip != 1 || fail != 0 {
+		t.Errorf("counts: ins=%d skip=%d fail=%d, want 0/1/0", ins, skip, fail)
+	}
+	if len(kms.inserted) != 0 {
+		t.Error("no insert should happen for an existing key")
+	}
+}
+
+func TestRunMigration_InsertError_CountsAsFailed(t *testing.T) {
+	entry := newKeyEntryFromRSA(t, "engine-a", "serial-1", "MyCA")
+	kms := newMockKMSStorage()
+	kms.insertErr = errors.New("write failed")
+
+	ins, skip, fail := runMigration(context.Background(), silentLogger(), kms, map[string]*keyEntry{entry.keyID: entry}, false)
+
+	if ins != 0 || skip != 0 || fail != 1 {
+		t.Errorf("counts: ins=%d skip=%d fail=%d, want 0/0/1", ins, skip, fail)
+	}
+}
+
+func TestRunMigration_CheckExistsError_CountsAsFailed(t *testing.T) {
+	entry := newKeyEntryFromRSA(t, "engine-a", "serial-1", "MyCA")
+	kms := newMockKMSStorage()
+	kms.existsErr = errors.New("db read error")
+
+	ins, skip, fail := runMigration(context.Background(), silentLogger(), kms, map[string]*keyEntry{entry.keyID: entry}, false)
+
+	if ins != 0 || skip != 0 || fail != 1 {
+		t.Errorf("counts: ins=%d skip=%d fail=%d, want 0/0/1", ins, skip, fail)
+	}
+}
+
+func TestRunMigration_DryRun_DoesNotInsert(t *testing.T) {
+	entry := newKeyEntryFromRSA(t, "engine-a", "serial-1", "MyCA")
+	kms := newMockKMSStorage()
+
+	ins, skip, fail := runMigration(context.Background(), silentLogger(), kms, map[string]*keyEntry{entry.keyID: entry}, true)
+
+	if ins != 1 || skip != 0 || fail != 0 {
+		t.Errorf("dry-run counts: ins=%d skip=%d fail=%d, want 1/0/0", ins, skip, fail)
+	}
+	if len(kms.inserted) != 0 {
+		t.Error("dry-run must not write to KMS storage")
+	}
+}
+
+func TestRunMigration_DryRun_SkipsExistingKey(t *testing.T) {
+	entry := newKeyEntryFromRSA(t, "engine-a", "serial-1", "MyCA")
+	kms := newMockKMSStorage()
+	kms.existing[entry.keyID] = &models.Key{KeyID: entry.keyID}
+
+	ins, skip, fail := runMigration(context.Background(), silentLogger(), kms, map[string]*keyEntry{entry.keyID: entry}, true)
+
+	if ins != 0 || skip != 1 || fail != 0 {
+		t.Errorf("dry-run skip counts: ins=%d skip=%d fail=%d, want 0/1/0", ins, skip, fail)
+	}
+}
+
+func TestRunMigration_Mixed_NewExistingFailed(t *testing.T) {
+	newEntry := newKeyEntryFromRSA(t, "engine-a", "new-sn", "NewCA")
+	existingEntry := newKeyEntryFromRSA(t, "engine-a", "existing-sn", "ExistingCA")
+	failEntry := newKeyEntryFromRSA(t, "engine-a", "fail-sn", "FailCA")
+
+	inner := newMockKMSStorage()
+	inner.existing[existingEntry.keyID] = &models.Key{KeyID: existingEntry.keyID}
+
+	// Succeed the first new-key insert, fail all subsequent ones.
+	kms := &controlledKMSStorage{inner: inner, failAfter: 1}
+
+	keyMap := map[string]*keyEntry{
+		newEntry.keyID:      newEntry,
+		existingEntry.keyID: existingEntry,
+		failEntry.keyID:     failEntry,
+	}
+
+	ins, skip, fail := runMigration(context.Background(), silentLogger(), kms, keyMap, false)
+
+	if ins != 1 {
+		t.Errorf("expected 1 inserted, got %d", ins)
+	}
+	if skip != 1 {
+		t.Errorf("expected 1 skipped, got %d", skip)
+	}
+	if fail != 1 {
+		t.Errorf("expected 1 failed, got %d", fail)
+	}
+}
+
+func TestRunMigration_MultipleSerials_AllInBindedResources(t *testing.T) {
+	entry := &keyEntry{
+		engineID:   "engine-a",
+		keyID:      "key-abc",
+		algorithm:  "RSA",
+		size:       2048,
+		publicKey:  "fake-pub",
+		name:       "SharedCA",
+		creationTS: time.Now(),
+		serials:    []string{"sn-1", "sn-2", "sn-3"},
+	}
+	kms := newMockKMSStorage()
+
+	runMigration(context.Background(), silentLogger(), kms, map[string]*keyEntry{entry.keyID: entry}, false)
+
+	if len(kms.inserted) != 1 {
+		t.Fatal("expected exactly 1 insert")
+	}
+	rawBindings := kms.inserted[0].Metadata[models.KMSBindResourceKey]
+	bindings, ok := rawBindings.([]models.KMSBindResource)
+	if !ok {
+		t.Fatalf("wrong binding type %T", rawBindings)
+	}
+	if len(bindings) != 3 {
+		t.Errorf("expected 3 binded-resources, got %d", len(bindings))
+	}
+	bySerial := map[string]bool{}
+	for _, b := range bindings {
+		bySerial[b.ResourceID] = true
+		if b.ResourceType != "certificate" {
+			t.Errorf("unexpected resource_type %q", b.ResourceType)
+		}
+	}
+	for _, sn := range entry.serials {
+		if !bySerial[sn] {
+			t.Errorf("serial %q missing from binded-resources", sn)
+		}
+	}
+}
+
+func TestRunMigration_Empty_ZeroCounts(t *testing.T) {
+	kms := newMockKMSStorage()
+	ins, skip, fail := runMigration(context.Background(), silentLogger(), kms, map[string]*keyEntry{}, false)
+	if ins != 0 || skip != 0 || fail != 0 {
+		t.Errorf("empty map should give 0/0/0, got %d/%d/%d", ins, skip, fail)
+	}
+}
+
+func TestRunMigration_Idempotent_SecondRunSkipsAll(t *testing.T) {
+	entries := []*keyEntry{
+		newKeyEntryFromRSA(t, "engine-a", "sn-1", "CA1"),
+		newKeyEntryFromRSA(t, "engine-a", "sn-2", "CA2"),
+	}
+	keyMap := map[string]*keyEntry{}
+	for _, e := range entries {
+		keyMap[e.keyID] = e
+	}
+
+	kms := newMockKMSStorage()
+
+	// First run: both keys are new.
+	ins, skip, fail := runMigration(context.Background(), silentLogger(), kms, keyMap, false)
+	if ins != 2 || skip != 0 || fail != 0 {
+		t.Errorf("first run: ins=%d skip=%d fail=%d, want 2/0/0", ins, skip, fail)
+	}
+
+	// Second run: both keys now exist.
+	ins, skip, fail = runMigration(context.Background(), silentLogger(), kms, keyMap, false)
+	if ins != 0 || skip != 2 || fail != 0 {
+		t.Errorf("second run: ins=%d skip=%d fail=%d, want 0/2/0", ins, skip, fail)
+	}
+}

--- a/backend/pkg/migration/catokms/migration.go
+++ b/backend/pkg/migration/catokms/migration.go
@@ -99,19 +99,19 @@ func collectKeys(ctx context.Context, logger *log.Entry, caStorage storage.CACer
 			return
 		}
 
-		x509Cert := (*x509.Certificate)(cert.Certificate)
-		pubKeyDER, err := x509.MarshalPKIXPublicKey(x509Cert.PublicKey)
-		if err != nil {
-			logger.Errorf("could not marshal public key for CA %s: %s", ca.ID, err)
-			return
-		}
-		pubKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubKeyDER})
-		pubKeyB64 := base64.StdEncoding.EncodeToString(pubKeyPEM)
-
 		keyID := cert.SubjectKeyID
 		if entry, ok := keyMap[keyID]; ok {
 			entry.serials = append(entry.serials, cert.SerialNumber)
 		} else {
+			x509Cert := (*x509.Certificate)(cert.Certificate)
+			pubKeyDER, err := x509.MarshalPKIXPublicKey(x509Cert.PublicKey)
+			if err != nil {
+				logger.Errorf("could not marshal public key for CA %s: %s", ca.ID, err)
+				return
+			}
+			pubKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubKeyDER})
+			pubKeyB64 := base64.StdEncoding.EncodeToString(pubKeyPEM)
+
 			keyMap[keyID] = &keyEntry{
 				engineID:   cert.EngineID,
 				keyID:      keyID,

--- a/backend/pkg/migration/catokms/migration.go
+++ b/backend/pkg/migration/catokms/migration.go
@@ -76,14 +76,15 @@ func MigrateWithConfig(ctx context.Context, logger *log.Entry, caStorageConf, km
 
 // keyEntry accumulates all data needed to build a models.Key record.
 type keyEntry struct {
-	engineID   string
-	keyID      string // subject_key_id == KMS key_id (SHA-256 hex of PKIX public key)
-	algorithm  string
-	size       int
-	publicKey  string // base64(PEM "PUBLIC KEY")
-	name       string // common name of first CA cert using this key
-	creationTS time.Time
-	serials    []string // serial numbers of all CA certs using this key
+	engineID    string
+	keyID       string // subject_key_id == KMS key_id (SHA-256 hex of PKIX public key)
+	algorithm   string
+	size        int
+	publicKey   string // base64(PEM "PUBLIC KEY")
+	name        string // common name of first CA cert using this key
+	creationTS  time.Time
+	serials     []string // serial numbers of all CA certs using this key
+	conflictErr string   // non-empty if the entry cannot be migrated safely
 }
 
 // collectKeys scans MANAGED and IMPORTED_WITH_KEY CA certs and groups them by key.
@@ -103,6 +104,13 @@ func collectKeys(ctx context.Context, logger *log.Entry, caStorage storage.CACer
 
 		keyID := cert.SubjectKeyID
 		if entry, ok := keyMap[keyID]; ok {
+			if cert.EngineID != entry.engineID && entry.conflictErr == "" {
+				entry.conflictErr = fmt.Sprintf(
+					"key %s is referenced by CA certificates with conflicting engine_ids (%q vs %q); "+
+						"cannot determine the correct engine — resolve the conflict manually",
+					keyID, entry.engineID, cert.EngineID,
+				)
+			}
 			entry.serials = append(entry.serials, cert.SerialNumber)
 		} else {
 			x509Cert := (*x509.Certificate)(cert.Certificate)
@@ -162,6 +170,12 @@ func collectKeys(ctx context.Context, logger *log.Entry, caStorage storage.CACer
 // It returns the number of inserted (or would-insert in dry-run), skipped, and failed keys.
 func runMigration(ctx context.Context, logger *log.Entry, kmsStorage storage.KMSKeysRepo, keyMap map[string]*keyEntry, dryRun bool) (inserted, skipped, failed int) {
 	for _, entry := range keyMap {
+		if entry.conflictErr != "" {
+			logger.Errorf("skipping key %s: %s", entry.keyID, entry.conflictErr)
+			failed++
+			continue
+		}
+
 		exists, _, err := kmsStorage.SelectExistsByKeyID(ctx, entry.keyID)
 		if err != nil {
 			logger.Errorf("could not check key %s in KMS storage: %s", entry.keyID, err)

--- a/backend/pkg/migration/catokms/migration.go
+++ b/backend/pkg/migration/catokms/migration.go
@@ -17,14 +17,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Config holds the storage configurations for both the CA and KMS databases.
-// It can be loaded directly via cconfig.LoadConfig[catokms.Config] in any caller.
-type Config struct {
-	LogLevel   cconfig.LogLevel               `mapstructure:"log_level"`
-	CAStorage  cconfig.PluggableStorageEngine `mapstructure:"ca_storage"`
-	KMSStorage cconfig.PluggableStorageEngine `mapstructure:"kms_storage"`
-}
-
 // Result summarises the outcome of a migration run.
 type Result struct {
 	Inserted int
@@ -46,23 +38,20 @@ func Migrate(ctx context.Context, logger *log.Entry, caStorage storage.CACertifi
 	return Result{Inserted: ins, Skipped: skip, Failed: fail}, nil
 }
 
-// MigrateWithConfig builds storage engines from the supplied configs and runs the migration.
-// Convenient for callers that hold a Config struct (e.g. Lambda handlers reading from SSM or env).
-func MigrateWithConfig(ctx context.Context, logger *log.Entry, caStorageConf, kmsStorageConf cconfig.PluggableStorageEngine, dryRun bool) (Result, error) {
-	caEngine, err := storagebuilder.BuildStorageEngine(logger.WithField("db", "ca"), caStorageConf)
+// MigrateWithConfig builds CA and KMS storage from a single Postgres config and runs the
+// migration. Both databases ("ca" and "kms") are expected on the same server; the engine
+// connects to each automatically. Pass the KMSConfig.Storage field from the standard
+// Lamassu service config.
+func MigrateWithConfig(ctx context.Context, logger *log.Entry, storageConf cconfig.PluggableStorageEngine, dryRun bool) (Result, error) {
+	engine, err := storagebuilder.BuildStorageEngine(logger, storageConf)
 	if err != nil {
-		return Result{}, fmt.Errorf("build CA storage engine: %w", err)
+		return Result{}, fmt.Errorf("build storage engine: %w", err)
 	}
-	caStorage, err := caEngine.GetCAStorage()
+	caStorage, err := engine.GetCAStorage()
 	if err != nil {
 		return Result{}, fmt.Errorf("get CA storage: %w", err)
 	}
-
-	kmsEngine, err := storagebuilder.BuildStorageEngine(logger.WithField("db", "kms"), kmsStorageConf)
-	if err != nil {
-		return Result{}, fmt.Errorf("build KMS storage engine: %w", err)
-	}
-	kmsStorage, err := kmsEngine.GetKMSStorage()
+	kmsStorage, err := engine.GetKMSStorage()
 	if err != nil {
 		return Result{}, fmt.Errorf("get KMS storage: %w", err)
 	}

--- a/backend/pkg/migration/catokms/migration.go
+++ b/backend/pkg/migration/catokms/migration.go
@@ -2,6 +2,8 @@ package catokms
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/rsa"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
@@ -104,6 +106,21 @@ func collectKeys(ctx context.Context, logger *log.Entry, caStorage storage.CACer
 			entry.serials = append(entry.serials, cert.SerialNumber)
 		} else {
 			x509Cert := (*x509.Certificate)(cert.Certificate)
+
+			var algorithm string
+			var size int
+			switch pub := x509Cert.PublicKey.(type) {
+			case *rsa.PublicKey:
+				algorithm = "RSA"
+				size = pub.N.BitLen()
+			case *ecdsa.PublicKey:
+				algorithm = "ECDSA"
+				size = pub.Params().BitSize
+			default:
+				logger.Warnf("skipping CA %s: unsupported public key type %T", ca.ID, x509Cert.PublicKey)
+				return
+			}
+
 			pubKeyDER, err := x509.MarshalPKIXPublicKey(x509Cert.PublicKey)
 			if err != nil {
 				logger.Errorf("could not marshal public key for CA %s: %s", ca.ID, err)
@@ -115,8 +132,8 @@ func collectKeys(ctx context.Context, logger *log.Entry, caStorage storage.CACer
 			keyMap[keyID] = &keyEntry{
 				engineID:   cert.EngineID,
 				keyID:      keyID,
-				algorithm:  cert.KeyMetadata.Type.String(),
-				size:       cert.KeyMetadata.Bits,
+				algorithm:  algorithm,
+				size:       size,
 				publicKey:  pubKeyB64,
 				name:       cert.Subject.CommonName,
 				creationTS: cert.ValidFrom,

--- a/backend/pkg/migration/catokms/migration.go
+++ b/backend/pkg/migration/catokms/migration.go
@@ -1,0 +1,206 @@
+package catokms
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"time"
+
+	storagebuilder "github.com/lamassuiot/lamassuiot/backend/v3/pkg/storage/builder"
+	cconfig "github.com/lamassuiot/lamassuiot/core/v3/pkg/config"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/engines/storage"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
+	log "github.com/sirupsen/logrus"
+)
+
+// Config holds the storage configurations for both the CA and KMS databases.
+// It can be loaded directly via cconfig.LoadConfig[catokms.Config] in any caller.
+type Config struct {
+	LogLevel   cconfig.LogLevel               `mapstructure:"log_level"`
+	CAStorage  cconfig.PluggableStorageEngine `mapstructure:"ca_storage"`
+	KMSStorage cconfig.PluggableStorageEngine `mapstructure:"kms_storage"`
+}
+
+// Result summarises the outcome of a migration run.
+type Result struct {
+	Inserted int
+	Skipped  int
+	Failed   int
+}
+
+// Migrate runs the migration using pre-built storage instances.
+// This is the primary entry point for programmatic callers (e.g. Lambda handlers)
+// that manage their own storage connections.
+func Migrate(ctx context.Context, logger *log.Entry, caStorage storage.CACertificatesRepo, kmsStorage storage.KMSKeysRepo, dryRun bool) (Result, error) {
+	keyMap, err := collectKeys(ctx, logger, caStorage)
+	if err != nil {
+		return Result{}, fmt.Errorf("collect keys: %w", err)
+	}
+	logger.Infof("found %d unique keys across CA certificates", len(keyMap))
+
+	ins, skip, fail := runMigration(ctx, logger, kmsStorage, keyMap, dryRun)
+	return Result{Inserted: ins, Skipped: skip, Failed: fail}, nil
+}
+
+// MigrateWithConfig builds storage engines from the supplied configs and runs the migration.
+// Convenient for callers that hold a Config struct (e.g. Lambda handlers reading from SSM or env).
+func MigrateWithConfig(ctx context.Context, logger *log.Entry, caStorageConf, kmsStorageConf cconfig.PluggableStorageEngine, dryRun bool) (Result, error) {
+	caEngine, err := storagebuilder.BuildStorageEngine(logger.WithField("db", "ca"), caStorageConf)
+	if err != nil {
+		return Result{}, fmt.Errorf("build CA storage engine: %w", err)
+	}
+	caStorage, err := caEngine.GetCAStorage()
+	if err != nil {
+		return Result{}, fmt.Errorf("get CA storage: %w", err)
+	}
+
+	kmsEngine, err := storagebuilder.BuildStorageEngine(logger.WithField("db", "kms"), kmsStorageConf)
+	if err != nil {
+		return Result{}, fmt.Errorf("build KMS storage engine: %w", err)
+	}
+	kmsStorage, err := kmsEngine.GetKMSStorage()
+	if err != nil {
+		return Result{}, fmt.Errorf("get KMS storage: %w", err)
+	}
+
+	return Migrate(ctx, logger, caStorage, kmsStorage, dryRun)
+}
+
+// ---------------------------------------------------------------------------
+// Internal implementation
+// ---------------------------------------------------------------------------
+
+// keyEntry accumulates all data needed to build a models.Key record.
+type keyEntry struct {
+	engineID   string
+	keyID      string // subject_key_id == KMS key_id (SHA-256 hex of PKIX public key)
+	algorithm  string
+	size       int
+	publicKey  string // base64(PEM "PUBLIC KEY")
+	name       string // common name of first CA cert using this key
+	creationTS time.Time
+	serials    []string // serial numbers of all CA certs using this key
+}
+
+// collectKeys scans MANAGED and IMPORTED_WITH_KEY CA certs and groups them by key.
+func collectKeys(ctx context.Context, logger *log.Entry, caStorage storage.CACertificatesRepo) (map[string]*keyEntry, error) {
+	keyMap := map[string]*keyEntry{}
+
+	collect := func(ca models.CACertificate) {
+		cert := ca.Certificate
+		if cert.EngineID == "" || cert.SubjectKeyID == "" {
+			logger.Warnf("skipping CA %s: missing engine_id or subject_key_id", ca.ID)
+			return
+		}
+		if cert.Certificate == nil {
+			logger.Warnf("skipping CA %s: nil certificate blob", ca.ID)
+			return
+		}
+
+		x509Cert := (*x509.Certificate)(cert.Certificate)
+		pubKeyDER, err := x509.MarshalPKIXPublicKey(x509Cert.PublicKey)
+		if err != nil {
+			logger.Errorf("could not marshal public key for CA %s: %s", ca.ID, err)
+			return
+		}
+		pubKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubKeyDER})
+		pubKeyB64 := base64.StdEncoding.EncodeToString(pubKeyPEM)
+
+		keyID := cert.SubjectKeyID
+		if entry, ok := keyMap[keyID]; ok {
+			entry.serials = append(entry.serials, cert.SerialNumber)
+		} else {
+			keyMap[keyID] = &keyEntry{
+				engineID:   cert.EngineID,
+				keyID:      keyID,
+				algorithm:  cert.KeyMetadata.Type.String(),
+				size:       cert.KeyMetadata.Bits,
+				publicKey:  pubKeyB64,
+				name:       cert.Subject.CommonName,
+				creationTS: cert.ValidFrom,
+				serials:    []string{cert.SerialNumber},
+			}
+		}
+	}
+
+	for _, certType := range []models.CertificateType{
+		models.CertificateTypeManaged,
+		models.CertificateTypeImportedWithKey,
+	} {
+		_, err := caStorage.SelectByType(ctx, certType, storage.StorageListRequest[models.CACertificate]{
+			ExhaustiveRun: true,
+			ApplyFunc:     collect,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("could not list CA certs of type %s: %w", certType, err)
+		}
+	}
+
+	return keyMap, nil
+}
+
+// runMigration inserts missing keys into KMS storage (or logs what it would do in dry-run mode).
+// It returns the number of inserted (or would-insert in dry-run), skipped, and failed keys.
+func runMigration(ctx context.Context, logger *log.Entry, kmsStorage storage.KMSKeysRepo, keyMap map[string]*keyEntry, dryRun bool) (inserted, skipped, failed int) {
+	for _, entry := range keyMap {
+		exists, _, err := kmsStorage.SelectExistsByKeyID(ctx, entry.keyID)
+		if err != nil {
+			logger.Errorf("could not check key %s in KMS storage: %s", entry.keyID, err)
+			failed++
+			continue
+		}
+		if exists {
+			logger.Debugf("key %s already in KMS storage — skipping", entry.keyID)
+			skipped++
+			continue
+		}
+
+		bindedResources := make([]models.KMSBindResource, len(entry.serials))
+		for i, sn := range entry.serials {
+			bindedResources[i] = models.KMSBindResource{
+				ResourceType: "certificate",
+				ResourceID:   sn,
+			}
+		}
+
+		key := &models.Key{
+			KeyID:         entry.keyID,
+			EngineID:      entry.engineID,
+			Name:          entry.name,
+			Aliases:       []string{},
+			HasPrivateKey: true,
+			Algorithm:     entry.algorithm,
+			Size:          entry.size,
+			PublicKey:     entry.publicKey,
+			CreationTS:    entry.creationTS,
+			Tags:          []string{},
+			Metadata: map[string]any{
+				models.KMSBindResourceKey: bindedResources,
+			},
+		}
+
+		logger.Infof("key %s — engine=%s alg=%s bits=%d binds=%d",
+			entry.keyID, entry.engineID, entry.algorithm, entry.size, len(entry.serials))
+
+		if dryRun {
+			inserted++ // count as "would insert"
+			continue
+		}
+
+		if _, err = kmsStorage.Insert(ctx, key); err != nil {
+			logger.Errorf("could not insert key %s: %s", entry.keyID, err)
+			failed++
+			continue
+		}
+		inserted++
+	}
+
+	action := "inserted"
+	if dryRun {
+		action = "would insert"
+	}
+	logger.Infof("migration complete: %s=%d skipped=%d failed=%d", action, inserted, skipped, failed)
+	return
+}

--- a/backend/pkg/migration/catokms/migration_test.go
+++ b/backend/pkg/migration/catokms/migration_test.go
@@ -457,6 +457,48 @@ func TestCollectKeys_SharedKey_GroupsBothSerials(t *testing.T) {
 	}
 }
 
+func TestCollectKeys_SharedKey_EngineIDMismatch_KeepsFirstAndGroupsSerials(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub := key.Public()
+	ts := time.Now()
+
+	ca1 := makeCACert(t, "ca-8a", "serial-8a", "engine-a", models.CertificateTypeManaged, pub, 2048, models.KeyType(x509.RSA), "SharedKeyCA1", ts)
+	ca2 := makeCACert(t, "ca-8b", "serial-8b", "engine-b", models.CertificateTypeManaged, pub, 2048, models.KeyType(x509.RSA), "SharedKeyCA2", ts)
+
+	keyMap, err := collectKeys(context.Background(), silentLogger(), &mockCACertStorage{certs: []models.CACertificate{ca1, ca2}})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(keyMap) != 1 {
+		t.Fatalf("expected 1 key entry despite engine_id mismatch, got %d", len(keyMap))
+	}
+	entry := keyMap[ca1.Certificate.SubjectKeyID]
+	if entry.conflictErr == "" {
+		t.Error("expected conflictErr to be set on engine_id mismatch")
+	}
+	if len(entry.serials) != 2 {
+		t.Errorf("expected both serials grouped, got %d", len(entry.serials))
+	}
+}
+
+func TestRunMigration_EngineIDConflict_CountsAsFailed(t *testing.T) {
+	entry := newKeyEntryFromRSA(t, "engine-a", "serial-1", "MyCA")
+	entry.conflictErr = "conflicting engine_ids"
+	kms := newMockKMSStorage()
+
+	ins, skip, fail := runMigration(context.Background(), silentLogger(), kms, map[string]*keyEntry{entry.keyID: entry}, false)
+
+	if ins != 0 || skip != 0 || fail != 1 {
+		t.Errorf("counts: ins=%d skip=%d fail=%d, want 0/0/1", ins, skip, fail)
+	}
+	if len(kms.inserted) != 0 {
+		t.Error("no insert should happen for a conflicted key")
+	}
+}
+
 func TestCollectKeys_UnsupportedKeyType_IsSkipped(t *testing.T) {
 	// Ed25519 is not RSA or ECDSA; the type switch should skip it.
 	edPub, _, err := ed25519.GenerateKey(rand.Reader)

--- a/backend/pkg/migration/catokms/migration_test.go
+++ b/backend/pkg/migration/catokms/migration_test.go
@@ -1,4 +1,4 @@
-package main
+package catokms
 
 import (
 	"context"
@@ -282,6 +282,26 @@ func newECDSACACert(t *testing.T, id, serial, engineID string, certType models.C
 	return makeCACert(t, id, serial, engineID, certType, key.Public(), curve.Params().BitSize, models.KeyType(x509.ECDSA), cn, validFrom)
 }
 
+// newKeyEntryFromRSA builds a keyEntry from a freshly generated RSA key.
+func newKeyEntryFromRSA(t *testing.T, engineID, serial, cn string) *keyEntry {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyID := keyIDFromPub(t, key.Public())
+	return &keyEntry{
+		engineID:   engineID,
+		keyID:      keyID,
+		algorithm:  "RSA",
+		size:       2048,
+		publicKey:  pubKeyB64PEM(t, key.Public()),
+		name:       cn,
+		creationTS: time.Now(),
+		serials:    []string{serial},
+	}
+}
+
 // ---------------------------------------------------------------------------
 // collectKeys tests
 // ---------------------------------------------------------------------------
@@ -333,7 +353,6 @@ func TestCollectKeys_ManagedCert(t *testing.T) {
 	if entry.publicKey == "" {
 		t.Error("publicKey should not be empty")
 	}
-	// publicKey should decode to valid base64-encoded PEM
 	raw, err2 := base64.StdEncoding.DecodeString(entry.publicKey)
 	if err2 != nil {
 		t.Errorf("publicKey is not valid base64: %s", err2)
@@ -463,26 +482,6 @@ func TestCollectKeys_MixedTypes_OnlyManagedAndImportedWithKey(t *testing.T) {
 // runMigration tests
 // ---------------------------------------------------------------------------
 
-// newKeyEntryFromRSA builds a keyEntry from a freshly generated RSA key.
-func newKeyEntryFromRSA(t *testing.T, engineID, serial, cn string) *keyEntry {
-	t.Helper()
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		t.Fatal(err)
-	}
-	keyID := keyIDFromPub(t, key.Public())
-	return &keyEntry{
-		engineID:   engineID,
-		keyID:      keyID,
-		algorithm:  "RSA",
-		size:       2048,
-		publicKey:  pubKeyB64PEM(t, key.Public()),
-		name:       cn,
-		creationTS: time.Now(),
-		serials:    []string{serial},
-	}
-}
-
 func TestRunMigration_InsertsNewKey(t *testing.T) {
 	entry := newKeyEntryFromRSA(t, "engine-a", "serial-1", "MyCA")
 	kms := newMockKMSStorage()
@@ -602,7 +601,6 @@ func TestRunMigration_Mixed_NewExistingFailed(t *testing.T) {
 	inner := newMockKMSStorage()
 	inner.existing[existingEntry.keyID] = &models.Key{KeyID: existingEntry.keyID}
 
-	// Succeed the first new-key insert, fail all subsequent ones.
 	kms := &controlledKMSStorage{inner: inner, failAfter: 1}
 
 	keyMap := map[string]*keyEntry{
@@ -684,15 +682,58 @@ func TestRunMigration_Idempotent_SecondRunSkipsAll(t *testing.T) {
 
 	kms := newMockKMSStorage()
 
-	// First run: both keys are new.
 	ins, skip, fail := runMigration(context.Background(), silentLogger(), kms, keyMap, false)
 	if ins != 2 || skip != 0 || fail != 0 {
 		t.Errorf("first run: ins=%d skip=%d fail=%d, want 2/0/0", ins, skip, fail)
 	}
 
-	// Second run: both keys now exist.
 	ins, skip, fail = runMigration(context.Background(), silentLogger(), kms, keyMap, false)
 	if ins != 0 || skip != 2 || fail != 0 {
 		t.Errorf("second run: ins=%d skip=%d fail=%d, want 0/2/0", ins, skip, fail)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Migrate (public API) tests
+// ---------------------------------------------------------------------------
+
+func TestMigrate_ReturnsResultStruct(t *testing.T) {
+	ca := newRSACACert(t, "ca-1", "serial-1", "engine-a", models.CertificateTypeManaged, 2048, "MyCA", time.Now())
+	caStore := &mockCACertStorage{certs: []models.CACertificate{ca}}
+	kms := newMockKMSStorage()
+
+	result, err := Migrate(context.Background(), silentLogger(), caStore, kms, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if result.Inserted != 1 || result.Skipped != 0 || result.Failed != 0 {
+		t.Errorf("result: %+v, want {1 0 0}", result)
+	}
+}
+
+func TestMigrate_DryRun_ReturnsResultWithoutWriting(t *testing.T) {
+	ca := newRSACACert(t, "ca-1", "serial-1", "engine-a", models.CertificateTypeManaged, 2048, "MyCA", time.Now())
+	caStore := &mockCACertStorage{certs: []models.CACertificate{ca}}
+	kms := newMockKMSStorage()
+
+	result, err := Migrate(context.Background(), silentLogger(), caStore, kms, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if result.Inserted != 1 {
+		t.Errorf("dry-run inserted count: got %d, want 1", result.Inserted)
+	}
+	if len(kms.inserted) != 0 {
+		t.Error("dry-run must not write to storage")
+	}
+}
+
+func TestMigrate_CAStorageError_ReturnsError(t *testing.T) {
+	caStore := &mockCACertStorage{listErr: errors.New("db failure")}
+	kms := newMockKMSStorage()
+
+	_, err := Migrate(context.Background(), silentLogger(), caStore, kms, false)
+	if err == nil {
+		t.Fatal("expected error from CA storage failure, got nil")
 	}
 }

--- a/backend/pkg/migration/catokms/migration_test.go
+++ b/backend/pkg/migration/catokms/migration_test.go
@@ -3,6 +3,7 @@ package catokms
 import (
 	"context"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
@@ -453,6 +454,27 @@ func TestCollectKeys_SharedKey_GroupsBothSerials(t *testing.T) {
 	entry := keyMap[ca1.Certificate.SubjectKeyID]
 	if len(entry.serials) != 2 {
 		t.Errorf("expected 2 serials for shared key, got %d", len(entry.serials))
+	}
+}
+
+func TestCollectKeys_UnsupportedKeyType_IsSkipped(t *testing.T) {
+	// Ed25519 is not RSA or ECDSA; the type switch should skip it.
+	edPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Build a cert whose PublicKey is ed25519 (unsupported by the migration).
+	// We reuse makeCACert with an RSA key bit-size=0 placeholder since makeCACert
+	// replaces parsedCert.PublicKey with the supplied pub value.
+	ca := makeCACert(t, "ca-ed", "serial-ed", "engine-a", models.CertificateTypeManaged,
+		edPub, 0, models.KeyType(x509.UnknownPublicKeyAlgorithm), "Ed25519CA", time.Now())
+
+	keyMap, err := collectKeys(context.Background(), silentLogger(), &mockCACertStorage{certs: []models.CACertificate{ca}})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(keyMap) != 0 {
+		t.Fatal("cert with unsupported public key type should be skipped")
 	}
 }
 

--- a/ci/ca-to-kms-migration.dockerfile
+++ b/ci/ca-to-kms-migration.dockerfile
@@ -1,0 +1,49 @@
+FROM golang:1.26.2-bookworm AS builder
+WORKDIR /app
+
+COPY core core
+COPY shared shared
+COPY sdk sdk
+COPY backend backend
+COPY engines engines
+COPY monolithic monolithic
+COPY connectors connectors
+
+COPY go.work go.work
+COPY go.work.sum go.work.sum
+
+ARG SHA1VER= # set by build script
+ARG VERSION= # set by build script
+
+RUN go work vendor
+
+##############
+
+ENV GOSUMDB=off
+RUN now=$(TZ=GMT date +"%Y-%m-%dT%H:%M:%SZ") && \
+    CGO_ENABLED=0 go build \
+    -ldflags "-X main.version=$VERSION \
+    -X main.sha1ver=$SHA1VER \
+    -X main.buildTime=$now" \
+    -mod vendor \
+    -o ca-to-kms-migration \
+    backend/cmd/ca-to-kms-migration/main.go
+
+FROM alpine:3.19
+
+RUN apk --no-cache add ca-certificates tzdata
+
+ARG USERNAME=migrate
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN addgroup -g "$USER_GID" "$USERNAME" && \
+    adduser -D -u "$USER_UID" -G "$USERNAME" "$USERNAME"
+
+USER $USERNAME
+
+WORKDIR /home/$USERNAME
+
+COPY --from=builder /app/ca-to-kms-migration ./ca-to-kms-migration
+
+ENTRYPOINT ["./ca-to-kms-migration"]


### PR DESCRIPTION
### Background

The KMS service was introduced as a standalone service in v3.7.0. Prior to this, private keys were tracked only by the underlying crypto engine (filesystem, PKCS#11, Vault KV2, AWS KMS, etc.) with no corresponding row in the `kms_keys` table. When upgrading an existing installation, the KMS service is unaware of those keys and the `lamassu.io/kms/binded-resources` metadata linking keys to their CA certificates is absent.

Closes #640 

### What this PR adds

**`catokms`** — a reusable Go package containing the migration logic:

- `Result` — structured output with **Inserted**, **Skipped**, and **Failed** counts
- `Migrate(ctx, logger, caStorage, kmsStorage, dryRun)`— primary entry point for programmatic callers that supply their own storage instances [[1]](https://github.com/lamassuiot/lamassuiot/pull/614/changes#diff-1e6c278c3a083b9aca99ec14df7d88756183c19985677bcebf7d1927b4871df5R30)
- `MigrateWithConfig(ctx, logger, storageConf, dryRun)`— convenience wrapper that builds storage engines from config structs [[1]](https://github.com/lamassuiot/lamassuiot/pull/614/changes#diff-1e6c278c3a083b9aca99ec14df7d88756183c19985677bcebf7d1927b4871df5R45)

**`ca-to-kms-migration`** — a thin CLI binary that loads config from `LAMASSU_CONFIG_FILE` and delegates to `catokms.MigrateWithConfig`. Supports `--dry-run` mode. Exits `1` if any key insertion fails, making it suitable as a Helm `pre-upgrade` hook Job. [[1]](https://github.com/lamassuiot/lamassuiot/pull/614/changes#diff-1be3a67b3e5728ba8c37bf5bb52d1b983ab5e6fe0744b8ac5ac4499b74a386a6R14)

**`ca-to-kms-migration.dockerfile`**— multi-stage Dockerfile. [[1]](https://github.com/lamassuiot/lamassuiot/pull/614/changes#diff-6ca1efcb906a4168fd797b21c25856d47be80a551c92f17024b17506f23e85e1)

### Migration behaviour

1. Reads all `MANAGED` and `IMPORTED_WITH_KEY` CA certificates from the CA Postgres database (read-only)
2. Groups certificates that share the same public key (identified by `subject_key_id`)
3. For each unique key not already present in `kms_keys`: derives **algorithm**, **size**, and **public_key** from the stored X.509 certificate; sets `has_private_key = true`; populates `metadata["lamassu.io/kms/binded-resources"] `with the serial numbers of all CA certificates bound to that key
4. Skips `IMPORTED_WITHOUT_KEY` certificates (no private key to register)
5. **Idempotent** — keys already present in `kms_keys` are skipped, so the tool is safe to run multiple times

### CI / Release

**`ca-to-kms-migration`** has been added to the service matrix in both release workflows:

- **dev-release.yaml** — builds and pushes `ghcr.io/lamassuiot/lamassu-ca-to-kms-migration:dev` on manual dispatch
- **release_finalize.yaml** — builds and pushes `ghcr.io/lamassuiot/lamassu-ca-to-kms-migration:<version>` and `:latest` on each release

### Tests

23 unit tests in `migration_test.go` using in-memory mock storage — no Docker or database required. Coverage includes: empty CA store, RSA/ECDSA cert types, certificate type filtering, shared-key grouping, nil/missing field guards, dry-run, storage error handling, idempotency, and the full `Migrate` public API.