### PR TITLE
fix(DMS): rename external_webhook JSON field to external_webhook_settings

### DIFF
--- a/core/pkg/models/dms.go
+++ b/core/pkg/models/dms.go
@@ -73,7 +73,7 @@ type EnrollmentSettings struct {
 type EnrollmentOptionsESTRFC7030 struct {
 	AuthMode                   ESTAuthMode                  `json:"auth_mode"`
 	AuthOptionsMTLS            AuthOptionsClientCertificate `json:"client_certificate_settings"`
-	AuthOptionsExternalWebhook WebhookCall                  `json:"external_webhook"`
+	AuthOptionsExternalWebhook WebhookCall                  `json:"external_webhook_settings"`
 }
 
 type AuthOptionsClientCertificate struct {


### PR DESCRIPTION
This PR renames the JSON serialization key for `AuthOptionsExternalWebhook` in `EnrollmentOptionsESTRFC7030` from `external_webhook` to `external_webhook_settings` for naming consistency with the adjacent `client_certificate_settings` field.

The Dashboard app sends `external_webhook_settings` when submitting EST enrollment options, but the backend model was deserializing from `external_webhook`, causing a field mismatch and the webhook settings being silently dropped. This fix aligns the JSON key in `EnrollmentOptionsESTRFC7030` with what the frontend already sends.



