### PR TITLE
feat(ci): add dependency review workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,23 @@
+name: Dependency review
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  dependency-review:
+    name: Review dependency changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Block high-severity dependency vulnerabilities
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          comment-summary-in-pr: on-failure
+          fail-on-severity: high

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,3 +171,10 @@ Signed-off-by: Your Name <your.email@example.com>
 ```
 
 This line certifies that you wrote the code or otherwise have the right to submit it under the open source license indicated in the repository.
+
+## Dependency Review
+
+Every pull request runs a required dependency review. Changes that
+introduce dependencies with a known high or critical severity vulnerability are
+blocked until the dependency is removed, upgraded, or an approved exception is
+recorded.


### PR DESCRIPTION
## Summary

- Add a dependency review workflow for every pull request.
- Block newly introduced high or critical vulnerable dependencies.
- Add failure-only dependency-review summaries to pull requests.
- Document the required dependency review for contributors.

## Validation

- `actionlint .github/workflows/dependency-review.yml`
- `git diff --check`

Closes #699