### PR TITLE
Feat: Add BasePath to OTELTracesConfig and update tracer provider setup

### DIFF
--- a/core/pkg/config/otel.go
+++ b/core/pkg/config/otel.go
@@ -19,6 +19,7 @@ type OTELTracesConfig struct {
 	Hostname string `mapstructure:"hostname"`
 	Port     int    `mapstructure:"port"`
 	Scheme   string `mapstructure:"scheme"`
+	BasePath string `mapstructure:"base_path"`
 }
 
 type OTELLoggingConfig struct {

--- a/sdk/otel.go
+++ b/sdk/otel.go
@@ -117,8 +117,17 @@ func setupTracerProvider(ctx context.Context, config config.OTELTracesConfig, re
 		return nil
 	}
 
+	u := &url.URL{
+		Scheme: config.Scheme,
+		Host:   fmt.Sprintf("%s:%d", config.Hostname, config.Port),
+	}
+	if config.BasePath != "" {
+		u.Path = path.Join("/", config.BasePath)
+	}
+	endpointURL := u.String()
+
 	options := []otlptracehttp.Option{
-		otlptracehttp.WithEndpoint(fmt.Sprintf("%s:%d", config.Hostname, config.Port)),
+		otlptracehttp.WithEndpointURL(endpointURL),
 	}
 
 	if config.Scheme == "http" {


### PR DESCRIPTION
This pull request adds support for specifying a custom base path in the OpenTelemetry (OTEL) traces configuration and updates the tracer provider setup to use this new configuration when constructing the OTEL endpoint URL.

**OTEL Tracing Configuration Enhancements:**

* Added a new `BasePath` field to the `OTELTracesConfig` struct in `core/pkg/config/otel.go`, allowing users to specify a base path for the OTEL traces endpoint.

**Tracer Provider Setup Updates:**

* Updated the `setupTracerProvider` function in `sdk/otel.go` to construct the OTEL endpoint URL using the new `BasePath` configuration, and switched from `WithEndpoint` to `WithEndpointURL` to support the full URL (including scheme, host, port, and base path).