### PR TITLE
chore(deps): configure Dependabot update workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,48 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directories:
+      - "**/*"
+    schedule:
+      interval: weekly
+    assignees:
+      - mikelamutxastegi
+    commit-message:
+      prefix: "chore"
+      include: scope
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
+  - package-ecosystem: docker
+    directory: "/ci"
+    schedule:
+      interval: weekly
+    assignees:
+      - mikelamutxastegi
+    commit-message:
+      prefix: "chore"
+      include: scope
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    assignees:
+      - mikelamutxastegi
+    commit-message:
+      prefix: "chore"
+      include: scope
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary
Configure weekly Dependabot version updates for Go modules, Docker images in `ci/`, and GitHub Actions.

Closes #698

## What Changed
- Group minor and patch version updates into one PR per ecosystem.
- Keep major version updates as individual PRs.
- Assign Dependabot PRs to `@mikelamutxastegi` for triage and routing.
- Prefix generated commits and PR titles with `chore(deps)`.

## Decisions
- Weekly grouped version updates balance dependency currency with the review capacity of a small team.
- Security updates are deliberately not grouped: individual PRs preserve advisory-level traceability and prioritization.
- `assignees` is used instead of unsupported `reviewers`; the assignee is accountable for triage and requests the appropriate reviewers.
- Dependabot branches retain their `dependabot/` namespace rather than imitating issue-backed `task/` or `hotfix/` branches.
- Dependabot alerts, security-update notification routing, severity SLAs, and exception handling are deferred to a separate task.

## Validation
- Confirmed the configuration is valid YAML.