### PR TITLE
feat(ci): publish source SBOM with releases

### DIFF
--- a/.github/workflows/release_finalize.yaml
+++ b/.github/workflows/release_finalize.yaml
@@ -192,6 +192,7 @@ jobs:
     needs: [create_module_release, finalize]
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: write
     steps:
       - name: Checkout code to tag
@@ -223,6 +224,13 @@ jobs:
         run: |
           go work vendor
           zip -r vendor.zip vendor
+
+      - name: Generate and publish source SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: .
+          format: spdx-json
+          artifact-name: lamassuiot-${{ needs.finalize.outputs.release_version_with_v }}.source.sbom.spdx.json
 
       - name: Upload vendor dependencies
         uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2


### PR DESCRIPTION
## Summary

Generate an SPDX JSON SBOM from the tagged source and vendored dependencies during the global release workflow. The Anchore action publishes the named SBOM as a GitHub Release asset.

## Changes

- Grant the release job read access to workflow artifacts required for SBOM release publication.
- Generate the SBOM after `go work vendor` so it inventories the source and shipped vendored dependencies.
- Pin `anchore/sbom-action` to the verified v0.24.0 commit and use a versioned artifact name.

## Validation

- `actionlint .github/workflows/release_finalize.yaml`

Closes #689