### PR TITLE
chore: define permissions for dev release workflow

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -8,6 +8,10 @@ on:
         required: false
         default: ""
 
+permissions:
+  contents: read
+  packages: read
+  
 jobs:
   validate_tag:
     runs-on: ubuntu-latest

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -8,13 +8,12 @@ on:
         required: false
         default: ""
 
-permissions:
-  contents: read
-  packages: read
-  
 jobs:
   validate_tag:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     steps:
       - name: Validate tag input
         run: |


### PR DESCRIPTION
This pull request makes a small but important change to the `.github/workflows/dev-release.yaml` workflow file. It adds explicit permissions for reading repository contents and packages, which is a best practice for GitHub Actions workflows.