### PR TITLE
fix: improve future-dated certificate validation logic

### DIFF
--- a/backend/pkg/helpers/x509validation.go
+++ b/backend/pkg/helpers/x509validation.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"crypto/x509"
 	"fmt"
+	"time"
 )
 
 func ValidateCertificate(ca, cert *x509.Certificate, considerExpiration bool) error {
@@ -14,6 +15,13 @@ func ValidateCertificates(ca *x509.Certificate, certs []*x509.Certificate, consi
 		return fmt.Errorf("no certificates provided for validation")
 	}
 
+	leafCert := certs[0]
+
+	// Always reject future-dated certificates.
+	if time.Now().Before(leafCert.NotBefore) {
+		return fmt.Errorf("certificate is not yet valid (NotBefore=%s)", leafCert.NotBefore.UTC().Format(time.RFC3339))
+	}
+
 	caPool := x509.NewCertPool()
 	caPool.AddCert(ca)
 
@@ -21,8 +29,6 @@ func ValidateCertificates(ca *x509.Certificate, certs []*x509.Certificate, consi
 		Roots:     caPool,
 		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
 	}
-
-	leafCert := certs[0]
 
 	if !considerExpiration {
 		opts.CurrentTime = leafCert.NotBefore //set to same date as certificate, otherwise expired certificates will trigger Verify error

--- a/backend/pkg/helpers/x509validation_test.go
+++ b/backend/pkg/helpers/x509validation_test.go
@@ -1,7 +1,17 @@
 package helpers
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	chelpers "github.com/lamassuiot/lamassuiot/core/v3/pkg/helpers"
 )
@@ -44,4 +54,67 @@ func TestValidateCertificate(t *testing.T) {
 		t.Errorf("Certificate validation should have failed")
 	}
 
+}
+
+// generateTestCA creates an in-memory ECDSA CA and returns the cert and key.
+func generateTestCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test CA"},
+		NotBefore:             time.Now().Add(-24 * time.Hour),
+		NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	ca, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return ca, key
+}
+
+// generateLeafCert issues a leaf certificate from the given CA with the provided NotBefore/NotAfter.
+func generateLeafCert(t *testing.T, ca *x509.Certificate, caKey *ecdsa.PrivateKey, notBefore, notAfter time.Time) *x509.Certificate {
+	t.Helper()
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkixNameWithCN("test-device"),
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca, &leafKey.PublicKey, caKey)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return cert
+}
+
+// TestValidateCertificates_FutureDated verifies that a certificate whose NotBefore is in the
+// future is always rejected, regardless of the considerExpiration flag.
+// This guards against the vulnerability where setting considerExpiration=false (i.e. AllowExpired)
+// pinned opts.CurrentTime to NotBefore, inadvertently validating future-dated certificates.
+func TestValidateCertificates_FutureDated(t *testing.T) {
+	ca, caKey := generateTestCA(t)
+
+	futureCert := generateLeafCert(t, ca, caKey,
+		time.Now().Add(365*24*time.Hour),   // NotBefore: 1 year in the future
+		time.Now().Add(2*365*24*time.Hour), // NotAfter:  2 years in the future
+	)
+
+	// considerExpiration=false simulates the AllowExpired enrollment path — must still reject.
+	err := ValidateCertificate(ca, futureCert, false)
+	assert.Error(t, err, "future-dated certificate must be rejected when considerExpiration=false")
+	assert.Contains(t, err.Error(), "not yet valid")
+
+	// considerExpiration=true — must also reject (regression guard).
+	err = ValidateCertificate(ca, futureCert, true)
+	assert.Error(t, err, "future-dated certificate must be rejected when considerExpiration=true")
 }


### PR DESCRIPTION
This PR fixes an edge case in `ValidateCertificates` where a certificate with a `NotBefore` date in the future would bypass explicit rejection and instead have `CurrentTime` silently set to `NotBefore` (when `considerExpiration=false`), effectively allowing the certificate to pass validation.

Closes #641

### Changes

#### `backend/pkg/helpers/x509validation.go`
- Added an explicit early check: if `time.Now()` is before the leaf certificate's `NotBefore`, the function returns an error immediately with a descriptive message. [[1]](https://github.com/lamassuiot/lamassuiot/pull/642/changes#diff-1322584ace6cd6001eb90821b69d1314e820382e314699657120a14dd35da53eR21)

#### `backend/pkg/helpers/x509validation_test.go`
- Added `TestValidateCertificates_FutureDated` covering the new rejection path.

### Why

Previously, future-dated certificates were silently accepted because `opts.CurrentTime` was set to the certificate's own `NotBefore`, making X.509 `Verify` see it as "just valid". This fix ensures such certificates are always rejected with a clear error.