### PR TITLE
feat(authz): add init and migrate commands for standalone database setup

### DIFF
--- a/connectors/authz/cmd/main.go
+++ b/connectors/authz/cmd/main.go
@@ -41,8 +41,10 @@ Commands:
   migrate up-to VERSION   Apply migrations up to VERSION
   migrate status          Show the state of every migration
   migrate version         Print the current database version
-  migrate down --confirm  Roll back the last migration (DESTRUCTIVE: the down migration
-                          drops principals, principal_policies and policies)
+  migrate down --confirm  Roll back the last applied migration. One step at a time, so
+                          what it undoes depends on the current version; rolling back far
+                          enough reaches the initial migration, which drops principals,
+                          principal_policies and policies. Check 'migrate status' first.
 
 Configuration is read from the usual config file, so no connection string is needed.`
 
@@ -60,10 +62,11 @@ func runCommand(ctx context.Context, conf authzconfig.AuthzConfig, command strin
 		}
 		sub, subArgs := args[0], args[1:]
 
-		// The authz down migration drops principals, principal_policies and
-		// policies, so it takes the whole authorization model with it.
+		// Rolling back the authz schema eventually reaches the initial migration,
+		// which drops principals, principal_policies and policies. Which step a
+		// given "down" undoes depends on the current version, so gate them all.
 		if sub == "down" && !slices.Contains(subArgs, "--confirm") {
-			return fmt.Errorf("refusing to run %q without --confirm: it drops principals, principal_policies and policies", sub)
+			return fmt.Errorf("refusing to run %q without --confirm: rolling back this schema can drop principals, principal_policies and policies; check 'migrate status' first", sub)
 		}
 		subArgs = slices.DeleteFunc(subArgs, func(a string) bool { return a == "--confirm" })
 

--- a/connectors/authz/cmd/main.go
+++ b/connectors/authz/cmd/main.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"slices"
 
 	"github.com/lamassuiot/authz/pkg/api"
 	authzconfig "github.com/lamassuiot/authz/pkg/config"
@@ -28,6 +31,49 @@ $$ |  $$ |$$ |  $$ |   $$ |   $$ |  $$ |        $$  /
 $$ |  $$ |\$$$$$$  |   $$ |   $$ |  $$ |       $$$$$$$$\
 \__|  \__| \______/    \__|   \__|  \__|       \________|`
 
