### PR TITLE
feat(DMS): add specific auth config for DMS reenroll

### DIFF
--- a/backend/pkg/assemblers/tests/dms-manager/bind_identity_expiration_test.go
+++ b/backend/pkg/assemblers/tests/dms-manager/bind_identity_expiration_test.go
@@ -80,6 +80,9 @@ func TestBindIdentityToDevice_SetsExpirationDate(t *testing.T) {
 				VerifyCSRSignature:          true,
 			},
 			ReEnrollmentSettings: models.ReEnrollmentSettings{
+				ReEnrollmentOptionsESTRFC7030: models.EnrollmentOptionsESTRFC7030{
+					AuthMode: models.ESTAuthModeClientCertificate,
+				},
 				AdditionalValidationCAs:     []string{},
 				ReEnrollmentDelta:           models.TimeDuration(24 * 365 * time.Hour), // Allow re-enrollment any time within a year
 				EnableExpiredRenewal:        true,
@@ -245,6 +248,9 @@ func TestBindIdentityToDevice_DirectBinding_SetsExpirationDate(t *testing.T) {
 				EnrollmentCA:       testCA.ID,
 			},
 			ReEnrollmentSettings: models.ReEnrollmentSettings{
+				ReEnrollmentOptionsESTRFC7030: models.EnrollmentOptionsESTRFC7030{
+					AuthMode: models.ESTAuthModeClientCertificate,
+				},
 				ReEnrollmentDelta:           models.TimeDuration(time.Hour),
 				PreventiveReEnrollmentDelta: models.TimeDuration(time.Minute * 3),
 				CriticalReEnrollmentDelta:   models.TimeDuration(time.Minute * 2),
@@ -335,6 +341,9 @@ func TestBindIdentityToDevice_MultipleBindings_TracksLatestExpiration(t *testing
 				EnrollmentCA:       testCA.ID,
 			},
 			ReEnrollmentSettings: models.ReEnrollmentSettings{
+				ReEnrollmentOptionsESTRFC7030: models.EnrollmentOptionsESTRFC7030{
+					AuthMode: models.ESTAuthModeClientCertificate,
+				},
 				ReEnrollmentDelta:           models.TimeDuration(time.Hour),
 				PreventiveReEnrollmentDelta: models.TimeDuration(time.Minute * 3),
 				CriticalReEnrollmentDelta:   models.TimeDuration(time.Minute * 2),

--- a/backend/pkg/assemblers/tests/dms-manager/events_test.go
+++ b/backend/pkg/assemblers/tests/dms-manager/events_test.go
@@ -74,6 +74,9 @@ func TestBindIDEvent(t *testing.T) {
 					VerifyCSRSignature:          true,
 				},
 				ReEnrollmentSettings: models.ReEnrollmentSettings{
+					ReEnrollmentOptionsESTRFC7030: models.EnrollmentOptionsESTRFC7030{
+						AuthMode: models.ESTAuthModeClientCertificate,
+					},
 					AdditionalValidationCAs:     []string{},
 					ReEnrollmentDelta:           models.TimeDuration(time.Hour),
 					EnableExpiredRenewal:        true,

--- a/backend/pkg/assemblers/tests/dms-manager/main_test.go
+++ b/backend/pkg/assemblers/tests/dms-manager/main_test.go
@@ -3422,6 +3422,9 @@ func TestESTReEnroll(t *testing.T) {
 					VerifyCSRSignature:          true,
 				},
 				ReEnrollmentSettings: models.ReEnrollmentSettings{
+					ReEnrollmentOptionsESTRFC7030: models.EnrollmentOptionsESTRFC7030{
+						AuthMode: models.ESTAuthModeClientCertificate,
+					},
 					RevokeOnReEnrollment:        true,
 					AdditionalValidationCAs:     []string{},
 					ReEnrollmentDelta:           models.TimeDuration(time.Hour),
@@ -4039,8 +4042,8 @@ func TestESTReEnroll(t *testing.T) {
 					c.JSON(200, gin.H{"authorized": true})
 				})
 
-				dms.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthMode = models.ESTAuthModeExternalWebhook
-				dms.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthOptionsExternalWebhook = models.WebhookCall{
+				dms.Settings.ReEnrollmentSettings.ReEnrollmentOptionsESTRFC7030.AuthMode = models.ESTAuthModeExternalWebhook
+				dms.Settings.ReEnrollmentSettings.ReEnrollmentOptionsESTRFC7030.AuthOptionsExternalWebhook = models.WebhookCall{
 					Name: "myHook",
 					Url:  url + "/verify",
 					Config: models.WebhookCallHttpClient{
@@ -4101,8 +4104,8 @@ func TestESTReEnroll(t *testing.T) {
 					c.JSON(200, gin.H{"authorized": false})
 				})
 
-				dms.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthMode = models.ESTAuthModeExternalWebhook
-				dms.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthOptionsExternalWebhook = models.WebhookCall{
+				dms.Settings.ReEnrollmentSettings.ReEnrollmentOptionsESTRFC7030.AuthMode = models.ESTAuthModeExternalWebhook
+				dms.Settings.ReEnrollmentSettings.ReEnrollmentOptionsESTRFC7030.AuthOptionsExternalWebhook = models.WebhookCall{
 					Name: "myHook",
 					Url:  url + "/verify",
 					Config: models.WebhookCallHttpClient{
@@ -4160,8 +4163,8 @@ func TestESTReEnroll(t *testing.T) {
 					c.JSON(200, gin.H{"authorized": true})
 				})
 
-				dms.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthMode = models.ESTAuthModeClientCertificateAndWebhook
-				dms.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthOptionsExternalWebhook = models.WebhookCall{
+				dms.Settings.ReEnrollmentSettings.ReEnrollmentOptionsESTRFC7030.AuthMode = models.ESTAuthModeClientCertificateAndWebhook
+				dms.Settings.ReEnrollmentSettings.ReEnrollmentOptionsESTRFC7030.AuthOptionsExternalWebhook = models.WebhookCall{
 					Name: "myHook",
 					Url:  url + "/verify",
 					Config: models.WebhookCallHttpClient{
@@ -4221,8 +4224,8 @@ func TestESTReEnroll(t *testing.T) {
 					c.JSON(200, gin.H{"authorized": false})
 				})
 
-				dms.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthMode = models.ESTAuthModeClientCertificateAndWebhook
-				dms.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthOptionsExternalWebhook = models.WebhookCall{
+				dms.Settings.ReEnrollmentSettings.ReEnrollmentOptionsESTRFC7030.AuthMode = models.ESTAuthModeClientCertificateAndWebhook
+				dms.Settings.ReEnrollmentSettings.ReEnrollmentOptionsESTRFC7030.AuthOptionsExternalWebhook = models.WebhookCall{
 					Name: "myHook",
 					Url:  url + "/verify",
 					Config: models.WebhookCallHttpClient{
@@ -4283,8 +4286,8 @@ func TestESTReEnroll(t *testing.T) {
 					c.JSON(200, gin.H{"authorized": true})
 				})
 
-				dms.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthMode = models.ESTAuthModeClientCertificateAndWebhook
-				dms.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthOptionsExternalWebhook = models.WebhookCall{
+				dms.Settings.ReEnrollmentSettings.ReEnrollmentOptionsESTRFC7030.AuthMode = models.ESTAuthModeClientCertificateAndWebhook
+				dms.Settings.ReEnrollmentSettings.ReEnrollmentOptionsESTRFC7030.AuthOptionsExternalWebhook = models.WebhookCall{
 					Name: "myHook",
 					Url:  url + "/verify",
 					Config: models.WebhookCallHttpClient{
@@ -4348,8 +4351,8 @@ func TestESTReEnroll(t *testing.T) {
 					c.JSON(200, gin.H{"authorized": true})
 				})
 
-				dms.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthMode = models.ESTAuthModeClientCertificateAndWebhook
-				dms.Settings.EnrollmentSettings.EnrollmentOptionsESTRFC7030.AuthOptionsExternalWebhook = models.WebhookCall{
+				dms.Settings.ReEnrollmentSettings.ReEnrollmentOptionsESTRFC7030.AuthMode = models.ESTAuthModeClientCertificateAndWebhook
+				dms.Settings.ReEnrollmentSettings.ReEnrollmentOptionsESTRFC7030.AuthOptionsExternalWebhook = models.WebhookCall{
 					Name: "myHook",
 					Url:  url + "/verify",
 					Config: models.WebhookCallHttpClient{
@@ -4385,6 +4388,81 @@ func TestESTReEnroll(t *testing.T) {
 			resultCheck: func(caCert, cert *x509.Certificate, key any, err error) {
 				if err == nil {
 					t.Fatalf("expected error. Got none")
+				}
+			},
+		},
+		{
+			name: "OK/ReEnrollNoAuthIndependent",
+			run: func() (caCert *x509.Certificate, cert *x509.Certificate, key any, err error) {
+				dms, enrollmentCA, deviceCrt, deviceKey := prepReenrollScenario(
+					func(in *services.CreateDMSInput) {
+						in.Settings.ReEnrollmentSettings.ReEnrollmentDelta = models.TimeDuration(time.Hour)
+						in.Settings.ReEnrollmentSettings.ReEnrollmentOptionsESTRFC7030.AuthMode = models.ESTAuthModeNoAuth
+					},
+					"1m",
+				)
+
+				newCsr, _ := chelpers.GenerateCertificateRequest(models.Subject{CommonName: deviceCrt.Subject.CommonName}, deviceKey)
+
+				estCli := est.Client{
+					Host:                  fmt.Sprintf("localhost:%d", dmsMgr.Port),
+					AdditionalPathSegment: dms.ID,
+					Certificates:          []*x509.Certificate{},
+					PrivateKey:            nil,
+					InsecureSkipVerify:    true,
+				}
+
+				reEnrollCRT, err := estCli.Reenroll(context.Background(), newCsr)
+				if err != nil {
+					t.Fatalf("unexpected error while reenrolling: %s", err)
+				}
+
+				return enrollmentCA, reEnrollCRT, deviceKey, nil
+			},
+			resultCheck: func(caCert, cert *x509.Certificate, key any, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err)
+				}
+				checkReEnroll(t, caCert, cert, key)
+			},
+		},
+		{
+			name: "Err/ReenrollAuthMissing",
+			run: func() (caCert *x509.Certificate, cert *x509.Certificate, key any, err error) {
+				dms, _, deviceCrt, deviceKey := prepReenrollScenario(
+					func(in *services.CreateDMSInput) {
+						in.Settings.ReEnrollmentSettings.ReEnrollmentDelta = models.TimeDuration(time.Hour)
+					},
+					"1m",
+				)
+
+				dms.Settings.ReEnrollmentSettings.ReEnrollmentOptionsESTRFC7030 = models.EnrollmentOptionsESTRFC7030{}
+				dms, err = dmsMgr.HttpDeviceManagerSDK.UpdateDMS(context.Background(), services.UpdateDMSInput{
+					DMS: *dms,
+				})
+				if err != nil {
+					t.Fatalf("could not clear reenroll auth settings: %s", err)
+				}
+
+				newCsr, _ := chelpers.GenerateCertificateRequest(models.Subject{CommonName: deviceCrt.Subject.CommonName}, deviceKey)
+
+				estCli := est.Client{
+					Host:                  fmt.Sprintf("localhost:%d", dmsMgr.Port),
+					AdditionalPathSegment: dms.ID,
+					Certificates:          []*x509.Certificate{deviceCrt},
+					PrivateKey:            deviceKey,
+					InsecureSkipVerify:    true,
+				}
+
+				_, err = estCli.Reenroll(context.Background(), newCsr)
+				return nil, nil, nil, err
+			},
+			resultCheck: func(caCert, cert *x509.Certificate, key any, err error) {
+				if err == nil {
+					t.Fatalf("expected error. Got none")
+				}
+				if !strings.Contains(err.Error(), errs.ErrDMSAuthModeNotSupported.Error()) {
+					t.Fatalf("error should contain '%s'. Got error %s", errs.ErrDMSAuthModeNotSupported.Error(), err.Error())
 				}
 			},
 		},

--- a/backend/pkg/services/dmsmanager.go
+++ b/backend/pkg/services/dmsmanager.go
@@ -853,6 +853,7 @@ func (svc DMSManagerServiceBackend) Reenroll(ctx context.Context, csr *x509.Cert
 	}
 
 	reEnrollSettings := dms.Settings.ReEnrollmentSettings
+	reEnrollAuthSettings := reEnrollSettings.ReEnrollmentOptionsESTRFC7030
 
 	lFunc = lFunc.WithField("step", "Authenticating")
 	lFunc.Infof("starting authentication process")
@@ -860,7 +861,7 @@ func (svc DMSManagerServiceBackend) Reenroll(ctx context.Context, csr *x509.Cert
 	validateCert := func(ctx context.Context, lFunc *logrus.Entry, clientCerts []*x509.Certificate) (*logrus.Entry, error) {
 		return svc.validateClientCertificateReenrollment(ctx, lFunc, enrollCAID, enrollCA, reEnrollSettings, clientCerts, csr.Subject.CommonName)
 	}
-	lFunc, err = svc.authenticateEST(ctx, lFunc, enrollSettings.EnrollmentOptionsESTRFC7030, csr, aps, "reenrollment", validateCert)
+	lFunc, err = svc.authenticateEST(ctx, lFunc, reEnrollAuthSettings, csr, aps, "reenrollment", validateCert)
 	if err != nil {
 		return nil, err
 	}

--- a/core/pkg/models/dms.go
+++ b/core/pkg/models/dms.go
@@ -83,12 +83,13 @@ type AuthOptionsClientCertificate struct {
 }
 
 type ReEnrollmentSettings struct {
-	AdditionalValidationCAs     []string     `json:"additional_validation_cas"`
-	RevokeOnReEnrollment        bool         `json:"revoke_on_reenrollment"`
-	ReEnrollmentDelta           TimeDuration `json:"reenrollment_delta"`
-	EnableExpiredRenewal        bool         `json:"enable_expired_renewal"`
-	PreventiveReEnrollmentDelta TimeDuration `json:"preventive_delta"` // (expiration time - delta < time.now) at witch point an event is issued notify its time to reenroll
-	CriticalReEnrollmentDelta   TimeDuration `json:"critical_delta"`   // (expiration time - delta < time.now) at witch point an event is issued notify critical status
+	ReEnrollmentOptionsESTRFC7030 EnrollmentOptionsESTRFC7030 `json:"est_rfc7030_settings"`
+	AdditionalValidationCAs       []string                    `json:"additional_validation_cas"`
+	RevokeOnReEnrollment          bool                        `json:"revoke_on_reenrollment"`
+	ReEnrollmentDelta             TimeDuration                `json:"reenrollment_delta"`
+	EnableExpiredRenewal          bool                        `json:"enable_expired_renewal"`
+	PreventiveReEnrollmentDelta   TimeDuration                `json:"preventive_delta"` // (expiration time - delta < time.now) at witch point an event is issued notify its time to reenroll
+	CriticalReEnrollmentDelta     TimeDuration                `json:"critical_delta"`   // (expiration time - delta < time.now) at witch point an event is issued notify critical status
 }
 
 type CADistributionSettings struct {

--- a/docs/dms-manager-openapi.yaml
+++ b/docs/dms-manager-openapi.yaml
@@ -596,6 +596,8 @@ components:
     ReEnrollmentSettings:
       type: object
       properties:
+        est_rfc7030_settings:
+          $ref: '#/components/schemas/EnrollmentOptionsESTRFC7030'
         additional_validation_cas:
           type: array
           items:

--- a/docs/dms-manager-openapi.yaml
+++ b/docs/dms-manager-openapi.yaml
@@ -562,7 +562,7 @@ components:
           type: string
         client_certificate_settings:
           $ref: '#/components/schemas/AuthOptionsClientCertificate'
-        external_webhook:
+        external_webhook_settings:
           type: object
           additionalProperties: true
 

--- a/engines/storage/postgres/migrations/dmsmanager/20260604110000_reenroll_auth_settings.go
+++ b/engines/storage/postgres/migrations/dmsmanager/20260604110000_reenroll_auth_settings.go
@@ -1,0 +1,74 @@
+package dmsmanager
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	mhelper "github.com/lamassuiot/lamassuiot/engines/storage/postgres/v3/migrations/helpers"
+	"github.com/pressly/goose/v3"
+)
+
+func Register20260604110000ReenrollAuthSettings() {
+	goose.AddMigrationContext(upReenrollAuthSettings, downReenrollAuthSettings)
+}
+
+func upReenrollAuthSettings(ctx context.Context, tx *sql.Tx) error {
+	rows, err := tx.QueryContext(ctx, "SELECT id, settings FROM dms")
+	if err != nil {
+		return err
+	}
+
+	result, err := mhelper.RowsToMap(rows)
+	if err != nil {
+		return err
+	}
+
+	for _, r := range result {
+		settingsRaw, ok := r["settings"].(string)
+		if !ok {
+			return fmt.Errorf("invalid settings type for dms %v", r["id"])
+		}
+
+		var config map[string]any
+		if err := json.Unmarshal([]byte(settingsRaw), &config); err != nil {
+			return fmt.Errorf("failed to unmarshal settings for dms %v: %w", r["id"], err)
+		}
+
+		enrollmentSettings, ok := config["enrollment_settings"].(map[string]any)
+		if !ok {
+			continue
+		}
+		enrollmentESTSettings, ok := enrollmentSettings["est_rfc7030_settings"].(map[string]any)
+		if !ok {
+			continue
+		}
+
+		reenrollmentSettings, ok := config["reenrollment_settings"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if _, exists := reenrollmentSettings["est_rfc7030_settings"]; exists {
+			continue
+		}
+
+		reenrollmentSettings["est_rfc7030_settings"] = enrollmentESTSettings
+
+		newSettings, err := json.Marshal(config)
+		if err != nil {
+			return fmt.Errorf("failed to marshal settings for dms %v: %w", r["id"], err)
+		}
+
+		_, err = tx.ExecContext(ctx, "UPDATE dms SET settings = $1 WHERE id = $2", string(newSettings), r["id"])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func downReenrollAuthSettings(ctx context.Context, tx *sql.Tx) error {
+	return nil
+}

--- a/engines/storage/postgres/migrations/gomigrations.go
+++ b/engines/storage/postgres/migrations/gomigrations.go
@@ -20,5 +20,6 @@ func RegisterGoMigrations(dbname string) {
 	case "dmsmanager":
 		dmsmanager.Register20241230124809ServerkeygenRevokereenroll()
 		dmsmanager.Register20250612100530ESTVerifyCSRSignature()
+		dmsmanager.Register20260604110000ReenrollAuthSettings()
 	}
 }

--- a/engines/storage/postgres/migrations_test/dms_test.go
+++ b/engines/storage/postgres/migrations_test/dms_test.go
@@ -157,6 +157,16 @@ func TestDMSMigrations(t *testing.T) {
 	if t.Failed() {
 		t.Fatalf("failed while running migration v20251217120000_metadata_text_to_jsonb")
 	}
+
+	migrationTest_DMS_20260113212700_settings_text_to_jsonb(t, logger, con)
+	if t.Failed() {
+		t.Fatalf("failed while running migration v20260113212700_settings_text_to_jsonb")
+	}
+
+	migrationTest_DMS_20260604110000_reenroll_auth_settings(t, logger, con)
+	if t.Failed() {
+		t.Fatalf("failed while running migration v20260604110000_reenroll_auth_settings")
+	}
 }
 
 func migrationTest_DMS_20251217120000_metadata_text_to_jsonb(t *testing.T, logger *logrus.Entry, con *gorm.DB) {
@@ -210,4 +220,79 @@ func migrationTest_DMS_20251217120000_metadata_text_to_jsonb(t *testing.T, logge
 		t.Fatalf("failed to query jsonb column: %v", tx.Error)
 	}
 	assert.Equal(t, "dms_value", keyValue)
+}
+
+func migrationTest_DMS_20260113212700_settings_text_to_jsonb(t *testing.T, logger *logrus.Entry, con *gorm.DB) {
+	con.Exec(`INSERT INTO dms
+		(id, "name", metadata, creation_date, settings)
+		VALUES('dms-with-settings', 'DMS With Settings', '{}', '2024-11-25 10:46:28.914', '{"enrollment_settings":{"est_rfc7030_settings":{"auth_mode":"CLIENT_CERTIFICATE"}},"reenrollment_settings":{}}');
+	`)
+
+	con.Exec(`INSERT INTO dms
+		(id, "name", metadata, creation_date, settings)
+		VALUES('dms-empty-settings', 'DMS Empty Settings', '{}', '2024-11-25 10:46:28.914', '');
+	`)
+
+	con.Exec(`INSERT INTO dms
+		(id, "name", metadata, creation_date, settings)
+		VALUES('dms-null-settings', 'DMS Null Settings', '{}', '2024-11-25 10:46:28.914', NULL);
+	`)
+
+	ApplyMigration(t, logger, con, dmsDBName)
+
+	var settings1 string
+	tx := con.Table("dms").Where("id = 'dms-with-settings'").Select("settings").Find(&settings1)
+	if tx.Error != nil {
+		t.Fatalf("failed to select dms row: %v", tx.Error)
+	}
+	assert.Contains(t, settings1, `"enrollment_settings"`)
+
+	var settings2 string
+	tx = con.Table("dms").Where("id = 'dms-empty-settings'").Select("settings").Find(&settings2)
+	if tx.Error != nil {
+		t.Fatalf("failed to select dms row: %v", tx.Error)
+	}
+	assert.Equal(t, `{}`, settings2)
+
+	var settings3 string
+	tx = con.Table("dms").Where("id = 'dms-null-settings'").Select("settings").Find(&settings3)
+	if tx.Error != nil {
+		t.Fatalf("failed to select dms row: %v", tx.Error)
+	}
+	assert.Equal(t, `{}`, settings3)
+
+	var authMode string
+	tx = con.Raw("SELECT settings->'enrollment_settings'->'est_rfc7030_settings'->>'auth_mode' FROM dms WHERE id = 'dms-with-settings'").Scan(&authMode)
+	if tx.Error != nil {
+		t.Fatalf("failed to query jsonb settings column: %v", tx.Error)
+	}
+	assert.Equal(t, "CLIENT_CERTIFICATE", authMode)
+}
+
+func migrationTest_DMS_20260604110000_reenroll_auth_settings(t *testing.T, logger *logrus.Entry, con *gorm.DB) {
+	con.Exec(`INSERT INTO dms
+		(id, "name", metadata, creation_date, settings)
+		VALUES('dms-reenroll-backfill', 'DMS Reenroll Backfill', '{}', '2024-11-25 10:46:28.914', '{"enrollment_settings":{"est_rfc7030_settings":{"auth_mode":"EXTERNAL_WEBHOOK","external_webhook_settings":{"name":"hook","url":"https://example.com"}}},"reenrollment_settings":{"additional_validation_cas":[]}}');
+	`)
+
+	con.Exec(`INSERT INTO dms
+		(id, "name", metadata, creation_date, settings)
+		VALUES('dms-reenroll-existing', 'DMS Reenroll Existing', '{}', '2024-11-25 10:46:28.914', '{"enrollment_settings":{"est_rfc7030_settings":{"auth_mode":"NO_AUTH"}},"reenrollment_settings":{"est_rfc7030_settings":{"auth_mode":"CLIENT_CERTIFICATE"}}}');
+	`)
+
+	ApplyMigration(t, logger, con, dmsDBName)
+
+	var backfilledAuth string
+	tx := con.Raw("SELECT settings->'reenrollment_settings'->'est_rfc7030_settings'->>'auth_mode' FROM dms WHERE id = 'dms-reenroll-backfill'").Scan(&backfilledAuth)
+	if tx.Error != nil {
+		t.Fatalf("failed to query backfilled reenroll auth mode: %v", tx.Error)
+	}
+	assert.Equal(t, "EXTERNAL_WEBHOOK", backfilledAuth)
+
+	var existingAuth string
+	tx = con.Raw("SELECT settings->'reenrollment_settings'->'est_rfc7030_settings'->>'auth_mode' FROM dms WHERE id = 'dms-reenroll-existing'").Scan(&existingAuth)
+	if tx.Error != nil {
+		t.Fatalf("failed to query existing reenroll auth mode: %v", tx.Error)
+	}
+	assert.Equal(t, "CLIENT_CERTIFICATE", existingAuth)
 }

--- a/monolithic/pkg/sampledata/generator.go
+++ b/monolithic/pkg/sampledata/generator.go
@@ -212,6 +212,14 @@ func PopulateSampleData(
 			ReEnrollmentSettings: models.ReEnrollmentSettings{
 				RevokeOnReEnrollment:    false,
 				AdditionalValidationCAs: []string{},
+				ReEnrollmentOptionsESTRFC7030: models.EnrollmentOptionsESTRFC7030{
+					AuthMode: "CLIENT_CERTIFICATE",
+					AuthOptionsMTLS: models.AuthOptionsClientCertificate{
+						ValidationCAs:        []string{},
+						ChainLevelValidation: -1,
+						AllowExpired:         false,
+					},
+				},
 			},
 			CADistributionSettings: models.CADistributionSettings{
 				IncludeEnrollmentCA:    true,


### PR DESCRIPTION
This pull request adds dedicated reenroll authentication settings to **DMS Manager** for **EST RFC7030**, updates `Reenroll()` to use reenroll-specific auth instead of enrollment auth, and aligns OpenAPI, migration logic, and tests with that behavior. It also preserves upgrade safety by backfilling missing reenroll auth settings from existing enrollment settings during migration.

Closes #653

#### DMS Model and Service
- Added `ReEnrollmentOptionsESTRFC7030` under `ReEnrollmentSettings` in dms.go, introducing the `est_rfc7030_settings` config key for reenroll auth. [[1]](diffhunk://#diff-299c7dd4fd7643ae4e1b071759cb6085ae391c4958be8e96c22381d7131f3a83R86)
- Updated `Reenroll()` in dmsmanager.go to pass `reEnrollAuthSettings` into `authenticateEST(...)`, decoupling reenroll auth from enrollment auth and enforcing explicit reenroll behavior for **EST RFC7030** and **mTLS**/**Webhook** modes. [[1]](diffhunk://#diff-23d4c4af43f96397c134a3299f77ed31fc20dce780dda0b7f06c97af98e07533R856) [[2]](diffhunk://#diff-23d4c4af43f96397c134a3299f77ed31fc20dce780dda0b7f06c97af98e07533R864)

#### API Documentation
- Added `est_rfc7030_settings` to `ReEnrollmentSettings` in dms-manager-openapi.yaml, documenting reenroll-specific auth schema in the **OpenAPI** contract. [[1]](diffhunk://#diff-6d4e367127e6a0aeb08c4f94378ee8dc498ca97c0433f6f0b76f8d9eb7846791R599)

#### Database Migration
- Added migration 20260604110000_reenroll_auth_settings.go in dmsmanager to backfill `reenrollment_settings.est_rfc7030_settings` from `enrollment_settings.est_rfc7030_settings` only when reenroll settings are missing. [[1]](diffhunk://#diff-d0feac876824ce5dc06ae096f54b3d57716506ecc51f0354f122dfa0c8eb5742R17)
- Updated gomigrations.go to register `Register20260604110000ReenrollAuthSettings()`. [[1]](diffhunk://#diff-c4d452d883a56596d5c210ca7dcc1bcb1dfaf39cc497b440d05e387ea6d6caafR23)
- Added migration assertions in dms_test.go for both settings JSONB conversion and reenroll auth backfill coverage. [[1]](diffhunk://#diff-f2c6bbea616f9ea7d5da0e2d68718d64775f49263066a5fbf963acd280577675R225) [[2]](diffhunk://#diff-f2c6bbea616f9ea7d5da0e2d68718d64775f49263066a5fbf963acd280577675R272)

#### Test Coverage
- Updated reenroll integration scenarios in main_test.go to configure **Webhook** and combined auth through `ReEnrollmentSettings.ReEnrollmentOptionsESTRFC7030` rather than enrollment settings. [[1]](diffhunk://#diff-e00fa614fc9b2b5559302830dc93053cd7298964881ec8a8397574c3ab857f6aR4042)
- Added reenroll-specific test cases in main_test.go for independent `ESTAuthModeNoAuth` behavior and missing reenroll auth error handling. [[1]](diffhunk://#diff-e00fa614fc9b2b5559302830dc93053cd7298964881ec8a8397574c3ab857f6aR4391)
- Updated reenroll-related defaults in events_test.go and bind_identity_expiration_test.go to set explicit reenroll auth mode for **DMS Manager** flows. [[1]](diffhunk://#diff-4cbdfab195b2698a0b8780d06522db38d64d5a19be8d3bf835de9ba8f6f04c0cR74) [[2]](diffhunk://#diff-ecaa8c7be16d2c142af59855d24f1dd33113fbe76bfd3f1f8cfa3f7edfef7cdeR80)
