### PR TITLE
fix(changelog): update header pattern to fully support conventional commits

### DIFF
--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -15,6 +15,8 @@ options:
         - test
         - chore
         - refactor
+        - docs
+        - build
   commit_groups:
     title_maps:
       feat: Features
@@ -25,8 +27,10 @@ options:
       test: Tests
       chore: Chores
       refactor: Refactor
+      docs: Documentation
+      build: Build
   header:
-    pattern: "^((\\w+)[\\s:]\\s.*)$"
+    pattern: "^((\\w+)(\\([^)]*\\))?!?:\\s.*)$"
     pattern_maps:
       - Subject
       - Type


### PR DESCRIPTION
This pull request updates the **changelog** generator config to better recognize **Conventional Commits**, including scoped headers and breaking-change markers, and expands the grouped commit types it understands.

#### Changelog config
- Updated the header matching pattern in `.chglog/config.yml` so `chglog` accepts Conventional Commit headers with **optional scopes** and **!**.
- Added **docs** and **build** to the supported commit types and mapped them to the appropriate changelog groups.


