### PR TITLE
fix: update workflow permissions

### DIFF
--- a/.github/workflows/bump-goversion.yaml
+++ b/.github/workflows/bump-goversion.yaml
@@ -1,5 +1,9 @@
 name: Bump Go Version
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release_finalize.yaml
+++ b/.github/workflows/release_finalize.yaml
@@ -1,6 +1,9 @@
 # .github/workflows/release_finalize.yml
 name: Finalize Release
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]
@@ -56,6 +59,8 @@ jobs:
     name: Bump Module Versions
     needs: extract_version
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -138,6 +143,8 @@ jobs:
     name: Create Global Tag & Release
     needs: finalize
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -190,6 +197,8 @@ jobs:
     needs: [create_global_release, finalize]
     runs-on: ubuntu-latest
     environment: release
+    permissions:
+      contents: write
     strategy:
       matrix:
         module: ${{ fromJson(needs.finalize.outputs.json_modules) }}
@@ -216,6 +225,8 @@ jobs:
     needs: [create_module_release, finalize]
     runs-on: ubuntu-latest
     environment: release
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/release_open_pr.yaml
+++ b/.github/workflows/release_open_pr.yaml
@@ -1,5 +1,9 @@
 name: "Release Workflow - Open Pull Request with release notes"
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to explicitly set permissions for better security and clarity. The main changes involve adding or refining the `permissions` field for different jobs and workflows to ensure that only the required access is granted.

**Workflow permissions updates:**

*General workflow permissions:*
- Added explicit `permissions` fields to the top level of `.github/workflows/bump-goversion.yaml` and `.github/workflows/release_open_pr.yaml`, granting `contents: write` and `pull-requests: write` as needed. [[1]](diffhunk://#diff-686e8de3a0c7f80a7883b59e76c9d4e8b38a5a69e4b71a5f4e6ffd74d51880bdR3-R6) [[2]](diffhunk://#diff-64723abdd511e252debd6e32eb6282ad38ae9b15a1a2b7a0acfbbd6e98703243R3-R6)
- Added a `permissions: contents: read` field to the top level of `.github/workflows/release_finalize.yaml` to restrict default access.

*Job-specific permissions in `release_finalize.yaml`:*
- Added or refined `permissions` fields for individual jobs to grant only the necessary access, including:
  - `contents: read` for "Bump Module Versions" and "Finalize Module Release" jobs. [[1]](diffhunk://#diff-63d3b52a02115ceb6c7f267b450cad75430b889352daf8c8d16ec38aae43ab0cR62-R63) [[2]](diffhunk://#diff-63d3b52a02115ceb6c7f267b450cad75430b889352daf8c8d16ec38aae43ab0cR228-R229)
  - `contents: write` for "Create Global Tag & Release" and "Create Module Release" jobs. [[1]](diffhunk://#diff-63d3b52a02115ceb6c7f267b450cad75430b889352daf8c8d16ec38aae43ab0cR146-R147) [[2]](diffhunk://#diff-63d3b52a02115ceb6c7f267b450cad75430b889352daf8c8d16ec38aae43ab0cR200-R201)