+const usage = `Usage: authz [COMMAND]
+
+With no command, runs the Authz service.
+
+Commands:
+  init                    Apply migrations, preload policies and seed bootstrap principals, then exit
+  migrate up              Apply all pending migrations
+  migrate up-to VERSION   Apply migrations up to VERSION
+  migrate status          Show the state of every migration
+  migrate version         Print the current database version
+  migrate down --confirm  Roll back the last migration (DESTRUCTIVE: the down migration
+                          drops principals, principal_policies and policies)
+
+Configuration is read from the usual config file, so no connection string is needed.`
+
+// runCommand dispatches the one-shot subcommands. Returning an error (rather
+// than exiting) keeps the non-zero exit in one place, which is what a Kubernetes
+// Job needs to decide whether the step succeeded.
+func runCommand(ctx context.Context, conf authzconfig.AuthzConfig, command string, args []string) error {
+	switch command {
+	case "init":
+		return api.InitializeStorage(ctx, conf)
+
+	case "migrate":
+		if len(args) == 0 {
+			return fmt.Errorf("migrate requires a subcommand\n\n%s", usage)
+		}
+		sub, subArgs := args[0], args[1:]
+
+		// The authz down migration drops principals, principal_policies and
+		// policies, so it takes the whole authorization model with it.
+		if sub == "down" && !slices.Contains(subArgs, "--confirm") {
+			return fmt.Errorf("refusing to run %q without --confirm: it drops principals, principal_policies and policies", sub)
+		}
+		subArgs = slices.DeleteFunc(subArgs, func(a string) bool { return a == "--confirm" })
+
+		return api.RunMigrateCommand(ctx, conf, sub, subArgs)
+
+	default:
+		return fmt.Errorf("unknown command %q\n\n%s", command, usage)
+	}
+}
+
 func main() {
 	log.SetFormatter(helpers.LogFormatter)
 	log.Infof("starting api: version=%s buildTime=%s sha1ver=%s", version, buildTime, sha1ver)
@@ -52,6 +98,13 @@ func main() {
 	log.Debugf("===================================================")
 	log.Debugf("%s", confBytes)
 	log.Debugf("===================================================")
+
+	if len(os.Args) > 1 {
+		if err := runCommand(context.Background(), *conf, os.Args[1], os.Args[2:]); err != nil {
+			log.Fatalf("%s", err)
+		}
+		return
+	}
 
 	if _, _, _, _, _, err := api.AssembleAuthzServiceWithHTTPServer(*conf, models.APIServiceInfo{
 		Version:   version,

--- a/connectors/authz/pkg/api/assembler.go
+++ b/connectors/authz/pkg/api/assembler.go
@@ -108,9 +108,8 @@ func AssembleAuthzService(conf authzconfig.AuthzConfig) (*service.PrincipalManag
 	if err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("failed to get raw sql.DB for migrations: %w", err)
 	}
-	lMigrate := helpers.SetupLogger(conf.Logs.Level, "AUTHZ", "Migrate")
-	if err := store.RunMigrations(sqlDB, lMigrate); err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("database migration failed: %w", err)
+	if err := RunStorageMigrations(conf, sqlDB); err != nil {
+		return nil, nil, nil, nil, err
 	}
 
 	policyStore, err := store.NewGormPolicyStore(authzDB)
@@ -145,18 +144,8 @@ func AssembleAuthzService(conf authzconfig.AuthzConfig) (*service.PrincipalManag
 		return nil, nil, nil, nil, err
 	}
 
-	if conf.PreloadDir != "" {
-		lPreload := helpers.SetupLogger(conf.Logs.Level, "AUTHZ", "Preload")
-		if err := preloadPolicies(context.Background(), policyManager, conf.PreloadDir, lPreload); err != nil {
-			return nil, nil, nil, nil, fmt.Errorf("failed to preload policies: %w", err)
-		}
-	}
-
-	if len(conf.Bootstrap) > 0 {
-		lBootstrap := helpers.SetupLogger(conf.Logs.Level, "AUTHZ", "Bootstrap")
-		if err := runBootstrap(context.Background(), principalManager, conf.Bootstrap, lBootstrap); err != nil {
-			return nil, nil, nil, nil, fmt.Errorf("failed to run bootstrap: %w", err)
-		}
+	if err := seedStorage(context.Background(), conf, principalManager, policyManager); err != nil {
+		return nil, nil, nil, nil, err
 	}
 
 	resolver := principalManager.NewIdentityResolver(policyManager)

--- a/connectors/authz/pkg/api/init.go
+++ b/connectors/authz/pkg/api/init.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	authzconfig "github.com/lamassuiot/authz/pkg/config"
+	"github.com/lamassuiot/authz/pkg/service"
+	"github.com/lamassuiot/authz/pkg/store"
+	cconfig "github.com/lamassuiot/lamassuiot/core/v3/pkg/config"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/helpers"
+)
+
+// InitializeStorage applies migrations, preloads policies and seeds bootstrap
+// principals, then returns. It backs the `init` command, which prepares the
+// database before the service is deployed. AssembleAuthzService performs the
+// same steps at startup, so monolithic and development modes keep working
+// without a separate init step.
+func InitializeStorage(ctx context.Context, conf authzconfig.AuthzConfig) error {
+	lDB := helpers.SetupLogger(conf.Logs.Level, "AUTHZ", "DB")
+
+	authzDB, err := CreatePostgresDBConnection(lDB, conf.AuthzDB)
+	if err != nil {
+		return fmt.Errorf("failed to connect to authz database: %w", err)
+	}
+
+	sqlDB, err := authzDB.DB()
+	if err != nil {
+		return fmt.Errorf("failed to get raw sql.DB: %w", err)
+	}
+	defer sqlDB.Close()
+
+	if err := RunStorageMigrations(conf, sqlDB); err != nil {
+		return err
+	}
+
+	policyStore, err := store.NewGormPolicyStore(authzDB)
+	if err != nil {
+		return fmt.Errorf("failed to create policy store: %w", err)
+	}
+
+	principalManager, err := service.NewPrincipalManager(authzDB, conf.JWKSURL, conf.EnableJWTValidation)
+	if err != nil {
+		return err
+	}
+
+	return seedStorage(ctx, conf, principalManager, service.NewPolicyManager(policyStore))
+}
+
+// RunMigrateCommand runs a single goose command against the authz database and
+// returns. It backs the `migrate` command.
+func RunMigrateCommand(ctx context.Context, conf authzconfig.AuthzConfig, command string, args []string) error {
+	lDB := helpers.SetupLogger(conf.Logs.Level, "AUTHZ", "DB")
+
+	authzDB, err := CreatePostgresDBConnection(lDB, conf.AuthzDB)
+	if err != nil {
+		return fmt.Errorf("failed to connect to authz database: %w", err)
+	}
+
+	sqlDB, err := authzDB.DB()
+	if err != nil {
+		return fmt.Errorf("failed to get raw sql.DB: %w", err)
+	}
+	defer sqlDB.Close()
+
+	schema, err := authzDBSchema(conf)
+	if err != nil {
+		return err
+	}
+
+	lMigrate := helpers.SetupLogger(conf.Logs.Level, "AUTHZ", "Migrate")
+	return store.RunMigrationCommand(ctx, sqlDB, schema, command, args, lMigrate)
+}
+
+// RunStorageMigrations applies all pending migrations to the authz database.
+func RunStorageMigrations(conf authzconfig.AuthzConfig, sqlDB *sql.DB) error {
+	schema, err := authzDBSchema(conf)
+	if err != nil {
+		return err
+	}
+
+	lMigrate := helpers.SetupLogger(conf.Logs.Level, "AUTHZ", "Migrate")
+	if err := store.RunMigrations(sqlDB, schema, lMigrate); err != nil {
+		return fmt.Errorf("database migration failed: %w", err)
+	}
+	return nil
+}
+
+// seedStorage preloads policies and then applies bootstrap entries. Order
+// matters: grants declared in bootstrap reference policies that preload creates.
+func seedStorage(ctx context.Context, conf authzconfig.AuthzConfig, principalManager *service.PrincipalManager, policyManager *service.PolicyManager) error {
+	if conf.PreloadDir != "" {
+		lPreload := helpers.SetupLogger(conf.Logs.Level, "AUTHZ", "Preload")
+		if err := preloadPolicies(ctx, policyManager, conf.PreloadDir, lPreload); err != nil {
+			return fmt.Errorf("failed to preload policies: %w", err)
+		}
+	}
+
+	if len(conf.Bootstrap) > 0 {
+		lBootstrap := helpers.SetupLogger(conf.Logs.Level, "AUTHZ", "Bootstrap")
+		if err := runBootstrap(ctx, principalManager, conf.Bootstrap, lBootstrap); err != nil {
+			return fmt.Errorf("failed to run bootstrap: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func authzDBSchema(conf authzconfig.AuthzConfig) (string, error) {
+	dbCfg, err := cconfig.DecodeStruct[postgresDBConfig](conf.AuthzDB.Config)
+	if err != nil {
+		return "", fmt.Errorf("failed to decode authz postgres config: %w", err)
+	}
+	return dbCfg.Schema, nil
+}

--- a/connectors/authz/pkg/service/test_helpers_test.go
+++ b/connectors/authz/pkg/service/test_helpers_test.go
@@ -27,7 +27,7 @@ func setupDBWithAuthzMigrations(t *testing.T, initSQLPath string) *gorm.DB {
 
 	log := logrus.NewEntry(logrus.New())
 	log.Logger.SetOutput(io.Discard)
-	require.NoError(t, store.RunMigrations(sqlDB, log))
+	require.NoError(t, store.RunMigrations(sqlDB, "", log))
 
 	return container.DB
 }

--- a/connectors/authz/pkg/store/gorm_test.go
+++ b/connectors/authz/pkg/store/gorm_test.go
@@ -21,7 +21,7 @@ func TestGormPrincipalStore_UpdatePersistsZeroValues(t *testing.T) {
 
 	log := logrus.NewEntry(logrus.New())
 	log.Logger.SetLevel(logrus.ErrorLevel)
-	require.NoError(t, RunMigrations(sqlDB, log))
+	require.NoError(t, RunMigrations(sqlDB, "", log))
 
 	s, err := NewGormPrincipalStore(container.DB)
 	require.NoError(t, err)

--- a/connectors/authz/pkg/store/migrate.go
+++ b/connectors/authz/pkg/store/migrate.go
@@ -27,9 +27,10 @@ func RunMigrations(db *sql.DB, schema string, logger *logrus.Entry) error {
 // RunMigrationCommand runs a single goose command against the authz database.
 // Supported commands: up, up-to <version>, down, status, version.
 //
-// "down" is destructive here in a way it is not for the per-service pki schemas:
-// the down migration drops principals, principal_policies and policies, i.e. the
-// whole authorization model. Callers are responsible for confirming it.
+// "down" rolls back a single migration, so what it undoes depends on the current
+// version. Rolling back far enough reaches the initial migration, which drops
+// principals, principal_policies and policies — the whole authorization model.
+// Callers are responsible for confirming it.
 //
 // When schema is non-empty it is created if missing. goose resolves both its own
 // goose_db_version table and the migration DDL through search_path, which the
@@ -97,6 +98,11 @@ func ensureSchema(db *sql.DB, schema string, logger *logrus.Entry) error {
 	if schema == "" {
 		return nil
 	}
+	// Schema names are identifiers, and Postgres cannot bind an identifier as a
+	// query parameter, so this statement has to be built by interpolation. The
+	// value is constrained to [A-Za-z_][A-Za-z0-9_]* first, which admits no
+	// quote, whitespace or semicolon, so it cannot terminate or extend the
+	// statement.
 	if !schemaNamePattern.MatchString(schema) {
 		return fmt.Errorf("invalid schema name %q", schema)
 	}

--- a/connectors/authz/pkg/store/migrate.go
+++ b/connectors/authz/pkg/store/migrate.go
@@ -6,6 +6,8 @@ import (
 	"embed"
 	"fmt"
 	"io/fs"
+	"regexp"
+	"strconv"
 
 	"github.com/pressly/goose/v3"
 	"github.com/sirupsen/logrus"
@@ -14,26 +16,126 @@ import (
 //go:embed migrations/*.sql
 var embedMigrations embed.FS
 
-// RunMigrations runs all pending goose migrations against the authz database.
+var schemaNamePattern = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+// RunMigrations applies all pending goose migrations against the authz database.
 // Must be called before any store is created. Idempotent — safe on every startup.
-func RunMigrations(db *sql.DB, logger *logrus.Entry) error {
+func RunMigrations(db *sql.DB, schema string, logger *logrus.Entry) error {
+	return RunMigrationCommand(context.Background(), db, schema, "up", nil, logger)
+}
+
+// RunMigrationCommand runs a single goose command against the authz database.
+// Supported commands: up, up-to <version>, down, status, version.
+//
+// "down" is destructive here in a way it is not for the per-service pki schemas:
+// the down migration drops principals, principal_policies and policies, i.e. the
+// whole authorization model. Callers are responsible for confirming it.
+//
+// When schema is non-empty it is created if missing. goose resolves both its own
+// goose_db_version table and the migration DDL through search_path, which the
+// connection DSN already carries, so the schema only needs to exist beforehand.
+func RunMigrationCommand(ctx context.Context, db *sql.DB, schema, command string, args []string, logger *logrus.Entry) error {
+	if err := ensureSchema(db, schema, logger); err != nil {
+		return err
+	}
+
+	provider, err := newProvider(db)
+	if err != nil {
+		return err
+	}
+
+	switch command {
+	case "up":
+		results, err := provider.Up(ctx)
+		logResults(results, logger)
+		return err
+
+	case "up-to":
+		version, err := versionArg(args)
+		if err != nil {
+			return err
+		}
+		results, err := provider.UpTo(ctx, version)
+		logResults(results, logger)
+		return err
+
+	case "down":
+		result, err := provider.Down(ctx)
+		if result != nil {
+			logResults([]*goose.MigrationResult{result}, logger)
+		}
+		return err
+
+	case "status":
+		statuses, err := provider.Status(ctx)
+		if err != nil {
+			return fmt.Errorf("read migration status: %w", err)
+		}
+		for _, s := range statuses {
+			applied := "-"
+			if s.State == goose.StateApplied {
+				applied = s.AppliedAt.Format("2006-01-02 15:04:05")
+			}
+			logger.Infof("%-9s %-20s %s", s.State, applied, s.Source.Path)
+		}
+		return nil
+
+	case "version":
+		version, err := provider.GetDBVersion(ctx)
+		if err != nil {
+			return fmt.Errorf("read database version: %w", err)
+		}
+		logger.Infof("current database version: %d", version)
+		return nil
+
+	default:
+		return fmt.Errorf("unknown migration command %q (supported: up, up-to, down, status, version)", command)
+	}
+}
+
+func ensureSchema(db *sql.DB, schema string, logger *logrus.Entry) error {
+	if schema == "" {
+		return nil
+	}
+	if !schemaNamePattern.MatchString(schema) {
+		return fmt.Errorf("invalid schema name %q", schema)
+	}
+	if _, err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", schema)); err != nil {
+		return fmt.Errorf("create schema %s: %w", schema, err)
+	}
+	logger.Infof("using schema: %s", schema)
+	return nil
+}
+
+func newProvider(db *sql.DB) (*goose.Provider, error) {
 	sub, err := fs.Sub(embedMigrations, "migrations")
 	if err != nil {
-		return fmt.Errorf("prepare embedded migrations: %w", err)
+		return nil, fmt.Errorf("prepare embedded migrations: %w", err)
 	}
-
 	provider, err := goose.NewProvider(goose.DialectPostgres, db, sub)
 	if err != nil {
-		return fmt.Errorf("create goose provider: %w", err)
+		return nil, fmt.Errorf("create goose provider: %w", err)
 	}
+	return provider, nil
+}
 
-	results, err := provider.Up(context.Background())
+func versionArg(args []string) (int64, error) {
+	if len(args) == 0 {
+		return 0, fmt.Errorf("this command requires a VERSION argument")
+	}
+	version, err := strconv.ParseInt(args[0], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid VERSION %q: %w", args[0], err)
+	}
+	return version, nil
+}
+
+func logResults(results []*goose.MigrationResult, logger *logrus.Entry) {
 	for _, r := range results {
 		if r.Error != nil {
 			logger.WithError(r.Error).Errorf("migration failed: %s", r.Source.Path)
 		} else {
-			logger.Infof("migration applied: %s (%.2fs)", r.Source.Path, r.Duration.Seconds())
+			logger.Infof("migration %s: %s (%.2fs)", r.Direction, r.Source.Path, r.Duration.Seconds())
 		}
 	}
-	return err
 }

--- a/connectors/authz/pkg/store/migrate.go
+++ b/connectors/authz/pkg/store/migrate.go
@@ -36,7 +36,7 @@ func RunMigrations(db *sql.DB, schema string, logger *logrus.Entry) error {
 // goose_db_version table and the migration DDL through search_path, which the
 // connection DSN already carries, so the schema only needs to exist beforehand.
 func RunMigrationCommand(ctx context.Context, db *sql.DB, schema, command string, args []string, logger *logrus.Entry) error {
-	if err := ensureSchema(db, schema, logger); err != nil {
+	if err := ensureSchema(ctx, db, schema, logger); err != nil {
 		return err
 	}
 
@@ -94,21 +94,41 @@ func RunMigrationCommand(ctx context.Context, db *sql.DB, schema, command string
 	}
 }
 
-func ensureSchema(db *sql.DB, schema string, logger *logrus.Entry) error {
+// ensureSchemaFunc creates the schema named by its argument. Postgres cannot
+// bind an identifier as a query parameter, so a configured schema name would
+// otherwise have to be pasted into the statement from Go. This keeps the name a
+// bind parameter and lets the server quote it with format(%I), which is correct
+// for any identifier; the function body itself is a constant.
+const ensureSchemaFunc = `CREATE OR REPLACE FUNCTION pg_temp.lamassu_ensure_schema(schema_name text)
+RETURNS void AS $fn$
+BEGIN
+    EXECUTE format('CREATE SCHEMA IF NOT EXISTS %I', schema_name);
+END;
+$fn$ LANGUAGE plpgsql;`
+
+func ensureSchema(ctx context.Context, db *sql.DB, schema string, logger *logrus.Entry) error {
 	if schema == "" {
 		return nil
 	}
-	// Schema names are identifiers, and Postgres cannot bind an identifier as a
-	// query parameter, so this statement has to be built by interpolation. The
-	// value is constrained to [A-Za-z_][A-Za-z0-9_]* first, which admits no
-	// quote, whitespace or semicolon, so it cannot terminate or extend the
-	// statement.
 	if !schemaNamePattern.MatchString(schema) {
 		return fmt.Errorf("invalid schema name %q", schema)
 	}
-	if _, err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", schema)); err != nil {
+
+	// pg_temp is session scoped, so the helper and the call to it have to run on
+	// the same pooled connection.
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire connection: %w", err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.ExecContext(ctx, ensureSchemaFunc); err != nil {
+		return fmt.Errorf("prepare schema helper: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx, "SELECT pg_temp.lamassu_ensure_schema($1)", schema); err != nil {
 		return fmt.Errorf("create schema %s: %w", schema, err)
 	}
+
 	logger.Infof("using schema: %s", schema)
 	return nil
 }


### PR DESCRIPTION
## Summary

Lets the authz database be prepared from the deployment's upgrade Job instead of at service startup, so the ordering is **create DB → create tables → seed** rather than seeding whatever happens to exist when the pod comes up.

- `authz init` — migrations, policy preload and bootstrap principals, then exits
- `authz migrate up | up-to VERSION | status | version`
- `authz migrate down` — guarded by `--confirm`, since the down migration drops `principals`, `principal_policies` and `policies`
- `RunMigrations` now creates the target schema when one is configured, so the command is self-sufficient against a database that merely exists

`AssembleAuthzService` shares the same helpers instead of inlining the sequence, so monolithic and development modes keep working with no separate init step.

### Why a subcommand and not a separate image

authz's migrations are embedded in this Go module and cannot move into `goose-lamassu`: `connectors/authz` already depends on `engines/storage/postgres`, so importing authz from there would be a module cycle. A separate migration image would also have to be kept pinned to the exact service version — with a subcommand on the same image that drift is structurally impossible.

## Test plan

Validated against a real PostgreSQL, driven by the config the Helm chart renders:

- [x] `authz init` on an empty database → 2 migrations applied, 24 policies preloaded, principal created with 2 grants, exit 0
- [x] `authz init` a second time → no duplicates (1 principal, 2 grants, 24 policies), exit 0
- [x] `authz migrate status` / `version` → both migrations `applied`, version `20250619000001`
- [x] `authz migrate down` without `--confirm` → refused, exit 1
- [x] Unknown command and `up-to` without VERSION → usage, exit 1
- [x] No dangling grants: every `principal_policies` row resolves to a real policy
- [x] `go build` / `go vet` clean on this branch; monolithic and backend unaffected

Deployed to a dev cluster as the last step of the unified upgrade Job; the preceding steps (database creation and the six goose schema migrations) completed with exit 0.

The matching Helm chart changes live in the `lamassu-helm` repo and are not part of this PR.