### PR TITLE
chore: enhance DEV release workflow with tag validation

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -15,19 +15,21 @@ jobs:
       - name: Validate tag input
         run: |
           TAG="${{ github.event.inputs.tag }}"
-          if [ -z "$TAG" ]; then
-            echo "TAG=dev" >> $GITHUB_ENV
-          else
-            if [ "$TAG" = "latest" ]; then
-              echo "Error: tag 'latest' is not allowed."
-              exit 1
-            fi
-            if echo "$TAG" | grep -qE '^[0-9]'; then
-              echo "Error: tag must not start with a number (got '$TAG')."
-              exit 1
-            fi
-            echo "TAG=$TAG" >> $GITHUB_ENV
+          TAG="${TAG:-dev}"
+
+          # Disallow reserved tag
+          if [[ "${TAG,,}" == "latest" ]]; then
+            echo "Error: tag 'latest' is not allowed." >&2
+            exit 1
           fi
+
+          # Docker tag allowlist + prevents newline/env injection
+          if ! [[ "$TAG" =~ ^[A-Za-z_][A-Za-z0-9_.-]{0,127}$ ]]; then
+            echo "Error: tag must match ^[A-Za-z_][A-Za-z0-9_.-]{0,127}$ (got '$TAG')." >&2
+            exit 1
+          fi
+
+          printf 'TAG=%s\n' "$TAG" >> "$GITHUB_ENV"
 
   build_docker_image:
     needs: validate_tag

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -2,9 +2,35 @@ name: "DEV Release Workflow: (ONLY creates docker images with dev tag)"
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Docker image tag (leave blank to use 'dev'). Cannot be 'latest' or start with a number."
+        required: false
+        default: ""
 
 jobs:
+  validate_tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate tag input
+        run: |
+          TAG="${{ github.event.inputs.tag }}"
+          if [ -z "$TAG" ]; then
+            echo "TAG=dev" >> $GITHUB_ENV
+          else
+            if [ "$TAG" = "latest" ]; then
+              echo "Error: tag 'latest' is not allowed."
+              exit 1
+            fi
+            if echo "$TAG" | grep -qE '^[0-9]'; then
+              echo "Error: tag must not start with a number (got '$TAG')."
+              exit 1
+            fi
+            echo "TAG=$TAG" >> $GITHUB_ENV
+          fi
+
   build_docker_image:
+    needs: validate_tag
     permissions:
       contents: read
       packages: write
@@ -32,8 +58,12 @@ jobs:
         with:
           ref: ${{ github.ref_name }}
 
-      - run: |
-          echo "SHA1VER=dev-$(git rev-parse HEAD)" >> $GITHUB_ENV
+      - name: Resolve tag
+        run: |
+          INPUT_TAG="${{ github.event.inputs.tag }}"
+          TAG="${INPUT_TAG:-dev}"
+          echo "TAG=$TAG" >> $GITHUB_ENV
+          echo "SHA1VER=${TAG}-$(git rev-parse HEAD)" >> $GITHUB_ENV
 
       - name: Login to Github Registry
         uses: docker/login-action@v3
@@ -49,7 +79,7 @@ jobs:
           build-args: |
             BASE_IMAGE=alpine:3.14
             SHA1VER=${{ env.SHA1VER }}
-            VERSION=dev
+            VERSION=${{ env.TAG }}
           tags: |
-            ghcr.io/lamassuiot/lamassu-${{ matrix.service }}:dev
+            ghcr.io/lamassuiot/lamassu-${{ matrix.service }}:${{ env.TAG }}
           push: true


### PR DESCRIPTION
This pull request enhances the DEV Release GitHub Actions workflow by introducing a customizable Docker image tag input and ensuring robust validation for tag values. The workflow now prevents the use of problematic tags (like 'latest' or tags starting with a number) and consistently applies the chosen tag throughout the Docker build and push steps.

**Workflow input and validation improvements:**

* Added a `tag` input to the workflow, allowing users to specify a custom Docker image tag (defaults to 'dev' if left blank). The workflow validates that the tag is not 'latest' and does not start with a number, preventing accidental use of reserved or invalid tags.
* Introduced a dedicated `validate_tag` job to enforce tag rules before proceeding with the build. The main build job now depends on successful validation.

**Docker build and tagging consistency:**

* Updated the build step to use the validated tag for both the `VERSION` build argument and the Docker image tag, ensuring consistent and predictable image naming. [[1]](diffhunk://#diff-02355f8910fcfba904b11e72c7361d4c6c95a3722fb1bd9423d3117342ba6d2fL35-R66) [[2]](diffhunk://#diff-02355f8910fcfba904b11e72c7361d4c6c95a3722fb1bd9423d3117342ba6d2fL52-R84)
* Modified the `SHA1VER` environment variable to incorporate the custom tag, improving traceability of image versions.