### PR TITLE
feat(DMS): support external webhook auth in reenrollment

### DIFF
--- a/backend/pkg/assemblers/tests/dms-manager/main_test.go
+++ b/backend/pkg/assemblers/tests/dms-manager/main_test.go
@@ -2662,7 +2662,9 @@ func TestESTEnroll(t *testing.T) {
 				}
 				defer cleanup()
 
+				var webhookCallCount atomic.Int32
 				router.POST("/verify", func(c *gin.Context) {
+					webhookCallCount.Add(1)
 					c.JSON(200, gin.H{"authorized": true})
 				})
 
@@ -2700,6 +2702,9 @@ func TestESTEnroll(t *testing.T) {
 				enrollCSR, _ := chelpers.GenerateCertificateRequest(models.Subject{CommonName: "device-no-cert"}, enrollKey)
 
 				_, err = estCli.Enroll(context.Background(), enrollCSR)
+				if webhookCallCount.Load() != 0 {
+					t.Fatalf("webhook must not be called when client certificate validation fails first, but was called %d time(s)", webhookCallCount.Load())
+				}
 				return nil, nil, nil, err
 			},
 			resultCheck: func(caCert, cert *x509.Certificate, key any, err error) {
@@ -4272,7 +4277,9 @@ func TestESTReEnroll(t *testing.T) {
 				defer cleanup()
 
 				// webhook should never be reached since mTLS fails first
+				var webhookCallCount atomic.Int32
 				router.POST("/verify", func(c *gin.Context) {
+					webhookCallCount.Add(1)
 					c.JSON(200, gin.H{"authorized": true})
 				})
 
@@ -4308,6 +4315,9 @@ func TestESTReEnroll(t *testing.T) {
 				}
 
 				_, err = estCli.Reenroll(context.Background(), newCsr)
+				if webhookCallCount.Load() != 0 {
+					t.Fatalf("webhook must not be called when client certificate validation fails first, but was called %d time(s)", webhookCallCount.Load())
+				}
 				return nil, nil, nil, err
 			},
 			resultCheck: func(caCert, cert *x509.Certificate, key any, err error) {
@@ -4332,7 +4342,9 @@ func TestESTReEnroll(t *testing.T) {
 				}
 				defer cleanup()
 
+				var webhookCallCount atomic.Int32
 				router.POST("/verify", func(c *gin.Context) {
+					webhookCallCount.Add(1)
 					c.JSON(200, gin.H{"authorized": true})
 				})
 
@@ -4365,6 +4377,9 @@ func TestESTReEnroll(t *testing.T) {
 				}
 
 				_, err = estCli.Reenroll(context.Background(), newCsr)
+				if webhookCallCount.Load() != 0 {
+					t.Fatalf("webhook must not be called when client certificate validation fails first, but was called %d time(s)", webhookCallCount.Load())
+				}
 				return nil, nil, nil, err
 			},
 			resultCheck: func(caCert, cert *x509.Certificate, key any, err error) {

--- a/backend/pkg/assemblers/tests/dms-manager/main_test.go
+++ b/backend/pkg/assemblers/tests/dms-manager/main_test.go
@@ -4014,6 +4014,365 @@ func TestESTReEnroll(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "OK/ExternalWebhook",
+			run: func() (caCert *x509.Certificate, cert *x509.Certificate, key any, err error) {
+				dms, enrollmentCA, deviceCrt, deviceKey := prepReenrollScenario(
+					func(in *services.CreateDMSInput) {
+						in.Settings.ReEnrollmentSettings.ReEnrollmentDelta = models.TimeDuration(time.Hour)
+					},
+					"1m",
+				)
+
+				router, url, cleanup, err := tests.StartWebhookServer()
+				if err != nil {
+					t.Fatalf("could not start webhook server: %s", err)
+				}
+				defer cleanup()
+
+				router.POST("/verify", func(c *gin.Context) {
+					c.JSON(200, gin.H{"authorized": true})
+				})
+
+				dms.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthMode = models.ESTAuthModeExternalWebhook
+				dms.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthOptionsExternalWebhook = models.WebhookCall{
+					Name: "myHook",
+					Url:  url + "/verify",
+					Config: models.WebhookCallHttpClient{
+						ValidateServerCert: false,
+						LogLevel:           string(config.Debug),
+						AuthMode:           config.NoAuth,
+					},
+				}
+				dms, err = dmsMgr.HttpDeviceManagerSDK.UpdateDMS(context.Background(), services.UpdateDMSInput{
+					DMS: *dms,
+				})
+				if err != nil {
+					t.Fatalf("could not update DMS to webhook auth mode: %s", err)
+				}
+
+				newCsr, _ := chelpers.GenerateCertificateRequest(models.Subject{CommonName: deviceCrt.Subject.CommonName}, deviceKey)
+
+				// No client cert needed for external-webhook-only reenrollment
+				estCli := est.Client{
+					Host:                  fmt.Sprintf("localhost:%d", dmsMgr.Port),
+					AdditionalPathSegment: dms.ID,
+					Certificates:          []*x509.Certificate{},
+					PrivateKey:            nil,
+					InsecureSkipVerify:    true,
+				}
+
+				reEnrollCRT, err := estCli.Reenroll(context.Background(), newCsr)
+				if err != nil {
+					t.Fatalf("unexpected error while reenrolling: %s", err)
+				}
+
+				return enrollmentCA, reEnrollCRT, deviceKey, nil
+			},
+			resultCheck: func(caCert, cert *x509.Certificate, key any, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err)
+				}
+				checkReEnroll(t, caCert, cert, key)
+			},
+		},
+		{
+			name: "Err/ExternalWebhook-WebhookDenied",
+			run: func() (caCert *x509.Certificate, cert *x509.Certificate, key any, err error) {
+				dms, _, deviceCrt, deviceKey := prepReenrollScenario(
+					func(in *services.CreateDMSInput) {
+						in.Settings.ReEnrollmentSettings.ReEnrollmentDelta = models.TimeDuration(time.Hour)
+					},
+					"1m",
+				)
+
+				router, url, cleanup, err := tests.StartWebhookServer()
+				if err != nil {
+					t.Fatalf("could not start webhook server: %s", err)
+				}
+				defer cleanup()
+
+				router.POST("/verify", func(c *gin.Context) {
+					c.JSON(200, gin.H{"authorized": false})
+				})
+
+				dms.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthMode = models.ESTAuthModeExternalWebhook
+				dms.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthOptionsExternalWebhook = models.WebhookCall{
+					Name: "myHook",
+					Url:  url + "/verify",
+					Config: models.WebhookCallHttpClient{
+						ValidateServerCert: false,
+						LogLevel:           string(config.Debug),
+						AuthMode:           config.NoAuth,
+					},
+				}
+				dms, err = dmsMgr.HttpDeviceManagerSDK.UpdateDMS(context.Background(), services.UpdateDMSInput{
+					DMS: *dms,
+				})
+				if err != nil {
+					t.Fatalf("could not update DMS to webhook auth mode: %s", err)
+				}
+
+				newCsr, _ := chelpers.GenerateCertificateRequest(models.Subject{CommonName: deviceCrt.Subject.CommonName}, deviceKey)
+
+				estCli := est.Client{
+					Host:                  fmt.Sprintf("localhost:%d", dmsMgr.Port),
+					AdditionalPathSegment: dms.ID,
+					Certificates:          []*x509.Certificate{},
+					PrivateKey:            nil,
+					InsecureSkipVerify:    true,
+				}
+
+				_, err = estCli.Reenroll(context.Background(), newCsr)
+				return nil, nil, nil, err
+			},
+			resultCheck: func(caCert, cert *x509.Certificate, key any, err error) {
+				if err == nil {
+					t.Fatalf("expected error. Got none")
+				}
+				if !strings.Contains(err.Error(), "external webhook denied reenrollment") {
+					t.Fatalf("error should contain 'external webhook denied reenrollment'. Got error %s", err.Error())
+				}
+			},
+		},
+		{
+			name: "OK/CombinedMTLSAndWebhook",
+			run: func() (caCert *x509.Certificate, cert *x509.Certificate, key any, err error) {
+				dms, enrollmentCA, deviceCrt, deviceKey := prepReenrollScenario(
+					func(in *services.CreateDMSInput) {
+						in.Settings.ReEnrollmentSettings.ReEnrollmentDelta = models.TimeDuration(time.Hour)
+					},
+					"1m",
+				)
+
+				router, url, cleanup, err := tests.StartWebhookServer()
+				if err != nil {
+					t.Fatalf("could not start webhook server: %s", err)
+				}
+				defer cleanup()
+
+				router.POST("/verify", func(c *gin.Context) {
+					c.JSON(200, gin.H{"authorized": true})
+				})
+
+				dms.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthMode = models.ESTAuthModeClientCertificateAndWebhook
+				dms.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthOptionsExternalWebhook = models.WebhookCall{
+					Name: "myHook",
+					Url:  url + "/verify",
+					Config: models.WebhookCallHttpClient{
+						ValidateServerCert: false,
+						LogLevel:           string(config.Debug),
+						AuthMode:           config.NoAuth,
+					},
+				}
+				dms, err = dmsMgr.HttpDeviceManagerSDK.UpdateDMS(context.Background(), services.UpdateDMSInput{
+					DMS: *dms,
+				})
+				if err != nil {
+					t.Fatalf("could not update DMS to combined auth mode: %s", err)
+				}
+
+				newCsr, _ := chelpers.GenerateCertificateRequest(models.Subject{CommonName: deviceCrt.Subject.CommonName}, deviceKey)
+
+				estCli := est.Client{
+					Host:                  fmt.Sprintf("localhost:%d", dmsMgr.Port),
+					AdditionalPathSegment: dms.ID,
+					Certificates:          []*x509.Certificate{deviceCrt},
+					PrivateKey:            deviceKey,
+					InsecureSkipVerify:    true,
+				}
+
+				reEnrollCRT, err := estCli.Reenroll(context.Background(), newCsr)
+				if err != nil {
+					t.Fatalf("unexpected error while reenrolling: %s", err)
+				}
+
+				return enrollmentCA, reEnrollCRT, deviceKey, nil
+			},
+			resultCheck: func(caCert, cert *x509.Certificate, key any, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err)
+				}
+				checkReEnroll(t, caCert, cert, key)
+			},
+		},
+		{
+			name: "Err/CombinedMTLSAndWebhook-WebhookDenied",
+			run: func() (caCert *x509.Certificate, cert *x509.Certificate, key any, err error) {
+				dms, _, deviceCrt, deviceKey := prepReenrollScenario(
+					func(in *services.CreateDMSInput) {
+						in.Settings.ReEnrollmentSettings.ReEnrollmentDelta = models.TimeDuration(time.Hour)
+					},
+					"1m",
+				)
+
+				router, url, cleanup, err := tests.StartWebhookServer()
+				if err != nil {
+					t.Fatalf("could not start webhook server: %s", err)
+				}
+				defer cleanup()
+
+				router.POST("/verify", func(c *gin.Context) {
+					c.JSON(200, gin.H{"authorized": false})
+				})
+
+				dms.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthMode = models.ESTAuthModeClientCertificateAndWebhook
+				dms.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthOptionsExternalWebhook = models.WebhookCall{
+					Name: "myHook",
+					Url:  url + "/verify",
+					Config: models.WebhookCallHttpClient{
+						ValidateServerCert: false,
+						LogLevel:           string(config.Debug),
+						AuthMode:           config.NoAuth,
+					},
+				}
+				dms, err = dmsMgr.HttpDeviceManagerSDK.UpdateDMS(context.Background(), services.UpdateDMSInput{
+					DMS: *dms,
+				})
+				if err != nil {
+					t.Fatalf("could not update DMS to combined auth mode: %s", err)
+				}
+
+				newCsr, _ := chelpers.GenerateCertificateRequest(models.Subject{CommonName: deviceCrt.Subject.CommonName}, deviceKey)
+
+				estCli := est.Client{
+					Host:                  fmt.Sprintf("localhost:%d", dmsMgr.Port),
+					AdditionalPathSegment: dms.ID,
+					Certificates:          []*x509.Certificate{deviceCrt},
+					PrivateKey:            deviceKey,
+					InsecureSkipVerify:    true,
+				}
+
+				_, err = estCli.Reenroll(context.Background(), newCsr)
+				return nil, nil, nil, err
+			},
+			resultCheck: func(caCert, cert *x509.Certificate, key any, err error) {
+				if err == nil {
+					t.Fatalf("expected error. Got none")
+				}
+				if !strings.Contains(err.Error(), "external webhook denied reenrollment") {
+					t.Fatalf("error should contain 'external webhook denied reenrollment'. Got error %s", err.Error())
+				}
+			},
+		},
+		{
+			name: "Err/CombinedMTLSAndWebhook-InvalidCert",
+			run: func() (caCert *x509.Certificate, cert *x509.Certificate, key any, err error) {
+				dms, _, deviceCrt, deviceKey := prepReenrollScenario(
+					func(in *services.CreateDMSInput) {
+						in.Settings.ReEnrollmentSettings.ReEnrollmentDelta = models.TimeDuration(time.Hour)
+					},
+					"1m",
+				)
+
+				router, url, cleanup, err := tests.StartWebhookServer()
+				if err != nil {
+					t.Fatalf("could not start webhook server: %s", err)
+				}
+				defer cleanup()
+
+				// webhook should never be reached since mTLS fails first
+				router.POST("/verify", func(c *gin.Context) {
+					c.JSON(200, gin.H{"authorized": true})
+				})
+
+				dms.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthMode = models.ESTAuthModeClientCertificateAndWebhook
+				dms.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthOptionsExternalWebhook = models.WebhookCall{
+					Name: "myHook",
+					Url:  url + "/verify",
+					Config: models.WebhookCallHttpClient{
+						ValidateServerCert: false,
+						LogLevel:           string(config.Debug),
+						AuthMode:           config.NoAuth,
+					},
+				}
+				dms, err = dmsMgr.HttpDeviceManagerSDK.UpdateDMS(context.Background(), services.UpdateDMSInput{
+					DMS: *dms,
+				})
+				if err != nil {
+					t.Fatalf("could not update DMS to combined auth mode: %s", err)
+				}
+
+				// present a self-signed cert (not from the enroll CA)
+				fakeKey, _ := chelpers.GenerateRSAKey(2048)
+				fakeCert, _ := chelpers.GenerateSelfSignedCertificate(fakeKey, deviceCrt.Subject.CommonName)
+
+				newCsr, _ := chelpers.GenerateCertificateRequest(models.Subject{CommonName: deviceCrt.Subject.CommonName}, deviceKey)
+
+				estCli := est.Client{
+					Host:                  fmt.Sprintf("localhost:%d", dmsMgr.Port),
+					AdditionalPathSegment: dms.ID,
+					Certificates:          []*x509.Certificate{fakeCert},
+					PrivateKey:            fakeKey,
+					InsecureSkipVerify:    true,
+				}
+
+				_, err = estCli.Reenroll(context.Background(), newCsr)
+				return nil, nil, nil, err
+			},
+			resultCheck: func(caCert, cert *x509.Certificate, key any, err error) {
+				if err == nil {
+					t.Fatalf("expected error. Got none")
+				}
+			},
+		},
+		{
+			name: "Err/CombinedMTLSAndWebhook-NoCert",
+			run: func() (caCert *x509.Certificate, cert *x509.Certificate, key any, err error) {
+				dms, _, deviceCrt, deviceKey := prepReenrollScenario(
+					func(in *services.CreateDMSInput) {
+						in.Settings.ReEnrollmentSettings.ReEnrollmentDelta = models.TimeDuration(time.Hour)
+					},
+					"1m",
+				)
+
+				router, url, cleanup, err := tests.StartWebhookServer()
+				if err != nil {
+					t.Fatalf("could not start webhook server: %s", err)
+				}
+				defer cleanup()
+
+				router.POST("/verify", func(c *gin.Context) {
+					c.JSON(200, gin.H{"authorized": true})
+				})
+
+				dms.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthMode = models.ESTAuthModeClientCertificateAndWebhook
+				dms.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthOptionsExternalWebhook = models.WebhookCall{
+					Name: "myHook",
+					Url:  url + "/verify",
+					Config: models.WebhookCallHttpClient{
+						ValidateServerCert: false,
+						LogLevel:           string(config.Debug),
+						AuthMode:           config.NoAuth,
+					},
+				}
+				dms, err = dmsMgr.HttpDeviceManagerSDK.UpdateDMS(context.Background(), services.UpdateDMSInput{
+					DMS: *dms,
+				})
+				if err != nil {
+					t.Fatalf("could not update DMS to combined auth mode: %s", err)
+				}
+
+				newCsr, _ := chelpers.GenerateCertificateRequest(models.Subject{CommonName: deviceCrt.Subject.CommonName}, deviceKey)
+
+				// No client cert presented - should be rejected at the mTLS step
+				estCli := est.Client{
+					Host:                  fmt.Sprintf("localhost:%d", dmsMgr.Port),
+					AdditionalPathSegment: dms.ID,
+					Certificates:          []*x509.Certificate{},
+					PrivateKey:            nil,
+					InsecureSkipVerify:    true,
+				}
+
+				_, err = estCli.Reenroll(context.Background(), newCsr)
+				return nil, nil, nil, err
+			},
+			resultCheck: func(caCert, cert *x509.Certificate, key any, err error) {
+				if err == nil {
+					t.Fatalf("expected error. Got none")
+				}
+			},
+		},
 	}
 
 	for _, tc := range testcases {

--- a/backend/pkg/services/dmsmanager.go
+++ b/backend/pkg/services/dmsmanager.go
@@ -475,6 +475,7 @@ func checkReenrollmentExpiry(lFunc *logrus.Entry, leafCert *x509.Certificate, re
 // operation should be "enrollment" or "reenrollment" and is used in log messages and errors.
 func invokeWebhook(ctx context.Context, lFunc *logrus.Entry, webhookConf models.WebhookCall, csr *x509.CertificateRequest, aps string, operation string) (*logrus.Entry, error) {
 	lFunc = lFunc.WithField("auth-status", "verifying")
+	lFunc = lFunc.WithField("auth-uri", webhookConf.Url)
 	lFunc.Infof("verifying %s using external webhook: %s. Calling webhook %s", operation, webhookConf.Name, webhookConf.Url)
 
 	webhookRequestBodyHeaders := make(map[string]string)
@@ -548,7 +549,6 @@ func invokeWebhook(ctx context.Context, lFunc *logrus.Entry, webhookConf models.
 		}
 	}
 
-	lFunc = lFunc.WithField("auth-uri", webhookConf.Name)
 	lFunc.Infof("webhook authorized %s", operation)
 	return lFunc, nil
 }

--- a/backend/pkg/services/dmsmanager.go
+++ b/backend/pkg/services/dmsmanager.go
@@ -553,6 +553,83 @@ func invokeWebhook(ctx context.Context, lFunc *logrus.Entry, webhookConf models.
 	return lFunc, nil
 }
 
+// clientCertValidator is a function type used by authenticateEST to delegate
+// the per-operation (enroll / reenroll) certificate-chain validation logic.
+type clientCertValidator func(ctx context.Context, lFunc *logrus.Entry, clientCerts []*x509.Certificate) (*logrus.Entry, error)
+
+// authenticateEST runs the authentication step shared by Enroll and Reenroll,
+// dispatching to the appropriate handler based on estAuthOptions.AuthMode.
+// validateCert is called whenever the auth mode requires a client certificate;
+// its implementation differs between enrollment and reenrollment.
+func (svc DMSManagerServiceBackend) authenticateEST(
+	ctx context.Context,
+	lFunc *logrus.Entry,
+	estAuthOptions models.EnrollmentOptionsESTRFC7030,
+	csr *x509.CertificateRequest,
+	aps string,
+	operation string,
+	validateCert clientCertValidator,
+) (*logrus.Entry, error) {
+	var err error
+	switch estAuthOptions.AuthMode {
+	case models.ESTAuthModeClientCertificate:
+		lFunc = lFunc.WithField("auth-method", models.ESTAuthModeClientCertificate)
+		clientCerts, hasValue := ctx.Value(string(models.ESTAuthModeClientCertificate)).([]*x509.Certificate)
+		if !hasValue || len(clientCerts) == 0 {
+			lFunc.Errorf("aborting %s. No client certificate was presented", operation)
+			return lFunc, errs.ErrDMSAuthModeNotSupported
+		}
+		lFunc, err = validateCert(ctx, lFunc, clientCerts)
+		if err != nil {
+			return lFunc, err
+		}
+		lFunc = lFunc.WithField("auth-status", "verified")
+		lFunc.Infof("certificate verified")
+
+	case models.ESTAuthModeNoAuth:
+		lFunc = lFunc.WithField("auth-method", models.ESTAuthModeNoAuth)
+		lFunc = lFunc.WithField("auth-status", "verified")
+		lFunc = lFunc.WithField("auth-uri", "NoAuth")
+		lFunc.Warnf("DMS is configured with NoAuth, allowing %s", operation)
+
+	case models.ESTAuthModeExternalWebhook:
+		lFunc = lFunc.WithField("auth-method", models.ESTAuthModeExternalWebhook)
+		lFunc, err = invokeWebhook(ctx, lFunc, estAuthOptions.AuthOptionsExternalWebhook, csr, aps, operation)
+		if err != nil {
+			return lFunc, err
+		}
+		lFunc = lFunc.WithField("auth-status", "verified")
+		lFunc.Infof("external webhook authorized %s", operation)
+
+	case models.ESTAuthModeClientCertificateAndWebhook:
+		lFunc = lFunc.WithField("auth-method", models.ESTAuthModeClientCertificateAndWebhook)
+		lFunc.Infof("combined auth: starting client certificate validation (step 1/2)")
+		clientCerts, hasValue := ctx.Value(string(models.ESTAuthModeClientCertificate)).([]*x509.Certificate)
+		if !hasValue || len(clientCerts) == 0 {
+			lFunc = lFunc.WithField("auth-status", "failed")
+			lFunc.Errorf("aborting %s. No client certificate was presented", operation)
+			return lFunc, errs.ErrDMSAuthModeNotSupported
+		}
+		lFunc, err = validateCert(ctx, lFunc, clientCerts)
+		if err != nil {
+			return lFunc, err
+		}
+		lFunc.Infof("combined auth: client certificate validation passed. Starting webhook validation (step 2/2)")
+		lFunc, err = invokeWebhook(ctx, lFunc, estAuthOptions.AuthOptionsExternalWebhook, csr, aps, operation)
+		if err != nil {
+			return lFunc, err
+		}
+		lFunc = lFunc.WithField("auth-status", "verified")
+		lFunc.Infof("combined auth: both client certificate and webhook validations passed")
+
+	default:
+		lFunc.Errorf("aborting %s. DMS is not correctly configured. No auth method configured. Specify an authentication method", operation)
+		return lFunc, errs.ErrDMSAuthModeNotSupported
+	}
+
+	return lFunc, nil
+}
+
 // Validation:
 //   - Cert:
 //     Only Bootstrap cert (CA issued By Lamassu)
@@ -590,60 +667,12 @@ func (svc DMSManagerServiceBackend) Enroll(ctx context.Context, csr *x509.Certif
 	lFunc = lFunc.WithField("step", "Authenticating")
 	lFunc.Infof("starting authentication process")
 
-	switch estAuthOptions.AuthMode {
-	case models.ESTAuthModeClientCertificate:
-		lFunc = lFunc.WithField("auth-method", models.ESTAuthModeClientCertificate)
-		clientCerts, hasValue := ctx.Value(string(models.ESTAuthModeClientCertificate)).([]*x509.Certificate)
-		if !hasValue || len(clientCerts) == 0 {
-			lFunc.Errorf("aborting enrollment. No client certificate was presented")
-			return nil, errs.ErrDMSAuthModeNotSupported
-		}
-		lFunc, err = svc.validateClientCertificateEnrollment(ctx, lFunc, estAuthOptions, clientCerts)
-		if err != nil {
-			return nil, err
-		}
-		lFunc = lFunc.WithField("auth-status", "verified")
-		lFunc.Infof("certificate verified")
-
-	case models.ESTAuthModeNoAuth:
-		lFunc = lFunc.WithField("auth-method", models.ESTAuthModeNoAuth)
-		lFunc = lFunc.WithField("auth-status", "verified")
-		lFunc = lFunc.WithField("auth-uri", "NoAuth")
-		lFunc.Warnf("DMS is configured with NoAuth, allowing enrollment")
-
-	case models.ESTAuthModeExternalWebhook:
-		lFunc = lFunc.WithField("auth-method", models.ESTAuthModeExternalWebhook)
-		lFunc, err = invokeWebhook(ctx, lFunc, estAuthOptions.AuthOptionsExternalWebhook, csr, aps, "enrollment")
-		if err != nil {
-			return nil, err
-		}
-		lFunc = lFunc.WithField("auth-status", "verified")
-		lFunc.Infof("external webhook authorized enrollment")
-
-	case models.ESTAuthModeClientCertificateAndWebhook:
-		lFunc = lFunc.WithField("auth-method", models.ESTAuthModeClientCertificateAndWebhook)
-		lFunc.Infof("combined auth: starting client certificate validation (step 1/2)")
-		clientCerts, hasValue := ctx.Value(string(models.ESTAuthModeClientCertificate)).([]*x509.Certificate)
-		if !hasValue || len(clientCerts) == 0 {
-			lFunc = lFunc.WithField("auth-status", "failed")
-			lFunc.Errorf("aborting enrollment. No client certificate was presented")
-			return nil, errs.ErrDMSAuthModeNotSupported
-		}
-		lFunc, err = svc.validateClientCertificateEnrollment(ctx, lFunc, estAuthOptions, clientCerts)
-		if err != nil {
-			return nil, err
-		}
-		lFunc.Infof("combined auth: client certificate validation passed. Starting webhook validation (step 2/2)")
-		lFunc, err = invokeWebhook(ctx, lFunc, estAuthOptions.AuthOptionsExternalWebhook, csr, aps, "enrollment")
-		if err != nil {
-			return nil, err
-		}
-		lFunc = lFunc.WithField("auth-status", "verified")
-		lFunc.Infof("combined auth: both client certificate and webhook validations passed")
-
-	default:
-		lFunc.Errorf("aborting enrollment. DMS is not correctly configured. No auth method configured. Specify an authentication method")
-		return nil, errs.ErrDMSAuthModeNotSupported
+	validateCert := func(ctx context.Context, lFunc *logrus.Entry, clientCerts []*x509.Certificate) (*logrus.Entry, error) {
+		return svc.validateClientCertificateEnrollment(ctx, lFunc, estAuthOptions, clientCerts)
+	}
+	lFunc, err = svc.authenticateEST(ctx, lFunc, estAuthOptions, csr, aps, "enrollment", validateCert)
+	if err != nil {
+		return nil, err
 	}
 
 	lFunc.Infof("authentication process completed successfully")
@@ -828,61 +857,12 @@ func (svc DMSManagerServiceBackend) Reenroll(ctx context.Context, csr *x509.Cert
 	lFunc = lFunc.WithField("step", "Authenticating")
 	lFunc.Infof("starting authentication process")
 
-	authMode := enrollSettings.EnrollmentOptionsESTRFC7030.AuthMode
-	switch authMode {
-	case models.ESTAuthModeClientCertificate:
-		lFunc = lFunc.WithField("auth-method", models.ESTAuthModeClientCertificate)
-		clientCerts, hasValue := ctx.Value(string(models.ESTAuthModeClientCertificate)).([]*x509.Certificate)
-		if !hasValue || len(clientCerts) == 0 {
-			lFunc.Errorf("aborting reenrollment. No client certificate was presented")
-			return nil, errs.ErrDMSAuthModeNotSupported
-		}
-		lFunc, err = svc.validateClientCertificateReenrollment(ctx, lFunc, enrollCAID, enrollCA, reEnrollSettings, clientCerts, csr.Subject.CommonName)
-		if err != nil {
-			return nil, err
-		}
-		lFunc = lFunc.WithField("auth-status", "verified")
-		lFunc.Infof("certificate verified")
-
-	case models.ESTAuthModeExternalWebhook:
-		lFunc = lFunc.WithField("auth-method", models.ESTAuthModeExternalWebhook)
-		lFunc, err = invokeWebhook(ctx, lFunc, enrollSettings.EnrollmentOptionsESTRFC7030.AuthOptionsExternalWebhook, csr, aps, "reenrollment")
-		if err != nil {
-			return nil, err
-		}
-		lFunc = lFunc.WithField("auth-status", "verified")
-		lFunc.Infof("external webhook authorized reenrollment")
-
-	case models.ESTAuthModeClientCertificateAndWebhook:
-		lFunc = lFunc.WithField("auth-method", models.ESTAuthModeClientCertificateAndWebhook)
-		lFunc.Infof("combined auth: starting client certificate validation (step 1/2)")
-		clientCerts, hasValue := ctx.Value(string(models.ESTAuthModeClientCertificate)).([]*x509.Certificate)
-		if !hasValue || len(clientCerts) == 0 {
-			lFunc = lFunc.WithField("auth-status", "failed")
-			lFunc.Errorf("aborting reenrollment. No client certificate was presented")
-			return nil, errs.ErrDMSAuthModeNotSupported
-		}
-		lFunc, err = svc.validateClientCertificateReenrollment(ctx, lFunc, enrollCAID, enrollCA, reEnrollSettings, clientCerts, csr.Subject.CommonName)
-		if err != nil {
-			return nil, err
-		}
-		lFunc.Infof("combined auth: client certificate validation passed. Starting webhook validation (step 2/2)")
-		lFunc, err = invokeWebhook(ctx, lFunc, enrollSettings.EnrollmentOptionsESTRFC7030.AuthOptionsExternalWebhook, csr, aps, "reenrollment")
-		if err != nil {
-			return nil, err
-		}
-		lFunc = lFunc.WithField("auth-status", "verified")
-		lFunc.Infof("combined auth: both client certificate and webhook validations passed")
-
-	case models.ESTAuthModeNoAuth:
-		lFunc = lFunc.WithField("auth-method", models.ESTAuthModeNoAuth)
-		lFunc = lFunc.WithField("auth-status", "verified")
-		lFunc = lFunc.WithField("auth-uri", "NoAuth")
-		lFunc.Warnf("DMS is configured with NoAuth, allowing reenrollment")
-
-	default:
-		lFunc.Errorf("aborting reenrollment. DMS is not correctly configured. No auth method configured. Specify an authentication method")
-		return nil, errs.ErrDMSAuthModeNotSupported
+	validateCert := func(ctx context.Context, lFunc *logrus.Entry, clientCerts []*x509.Certificate) (*logrus.Entry, error) {
+		return svc.validateClientCertificateReenrollment(ctx, lFunc, enrollCAID, enrollCA, reEnrollSettings, clientCerts, csr.Subject.CommonName)
+	}
+	lFunc, err = svc.authenticateEST(ctx, lFunc, enrollSettings.EnrollmentOptionsESTRFC7030, csr, aps, "reenrollment", validateCert)
+	if err != nil {
+		return nil, err
 	}
 
 	lFunc.Infof("authentication process completed successfully")

--- a/backend/pkg/services/dmsmanager.go
+++ b/backend/pkg/services/dmsmanager.go
@@ -589,6 +589,7 @@ func (svc DMSManagerServiceBackend) Enroll(ctx context.Context, csr *x509.Certif
 
 	lFunc = lFunc.WithField("step", "Authenticating")
 	lFunc.Infof("starting authentication process")
+
 	switch estAuthOptions.AuthMode {
 	case models.ESTAuthModeClientCertificate:
 		lFunc = lFunc.WithField("auth-method", models.ESTAuthModeClientCertificate)
@@ -826,20 +827,64 @@ func (svc DMSManagerServiceBackend) Reenroll(ctx context.Context, csr *x509.Cert
 
 	lFunc = lFunc.WithField("step", "Authenticating")
 	lFunc.Infof("starting authentication process")
-	// Always require client certificate for authentication in reenrollment, even if enrollment doesn't require it, as EST RFC7030 recommends.
-	lFunc = lFunc.WithField("auth-method", models.ESTAuthModeClientCertificate)
-	clientCerts, hasValue := ctx.Value(string(models.ESTAuthModeClientCertificate)).([]*x509.Certificate)
-	if !hasValue || len(clientCerts) == 0 {
-		lFunc.Errorf("aborting reenrollment. No client certificate was presented")
+
+	authMode := enrollSettings.EnrollmentOptionsESTRFC7030.AuthMode
+	switch authMode {
+	case models.ESTAuthModeClientCertificate:
+		lFunc = lFunc.WithField("auth-method", models.ESTAuthModeClientCertificate)
+		clientCerts, hasValue := ctx.Value(string(models.ESTAuthModeClientCertificate)).([]*x509.Certificate)
+		if !hasValue || len(clientCerts) == 0 {
+			lFunc.Errorf("aborting reenrollment. No client certificate was presented")
+			return nil, errs.ErrDMSAuthModeNotSupported
+		}
+		lFunc, err = svc.validateClientCertificateReenrollment(ctx, lFunc, enrollCAID, enrollCA, reEnrollSettings, clientCerts, csr.Subject.CommonName)
+		if err != nil {
+			return nil, err
+		}
+		lFunc = lFunc.WithField("auth-status", "verified")
+		lFunc.Infof("certificate verified")
+
+	case models.ESTAuthModeExternalWebhook:
+		lFunc = lFunc.WithField("auth-method", models.ESTAuthModeExternalWebhook)
+		lFunc, err = invokeWebhook(ctx, lFunc, enrollSettings.EnrollmentOptionsESTRFC7030.AuthOptionsExternalWebhook, csr, aps, "reenrollment")
+		if err != nil {
+			return nil, err
+		}
+		lFunc = lFunc.WithField("auth-status", "verified")
+		lFunc.Infof("external webhook authorized reenrollment")
+
+	case models.ESTAuthModeClientCertificateAndWebhook:
+		lFunc = lFunc.WithField("auth-method", models.ESTAuthModeClientCertificateAndWebhook)
+		lFunc.Infof("combined auth: starting client certificate validation (step 1/2)")
+		clientCerts, hasValue := ctx.Value(string(models.ESTAuthModeClientCertificate)).([]*x509.Certificate)
+		if !hasValue || len(clientCerts) == 0 {
+			lFunc = lFunc.WithField("auth-status", "failed")
+			lFunc.Errorf("aborting reenrollment. No client certificate was presented")
+			return nil, errs.ErrDMSAuthModeNotSupported
+		}
+		lFunc, err = svc.validateClientCertificateReenrollment(ctx, lFunc, enrollCAID, enrollCA, reEnrollSettings, clientCerts, csr.Subject.CommonName)
+		if err != nil {
+			return nil, err
+		}
+		lFunc.Infof("combined auth: client certificate validation passed. Starting webhook validation (step 2/2)")
+		lFunc, err = invokeWebhook(ctx, lFunc, enrollSettings.EnrollmentOptionsESTRFC7030.AuthOptionsExternalWebhook, csr, aps, "reenrollment")
+		if err != nil {
+			return nil, err
+		}
+		lFunc = lFunc.WithField("auth-status", "verified")
+		lFunc.Infof("combined auth: both client certificate and webhook validations passed")
+
+	case models.ESTAuthModeNoAuth:
+		lFunc = lFunc.WithField("auth-method", models.ESTAuthModeNoAuth)
+		lFunc = lFunc.WithField("auth-status", "verified")
+		lFunc = lFunc.WithField("auth-uri", "NoAuth")
+		lFunc.Warnf("DMS is configured with NoAuth, allowing reenrollment")
+
+	default:
+		lFunc.Errorf("aborting reenrollment. DMS is not correctly configured. No auth method configured. Specify an authentication method")
 		return nil, errs.ErrDMSAuthModeNotSupported
 	}
-	lFunc, err = svc.validateClientCertificateReenrollment(ctx, lFunc, enrollCAID, enrollCA, reEnrollSettings, clientCerts, csr.Subject.CommonName)
-	if err != nil {
-		return nil, err
-	}
 
-	lFunc = lFunc.WithField("auth-status", "verified")
-	lFunc.Infof("certificate verified")
 	lFunc.Infof("authentication process completed successfully")
 
 	lFunc = lFunc.WithField("step", "DeviceCheck")


### PR DESCRIPTION
This pull request extends the DMS **reenrollment** process to respect the DMS's configured authentication mode instead of unconditionally requiring a client certificate. Three additional auth modes are now handled during reenrollment: webhook-only (`ESTAuthModeExternalWebhook`), combined mTLS + webhook (`ESTAuthModeClientCertificateAndWebhook`), and no-auth (`ESTAuthModeNoAuth`).

### Changes
- Extract `authenticateEST` method and `clientCertValidator` type to share auth-mode dispatch between `Enroll` and `Reenroll`, removing the hardcoded client-certificate requirement from reenrollment [[1]](diffhunk://#diff-23d4c4af43f96397c134a3299f77ed31fc20dce780dda0b7f06c97af98e07533R564)
- Wire reenrollment to use the DMS's configured `AuthMode` (client certificate, external webhook, client certificate + webhook, no-auth) [[2]](diffhunk://#diff-23d4c4af43f96397c134a3299f77ed31fc20dce780dda0b7f06c97af98e07533R860)

### Testing
New integration tests in `main_test.go` cover all reenrollment auth-mode combinations (webhook-only, combined mTLS + webhook) including both success and denial scenarios. Webhook short-circuit behaviour (no call when mTLS fails first) is verified with an `atomic.Int32` call counter.

### Notes
Prior to this change, reenrollment always required a client certificate regardless of the DMS configuration. Existing deployments using `ESTAuthModeClientCertificate` are unaffected; the default `switch` path returns `ErrDMSAuthModeNotSupported` for unconfigured modes.