### PR TITLE
feat(ci): apply least-privilege permissions to workflows

### DIFF
--- a/.github/workflows/bump-goversion.yaml
+++ b/.github/workflows/bump-goversion.yaml
@@ -1,8 +1,6 @@
 name: Bump Go Version
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 on:
   workflow_dispatch:
@@ -16,6 +14,9 @@ jobs:
   bumper:
     name: Bump Go version and open PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Create commits

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -1,7 +1,6 @@
 name: GO Unit Testing
 
-permissions:
-  contents: read
+permissions: {}
 
 on:
   pull_request:
@@ -48,6 +47,8 @@ jobs:
           
     name: ${{ matrix.module.path }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -81,6 +82,8 @@ jobs:
   test-pkcs11:
     name: engines/crypto/pkcs11
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -141,6 +144,8 @@ jobs:
             name: Alerts
     name: ${{ matrix.module.name }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -175,6 +180,8 @@ jobs:
   test-backend-rest:
     name: backend (excluding assemblers/tests)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -26,9 +26,7 @@ on:
 jobs:
   validate_tag:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: read
+    permissions: {}
     steps:
       - name: Validate tag input
         run: |

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     env:
       GO111MODULE: on
     steps:

--- a/.github/workflows/pinact.yaml
+++ b/.github/workflows/pinact.yaml
@@ -1,7 +1,6 @@
 name: "Pin Check: verify all GitHub Actions are pinned to commit SHAs"
 
-permissions:
-  contents: read
+permissions: {}
 
 on:
   pull_request:
@@ -13,6 +12,8 @@ jobs:
   pinact:
     name: Verify pinned actions
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1

--- a/.github/workflows/release_finalize.yaml
+++ b/.github/workflows/release_finalize.yaml
@@ -1,8 +1,7 @@
 # .github/workflows/release_finalize.yml
 name: Finalize Release
 
-permissions:
-  contents: read
+permissions: {}
 
 on:
   push:
@@ -18,6 +17,8 @@ jobs:
   extract_version:
     name: Extract Version from Commit Message
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       release_version: ${{ steps.extract.outputs.release_version }}
       major_version: ${{ steps.extract.outputs.major_version }}
@@ -89,6 +90,8 @@ jobs:
     name: Setup Release Variables
     needs: [extract_version, bump_versions]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:

--- a/.github/workflows/release_open_pr.yaml
+++ b/.github/workflows/release_open_pr.yaml
@@ -1,8 +1,6 @@
 name: "Release Workflow - Open Pull Request with release notes"
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 on:
   workflow_dispatch:
@@ -19,6 +17,9 @@ jobs:
     name: "Open PR with release notes and changelog"
     runs-on: ubuntu-latest
     container: quay.io/git-chglog/git-chglog:0.15.0
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1


### PR DESCRIPTION
## Summary

Adds explicit, job-scoped GitHub token permissions across the repository workflows.

## Changes

- Set a no-permissions default at workflow scope.
- Grant only the permissions each job requires, including contents, packages, pull requests, and security events where applicable.

Closes #702