### PR TITLE
feat(ci): Update dev workflow to allow go version selection

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -19,7 +19,7 @@ on:
           - other
         default: golang:1.26.2-bookworm
       other:
-        description: "Only used when go = 'other'"
+        description: "Only used when go = 'other'."
         type: string
         default: ""
  

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -7,7 +7,22 @@ on:
         description: "Docker image tag (leave blank to use 'dev'). Cannot be 'latest' or start with a number."
         required: false
         default: ""
-
+      go:
+        description: "Go version to use as builder."
+        required: true
+        type: choice
+        options:
+          - golang:1.26.2-bookworm
+          - ghcr.io/lamassuiot/golang-pqc:latest
+          - ghcr.io/lamassuiot/golang-pqc:go1.27
+          - ghcr.io/lamassuiot/golang-pqc:go1.26
+          - other
+        default: golang:1.26.2-bookworm
+      other:
+        description: "Only used when go = 'other'"
+        type: string
+        default: ""
+ 
 jobs:
   validate_tag:
     runs-on: ubuntu-latest
@@ -70,6 +85,16 @@ jobs:
           echo "TAG=$TAG" >> $GITHUB_ENV
           echo "SHA1VER=${TAG}-$(git rev-parse HEAD)" >> $GITHUB_ENV
 
+      - name: Resolve builder
+        run: |
+          GO_INPUT="${{ github.event.inputs.go }}"
+          if [[ "$GO_INPUT" == "other" ]]; then
+            BUILDER="${{ github.event.inputs.other }}"
+          else
+            BUILDER="$GO_INPUT"
+          fi
+          echo "BUILDER=$BUILDER" >> $GITHUB_ENV
+
       - name: Login to Github Registry
         uses: docker/login-action@v3
         with:
@@ -82,7 +107,7 @@ jobs:
           context: .
           file: ci/${{ matrix.service }}.dockerfile
           build-args: |
-            BASE_IMAGE=alpine:3.14
+            BUILDER=${{ env.BUILDER }}
             SHA1VER=${{ env.SHA1VER }}
             VERSION=${{ env.TAG }}
           tags: |

--- a/ci/alerts.dockerfile
+++ b/ci/alerts.dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.26.2-bookworm AS builder
+ARG BUILDER=golang:1.26.2-bookworm
+FROM ${BUILDER} AS builder
 WORKDIR /app
 
 # go.work/go.work.sum rarely change — keep as an early cache layer.

--- a/ci/authz.dockerfile
+++ b/ci/authz.dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.26.2-bookworm
+ARG BUILDER=golang:1.26.2-bookworm
+FROM ${BUILDER} AS builder
 WORKDIR /app
 
 COPY core core
@@ -26,10 +27,10 @@ FROM ubuntu:26.04
 RUN groupadd --system lamassu && \
     useradd --system --gid lamassu --no-create-home --shell /usr/sbin/nologin lamassu
 
-COPY --from=0 /app/authz /
-COPY --from=0 /app/connectors/authz/cmd/preload /etc/lamassuiot/authz/preload
-COPY --from=0 /app/connectors/authz/authz.json /etc/lamassuiot/authz/schemas/authz.json
-COPY --from=0 /app/connectors/authz/pki.json /etc/lamassuiot/authz/schemas/pki.json
-COPY --from=0 /app/connectors/authz/wfx.json /etc/lamassuiot/authz/schemas/http-wfx.json
+COPY --from=builder /app/authz /
+COPY --from=builder /app/connectors/authz/cmd/preload /etc/lamassuiot/authz/preload
+COPY --from=builder /app/connectors/authz/authz.json /etc/lamassuiot/authz/schemas/authz.json
+COPY --from=builder /app/connectors/authz/pki.json /etc/lamassuiot/authz/schemas/pki.json
+COPY --from=builder /app/connectors/authz/wfx.json /etc/lamassuiot/authz/schemas/http-wfx.json
 USER lamassu
 CMD ["/authz"]

--- a/ci/aws-connector.dockerfile
+++ b/ci/aws-connector.dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.26.2-bookworm AS builder
+ARG BUILDER=golang:1.26.2-bookworm
+FROM ${BUILDER} AS builder
 WORKDIR /app
 
 # go.work/go.work.sum rarely change — keep as an early cache layer.

--- a/ci/ca-to-kms-migration.dockerfile
+++ b/ci/ca-to-kms-migration.dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.26.2-bookworm AS builder
+ARG BUILDER=golang:1.26.2-bookworm
+FROM ${BUILDER} AS builder
 WORKDIR /app
 
 # go.work/go.work.sum rarely change — keep as an early cache layer.

--- a/ci/ca.dockerfile
+++ b/ci/ca.dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.26.2-bookworm AS builder
+ARG BUILDER=golang:1.26.2-bookworm
+FROM ${BUILDER} AS builder
 WORKDIR /app
 
 # go.work/go.work.sum rarely change — keep as an early cache layer.

--- a/ci/devmanager.dockerfile
+++ b/ci/devmanager.dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.26.2-bookworm AS builder
+ARG BUILDER=golang:1.26.2-bookworm
+FROM ${BUILDER} AS builder
 WORKDIR /app
 
 # go.work/go.work.sum rarely change — keep as an early cache layer.

--- a/ci/dmsmanager.dockerfile
+++ b/ci/dmsmanager.dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.26.2-bookworm AS builder
+ARG BUILDER=golang:1.26.2-bookworm
+FROM ${BUILDER} AS builder
 WORKDIR /app
 
 # go.work/go.work.sum rarely change — keep as an early cache layer.

--- a/ci/kms.dockerfile
+++ b/ci/kms.dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.26.2-bookworm AS builder
+ARG BUILDER=golang:1.26.2-bookworm
+FROM ${BUILDER} AS builder
 WORKDIR /app
 
 # go.work/go.work.sum rarely change — keep as an early cache layer.

--- a/ci/lamassu-db-migration.dockerfile
+++ b/ci/lamassu-db-migration.dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.26.2-bookworm AS builder
+ARG BUILDER=golang:1.26.2-bookworm
+FROM ${BUILDER} AS builder
 WORKDIR /app
 
 # go.work/go.work.sum rarely change — keep as an early cache layer.

--- a/ci/va.dockerfile
+++ b/ci/va.dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.26.2-bookworm AS builder
+ARG BUILDER=golang:1.26.2-bookworm
+FROM ${BUILDER} AS builder
 WORKDIR /app
 
 # go.work/go.work.sum rarely change — keep as an early cache layer.


### PR DESCRIPTION
This pull request introduces the necessary changes in the dev-release workflow so as to prompt the user for the desired golang version that should be used to build lamassu. Currently, the following options are given:
- golang:1.26.2-bookworm
- ghcr.io/lamassuiot/golang-pqc:latest
- ghcr.io/lamassuiot/golang-pqc:go1.27
- ghcr.io/lamassuiot/golang-pqc:go1.26
- other

A string input is available in case the "other" option is selected. Furthermore, all dockerfiles have been updated to use the golang version passed in as a build argument as the base image for the build process.
