### PR TITLE
feat(ci): enable SBOM generation in Docker image builds

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -113,3 +113,4 @@ jobs:
           tags: |
             ghcr.io/lamassuiot/lamassu-${{ matrix.service }}:${{ env.TAG }}
           push: true
+          sbom: true

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -101,6 +101,10 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
       - name: Build ${{ matrix.service }} DEV docker image
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -103,7 +103,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ matrix.service }} DEV docker image
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0

--- a/.github/workflows/release_finalize.yaml
+++ b/.github/workflows/release_finalize.yaml
@@ -305,3 +305,4 @@ jobs:
             ghcr.io/lamassuiot/lamassu-${{ matrix.service }}:${{ needs.finalize.outputs.release_version }}
             ghcr.io/lamassuiot/lamassu-${{ matrix.service }}:latest
           push: true
+          sbom: true

--- a/.github/workflows/release_finalize.yaml
+++ b/.github/workflows/release_finalize.yaml
@@ -293,7 +293,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Build ${{ matrix.service }} DEV docker image
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:

--- a/.github/workflows/release_finalize.yaml
+++ b/.github/workflows/release_finalize.yaml
@@ -292,6 +292,8 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
       - name: Build ${{ matrix.service }} DEV docker image
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:

--- a/ci/alerts.dockerfile
+++ b/ci/alerts.dockerfile
@@ -1,6 +1,9 @@
 ARG BUILDER=golang:1.26.2-bookworm
 FROM ${BUILDER} AS builder
 WORKDIR /app
+# Instruct BuildKit's Syft scanner to also generate an SBOM attestation for
+# this intermediate stage (in addition to the default final-stage scan).
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 # go.work/go.work.sum rarely change — keep as an early cache layer.
 COPY go.work go.work

--- a/ci/authz.dockerfile
+++ b/ci/authz.dockerfile
@@ -1,6 +1,9 @@
 ARG BUILDER=golang:1.26.2-bookworm
 FROM ${BUILDER} AS builder
 WORKDIR /app
+# Instruct BuildKit's Syft scanner to also generate an SBOM attestation for
+# this intermediate stage (in addition to the default final-stage scan).
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 COPY core core
 COPY shared shared

--- a/ci/aws-connector.dockerfile
+++ b/ci/aws-connector.dockerfile
@@ -1,6 +1,9 @@
 ARG BUILDER=golang:1.26.2-bookworm
 FROM ${BUILDER} AS builder
 WORKDIR /app
+# Instruct BuildKit's Syft scanner to also generate an SBOM attestation for
+# this intermediate stage (in addition to the default final-stage scan).
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 # go.work/go.work.sum rarely change — keep as an early cache layer.
 COPY go.work go.work

--- a/ci/ca-to-kms-migration.dockerfile
+++ b/ci/ca-to-kms-migration.dockerfile
@@ -1,6 +1,9 @@
 ARG BUILDER=golang:1.26.2-bookworm
 FROM ${BUILDER} AS builder
 WORKDIR /app
+# Instruct BuildKit's Syft scanner to also generate an SBOM attestation for
+# this intermediate stage (in addition to the default final-stage scan).
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 # go.work/go.work.sum rarely change — keep as an early cache layer.
 COPY go.work go.work

--- a/ci/ca.dockerfile
+++ b/ci/ca.dockerfile
@@ -1,6 +1,9 @@
 ARG BUILDER=golang:1.26.2-bookworm
 FROM ${BUILDER} AS builder
 WORKDIR /app
+# Instruct BuildKit's Syft scanner to also generate an SBOM attestation for
+# this intermediate stage (in addition to the default final-stage scan).
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 # go.work/go.work.sum rarely change — keep as an early cache layer.
 COPY go.work go.work

--- a/ci/devmanager.dockerfile
+++ b/ci/devmanager.dockerfile
@@ -1,6 +1,9 @@
 ARG BUILDER=golang:1.26.2-bookworm
 FROM ${BUILDER} AS builder
 WORKDIR /app
+# Instruct BuildKit's Syft scanner to also generate an SBOM attestation for
+# this intermediate stage (in addition to the default final-stage scan).
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 # go.work/go.work.sum rarely change — keep as an early cache layer.
 COPY go.work go.work

--- a/ci/dmsmanager.dockerfile
+++ b/ci/dmsmanager.dockerfile
@@ -1,6 +1,9 @@
 ARG BUILDER=golang:1.26.2-bookworm
 FROM ${BUILDER} AS builder
 WORKDIR /app
+# Instruct BuildKit's Syft scanner to also generate an SBOM attestation for
+# this intermediate stage (in addition to the default final-stage scan).
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 # go.work/go.work.sum rarely change — keep as an early cache layer.
 COPY go.work go.work

--- a/ci/kms.dockerfile
+++ b/ci/kms.dockerfile
@@ -1,6 +1,9 @@
 ARG BUILDER=golang:1.26.2-bookworm
 FROM ${BUILDER} AS builder
 WORKDIR /app
+# Instruct BuildKit's Syft scanner to also generate an SBOM attestation for
+# this intermediate stage (in addition to the default final-stage scan).
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 # go.work/go.work.sum rarely change — keep as an early cache layer.
 COPY go.work go.work
@@ -30,6 +33,9 @@ RUN now=$(TZ=GMT date +"%Y-%m-%dT%H:%M:%SZ") && \
       backend/cmd/kms/main.go
 
 FROM debian:bookworm-slim AS pkcs11-client-proxy
+# Instruct BuildKit's Syft scanner to also generate an SBOM attestation for
+# this intermediate stage (in addition to the default final-stage scan).
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
 RUN apt-get update && apt-get install -y --no-install-recommends p11-kit
 
 # gcr.io/distroless/cc-debian13:nonroot provides glibc + libgcc (required for

--- a/ci/lamassu-db-migration.dockerfile
+++ b/ci/lamassu-db-migration.dockerfile
@@ -1,6 +1,9 @@
 ARG BUILDER=golang:1.26.2-bookworm
 FROM ${BUILDER} AS builder
 WORKDIR /app
+# Instruct BuildKit's Syft scanner to also generate an SBOM attestation for
+# this intermediate stage (in addition to the default final-stage scan).
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 # go.work/go.work.sum rarely change — keep as an early cache layer.
 COPY go.work go.work

--- a/ci/va.dockerfile
+++ b/ci/va.dockerfile
@@ -1,6 +1,9 @@
 ARG BUILDER=golang:1.26.2-bookworm
 FROM ${BUILDER} AS builder
 WORKDIR /app
+# Instruct BuildKit's Syft scanner to also generate an SBOM attestation for
+# this intermediate stage (in addition to the default final-stage scan).
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 # go.work/go.work.sum rarely change — keep as an early cache layer.
 COPY go.work go.work


### PR DESCRIPTION
## Summary

Enable automatic SBOM (Software Bill of Materials) generation for all Docker images built in CI, for both dev and release workflows.

## Changes

- Upgraded `docker/login-action` from v3 → v4 in both workflows
- Added `docker/setup-buildx-action@v4` step (required by `build-push-action` v7 for SBOM support)
- Upgraded `docker/build-push-action` from v5 → v7
- Added `sbom: true` to both `dev-release.yaml` and `release_finalize.yaml` build steps

The SBOM is generated at build time and attached as a provenance attestation to each image manifest in GHCR. This enables downstream vulnerability scanning and supply-chain compliance tooling.

## Affected workflows

- `.github/workflows/dev-release.yaml`
- `.github/workflows/release_finalize.yaml`

Closes #687