### PR TITLE
chore: upgrade Go setup action from v5 to v6 in CI workflows

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -55,7 +55,7 @@ jobs:
           ref: ${{ github.head_ref }}
  
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '^1.26.2' # The Go version to download (if necessary) and use.
           cache-dependency-path: "**/*.sum"
@@ -86,7 +86,7 @@ jobs:
         uses: actions/checkout@v4
  
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '^1.26.2' # The Go version to download (if necessary) and use.
           cache-dependency-path: "**/*.sum"
@@ -148,7 +148,7 @@ jobs:
           ref: ${{ github.head_ref }}
  
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '^1.26.2'
           cache-dependency-path: "**/*.sum"
@@ -182,7 +182,7 @@ jobs:
           ref: ${{ github.head_ref }}
  
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '^1.26.2'
           cache-dependency-path: "**/*.sum"

--- a/.github/workflows/release_finalize.yaml
+++ b/.github/workflows/release_finalize.yaml
@@ -68,7 +68,7 @@ jobs:
           token: ${{ github.token }}
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "^1.26.2"
 
@@ -212,7 +212,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "^1.26.2"
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use the latest major version of the `actions/setup-go` action. All instances of `setup-go` are upgraded from version 5 to version 6 to ensure compatibility with the latest features and security updates.

**GitHub Actions workflow updates:**

* Upgraded `actions/setup-go` from `v5` to `v6` in four jobs within `.github/workflows/ci-test.yaml` to use the latest version for setting up Go during CI runs. [[1]](diffhunk://#diff-6fb9ca50cf826f8a0f541413a720a29c3f48a21a2bedf47faa244cf0486c9122L58-R58) [[2]](diffhunk://#diff-6fb9ca50cf826f8a0f541413a720a29c3f48a21a2bedf47faa244cf0486c9122L89-R89) [[3]](diffhunk://#diff-6fb9ca50cf826f8a0f541413a720a29c3f48a21a2bedf47faa244cf0486c9122L151-R151) [[4]](diffhunk://#diff-6fb9ca50cf826f8a0f541413a720a29c3f48a21a2bedf47faa244cf0486c9122L185-R185)
* Upgraded `actions/setup-go` from `v5` to `v6` in two jobs within `.github/workflows/release_finalize.yaml` to ensure the release workflow uses the latest action version. [[1]](diffhunk://#diff-63d3b52a02115ceb6c7f267b450cad75430b889352daf8c8d16ec38aae43ab0cL71-R71) [[2]](diffhunk://#diff-63d3b52a02115ceb6c7f267b450cad75430b889352daf8c8d16ec38aae43ab0cL215-R215)