### PR TITLE
fix(kms): make (key_id, engine_id) the identity of a KMS key

### DIFF
--- a/backend/pkg/assemblers/tests/ca/ca_create_certificate_test.go
+++ b/backend/pkg/assemblers/tests/ca/ca_create_certificate_test.go
@@ -168,7 +168,7 @@ func TestCreateCertificateSDK(t *testing.T) {
 				return caSDK.CreateCertificate(context.Background(), services.CreateCertificateInput{
 					CAID: caID,
 					KeySpec: services.CertificateKeySpec{
-						KeyIdentifier: key.KeyID,
+						KeyIdentifier: key.PKCS11URI,
 					},
 					Subject: models.Subject{CommonName: "reuse-key-cert"},
 				})
@@ -1134,7 +1134,7 @@ func TestCreateCertificateEventAndAuditBehavior(t *testing.T) {
 			cert, err := caTest.HttpCASDK.CreateCertificate(context.Background(), services.CreateCertificateInput{
 				CAID: ca.ID,
 				KeySpec: services.CertificateKeySpec{
-					KeyIdentifier: sharedKey.KeyID,
+					KeyIdentifier: sharedKey.PKCS11URI,
 				},
 				Subject: models.Subject{CommonName: fmt.Sprintf("shared-key-cert-%d", i)},
 			})

--- a/backend/pkg/assemblers/tests/kms/create_import_tags_metadata_test.go
+++ b/backend/pkg/assemblers/tests/kms/create_import_tags_metadata_test.go
@@ -489,7 +489,7 @@ func TestCreateAndRetrieveKeyWithTagsAndMetadata(t *testing.T) {
 
 				// Retrieve the key
 				retrievedKey, err := kmsSDK.GetKey(context.Background(), services.GetKeyInput{
-					Identifier: createdKey.KeyID,
+					Identifier: createdKey.PKCS11URI,
 				})
 				if err != nil {
 					return fmt.Errorf("failed to retrieve key: %s", err)

--- a/backend/pkg/assemblers/tests/kms/key_filter_test.go
+++ b/backend/pkg/assemblers/tests/kms/key_filter_test.go
@@ -64,7 +64,7 @@ func TestGetKeysFilterByMetadataJsonPath(t *testing.T) {
 	ud1["critical"] = true
 	ud1["rotation_days"] = 90
 	_, err = kmsTest.Service.UpdateKeyMetadata(ctx, services.UpdateKeyMetadataInput{
-		ID: key1.KeyID,
+		ID: key1.PKCS11URI,
 		Patches: helpers.NewPatchBuilder().
 			Add(helpers.JSONPointerBuilder(), ud1).
 			Build(),
@@ -79,7 +79,7 @@ func TestGetKeysFilterByMetadataJsonPath(t *testing.T) {
 	ud2["critical"] = false
 	ud2["rotation_days"] = 30
 	_, err = kmsTest.Service.UpdateKeyMetadata(ctx, services.UpdateKeyMetadataInput{
-		ID: key2.KeyID,
+		ID: key2.PKCS11URI,
 		Patches: helpers.NewPatchBuilder().
 			Add(helpers.JSONPointerBuilder(), ud2).
 			Build(),
@@ -94,7 +94,7 @@ func TestGetKeysFilterByMetadataJsonPath(t *testing.T) {
 	ud3["critical"] = true
 	ud3["rotation_days"] = 60
 	_, err = kmsTest.Service.UpdateKeyMetadata(ctx, services.UpdateKeyMetadataInput{
-		ID: key3.KeyID,
+		ID: key3.PKCS11URI,
 		Patches: helpers.NewPatchBuilder().
 			Add(helpers.JSONPointerBuilder(), ud3).
 			Build(),

--- a/backend/pkg/assemblers/tests/kms/main_test.go
+++ b/backend/pkg/assemblers/tests/kms/main_test.go
@@ -874,6 +874,30 @@ func TestGetKey(t *testing.T) {
 				return nil
 			},
 		},
+		{
+			// A keyID alone is a search, not an identity: it resolves only while a single
+			// engine holds the key. Ambiguity across engines is covered by the storage tests.
+			name: "OK/GetKey-BareKeyIDWhileHeldByOneEngine",
+			before: func() {
+				validKeyID = importKey("KeyByBareID", 2048)
+			},
+			run: func() (*models.Key, error) {
+				keyUriParts, err := models.ParsePKCS11URI(validKeyID)
+				if err != nil {
+					return nil, err
+				}
+				return kmsTest.HttpKMSSDK.GetKey(context.Background(), services.GetKeyInput{Identifier: keyUriParts["id"]})
+			},
+			resultCheck: func(key *models.Key, err error) error {
+				if err != nil {
+					return fmt.Errorf("should not error on GetKey: %s", err)
+				}
+				if key == nil || key.PKCS11URI != validKeyID {
+					return fmt.Errorf("unexpected key result for GetKey: %+v", key)
+				}
+				return nil
+			},
+		},
 	}
 
 	for _, tc := range testcases {

--- a/backend/pkg/assemblers/tests/kms/tags_test.go
+++ b/backend/pkg/assemblers/tests/kms/tags_test.go
@@ -33,7 +33,7 @@ func TestUpdateKeyTags(t *testing.T) {
 			},
 			run: func(kmsSDK services.KMSService, key *models.Key) (*models.Key, error) {
 				return kmsSDK.UpdateKeyTags(context.Background(), services.UpdateKeyTagsInput{
-					ID:   key.KeyID,
+					ID:   key.PKCS11URI,
 					Tags: []string{"production", "critical", "us-east-1"},
 				})
 			},
@@ -78,13 +78,13 @@ func TestUpdateKeyTags(t *testing.T) {
 				}
 				// Add initial tags
 				return svc.UpdateKeyTags(context.Background(), services.UpdateKeyTagsInput{
-					ID:   key.KeyID,
+					ID:   key.PKCS11URI,
 					Tags: []string{"development", "temporary"},
 				})
 			},
 			run: func(kmsSDK services.KMSService, key *models.Key) (*models.Key, error) {
 				return kmsSDK.UpdateKeyTags(context.Background(), services.UpdateKeyTagsInput{
-					ID:   key.KeyID,
+					ID:   key.PKCS11URI,
 					Tags: []string{"production", "permanent", "critical"},
 				})
 			},
@@ -134,13 +134,13 @@ func TestUpdateKeyTags(t *testing.T) {
 				}
 				// Add initial tags
 				return svc.UpdateKeyTags(context.Background(), services.UpdateKeyTagsInput{
-					ID:   key.KeyID,
+					ID:   key.PKCS11URI,
 					Tags: []string{"tag1", "tag2", "tag3"},
 				})
 			},
 			run: func(kmsSDK services.KMSService, key *models.Key) (*models.Key, error) {
 				return kmsSDK.UpdateKeyTags(context.Background(), services.UpdateKeyTagsInput{
-					ID:   key.KeyID,
+					ID:   key.PKCS11URI,
 					Tags: []string{},
 				})
 			},
@@ -166,7 +166,7 @@ func TestUpdateKeyTags(t *testing.T) {
 			},
 			run: func(kmsSDK services.KMSService, key *models.Key) (*models.Key, error) {
 				return kmsSDK.UpdateKeyTags(context.Background(), services.UpdateKeyTagsInput{
-					ID:   key.KeyID,
+					ID:   key.PKCS11URI,
 					Tags: []string{"important"},
 				})
 			},
@@ -197,7 +197,7 @@ func TestUpdateKeyTags(t *testing.T) {
 				}
 				// First update
 				key, err = svc.UpdateKeyTags(context.Background(), services.UpdateKeyTagsInput{
-					ID:   key.KeyID,
+					ID:   key.PKCS11URI,
 					Tags: []string{"tag1"},
 				})
 				if err != nil {
@@ -205,13 +205,13 @@ func TestUpdateKeyTags(t *testing.T) {
 				}
 				// Second update
 				return svc.UpdateKeyTags(context.Background(), services.UpdateKeyTagsInput{
-					ID:   key.KeyID,
+					ID:   key.PKCS11URI,
 					Tags: []string{"tag1", "tag2"},
 				})
 			},
 			run: func(kmsSDK services.KMSService, key *models.Key) (*models.Key, error) {
 				return kmsSDK.UpdateKeyTags(context.Background(), services.UpdateKeyTagsInput{
-					ID:   key.KeyID,
+					ID:   key.PKCS11URI,
 					Tags: []string{"final-tag"},
 				})
 			},
@@ -242,7 +242,7 @@ func TestUpdateKeyTags(t *testing.T) {
 				}
 				// Add an alias
 				return svc.UpdateKeyAliases(context.Background(), services.UpdateKeyAliasesInput{
-					ID:      key.KeyID,
+					ID:      key.PKCS11URI,
 					Patches: []models.PatchOperation{{Op: models.PatchAdd, Path: "/-", Value: "my-test-alias"}},
 				})
 			},
@@ -381,13 +381,13 @@ func TestGetKeyWithTags(t *testing.T) {
 				}
 				// Add tags
 				return svc.UpdateKeyTags(context.Background(), services.UpdateKeyTagsInput{
-					ID:   key.KeyID,
+					ID:   key.PKCS11URI,
 					Tags: []string{"test-tag-1", "test-tag-2", "test-tag-3"},
 				})
 			},
 			run: func(kmsSDK services.KMSService, key *models.Key) (*models.Key, error) {
 				return kmsSDK.GetKey(context.Background(), services.GetKeyInput{
-					Identifier: key.KeyID,
+					Identifier: key.PKCS11URI,
 				})
 			},
 			resultCheck: func(retrievedKey *models.Key, err error) error {
@@ -427,7 +427,7 @@ func TestGetKeyWithTags(t *testing.T) {
 			},
 			run: func(kmsSDK services.KMSService, key *models.Key) (*models.Key, error) {
 				return kmsSDK.GetKey(context.Background(), services.GetKeyInput{
-					Identifier: key.KeyID,
+					Identifier: key.PKCS11URI,
 				})
 			},
 			resultCheck: func(retrievedKey *models.Key, err error) error {

--- a/backend/pkg/controllers/ca.go
+++ b/backend/pkg/controllers/ca.go
@@ -830,7 +830,7 @@ func (r *caHttpRoutes) CreateCertificate(ctx *gin.Context) {
 	})
 	if err != nil {
 		switch err {
-		case errs.ErrInvalidKeySpec, errs.ErrValidateBadRequest, errs.ErrCAStatus:
+		case errs.ErrInvalidKeySpec, errs.ErrValidateBadRequest, errs.ErrCAStatus, errs.ErrKeyEngineRequired:
 			ctx.JSON(400, gin.H{"err": err.Error()})
 		case errs.ErrCANotFound, errs.ErrKeyNotFound, errs.ErrIssuanceProfileNotFound:
 			ctx.JSON(404, gin.H{"err": err.Error()})

--- a/backend/pkg/controllers/kms.go
+++ b/backend/pkg/controllers/kms.go
@@ -25,7 +25,7 @@ func (r *kmsHttpRoutes) handleError(ctx *gin.Context, err error) {
 	switch err {
 	case errs.ErrKeyNotFound:
 		ctx.JSON(404, gin.H{"err": err.Error()})
-	case errs.ErrKeyEngineRequired, errs.ErrValidateBadRequest:
+	case errs.ErrKeyEngineRequired, errs.ErrKeyAliasCollidesWithKeyID, errs.ErrValidateBadRequest:
 		ctx.JSON(400, gin.H{"err": err.Error()})
 	default:
 		ctx.JSON(500, gin.H{"err": err.Error()})

--- a/backend/pkg/controllers/kms.go
+++ b/backend/pkg/controllers/kms.go
@@ -90,6 +90,8 @@ func (r *kmsHttpRoutes) GetKeyByID(ctx *gin.Context) {
 		switch err {
 		case errs.ErrKeyNotFound:
 			ctx.JSON(404, gin.H{"err": err.Error()})
+		case errs.ErrKeyEngineRequired:
+			ctx.JSON(400, gin.H{"err": err.Error()})
 		case errs.ErrValidateBadRequest:
 			ctx.JSON(400, gin.H{"err": err.Error()})
 		default:
@@ -201,6 +203,8 @@ func (r *kmsHttpRoutes) UpdateKeyAliases(ctx *gin.Context) {
 		switch err {
 		case errs.ErrKeyNotFound:
 			ctx.JSON(404, gin.H{"err": err.Error()})
+		case errs.ErrKeyEngineRequired:
+			ctx.JSON(400, gin.H{"err": err.Error()})
 		case errs.ErrValidateBadRequest:
 			ctx.JSON(400, gin.H{"err": err.Error()})
 		default:
@@ -238,6 +242,8 @@ func (r *kmsHttpRoutes) UpdateKeyMetadata(ctx *gin.Context) {
 		switch err {
 		case errs.ErrKeyNotFound:
 			ctx.JSON(404, gin.H{"err": err.Error()})
+		case errs.ErrKeyEngineRequired:
+			ctx.JSON(400, gin.H{"err": err.Error()})
 		case errs.ErrValidateBadRequest:
 			ctx.JSON(400, gin.H{"err": err.Error()})
 		default:
@@ -274,6 +280,8 @@ func (r *kmsHttpRoutes) UpdateKeyName(ctx *gin.Context) {
 		switch err {
 		case errs.ErrKeyNotFound:
 			ctx.JSON(404, gin.H{"err": err.Error()})
+		case errs.ErrKeyEngineRequired:
+			ctx.JSON(400, gin.H{"err": err.Error()})
 		case errs.ErrValidateBadRequest:
 			ctx.JSON(400, gin.H{"err": err.Error()})
 		default:
@@ -311,6 +319,8 @@ func (r *kmsHttpRoutes) UpdateKeyTags(ctx *gin.Context) {
 		switch err {
 		case errs.ErrKeyNotFound:
 			ctx.JSON(404, gin.H{"err": err.Error()})
+		case errs.ErrKeyEngineRequired:
+			ctx.JSON(400, gin.H{"err": err.Error()})
 		case errs.ErrValidateBadRequest:
 			ctx.JSON(400, gin.H{"err": err.Error()})
 		default:
@@ -341,6 +351,8 @@ func (r *kmsHttpRoutes) DeleteKeyByID(ctx *gin.Context) {
 		switch err {
 		case errs.ErrKeyNotFound:
 			ctx.JSON(404, gin.H{"err": err.Error()})
+		case errs.ErrKeyEngineRequired:
+			ctx.JSON(400, gin.H{"err": err.Error()})
 		case errs.ErrValidateBadRequest:
 			ctx.JSON(400, gin.H{"err": err.Error()})
 		default:
@@ -380,6 +392,8 @@ func (r *kmsHttpRoutes) SignMessage(ctx *gin.Context) {
 		switch err {
 		case errs.ErrKeyNotFound:
 			ctx.JSON(404, gin.H{"err": err.Error()})
+		case errs.ErrKeyEngineRequired:
+			ctx.JSON(400, gin.H{"err": err.Error()})
 		case errs.ErrValidateBadRequest:
 			ctx.JSON(400, gin.H{"err": err.Error()})
 		default:
@@ -418,6 +432,8 @@ func (r *kmsHttpRoutes) VerifySignature(ctx *gin.Context) {
 		switch err {
 		case errs.ErrKeyNotFound:
 			ctx.JSON(404, gin.H{"err": err.Error()})
+		case errs.ErrKeyEngineRequired:
+			ctx.JSON(400, gin.H{"err": err.Error()})
 		case errs.ErrValidateBadRequest:
 			ctx.JSON(400, gin.H{"err": err.Error()})
 		default:

--- a/backend/pkg/controllers/kms.go
+++ b/backend/pkg/controllers/kms.go
@@ -21,6 +21,17 @@ func NewKMSHttpRoutes(svc services.KMSService) *kmsHttpRoutes {
 	}
 }
 
+func (r *kmsHttpRoutes) handleError(ctx *gin.Context, err error) {
+	switch err {
+	case errs.ErrKeyNotFound:
+		ctx.JSON(404, gin.H{"err": err.Error()})
+	case errs.ErrKeyEngineRequired, errs.ErrValidateBadRequest:
+		ctx.JSON(400, gin.H{"err": err.Error()})
+	default:
+		ctx.JSON(500, gin.H{"err": err.Error()})
+	}
+}
+
 func (r *kmsHttpRoutes) GetCryptoEngineProvider(ctx *gin.Context) {
 	engine, err := r.svc.GetCryptoEngineProvider(ctx.Request.Context())
 	if err != nil {
@@ -87,16 +98,7 @@ func (r *kmsHttpRoutes) GetKeyByID(ctx *gin.Context) {
 	})
 
 	if err != nil {
-		switch err {
-		case errs.ErrKeyNotFound:
-			ctx.JSON(404, gin.H{"err": err.Error()})
-		case errs.ErrKeyEngineRequired:
-			ctx.JSON(400, gin.H{"err": err.Error()})
-		case errs.ErrValidateBadRequest:
-			ctx.JSON(400, gin.H{"err": err.Error()})
-		default:
-			ctx.JSON(500, gin.H{"err": err.Error()})
-		}
+		r.handleError(ctx, err)
 
 		return
 	}
@@ -121,12 +123,7 @@ func (r *kmsHttpRoutes) CreateKey(ctx *gin.Context) {
 	})
 
 	if err != nil {
-		switch err {
-		case errs.ErrValidateBadRequest:
-			ctx.JSON(400, gin.H{"err": err.Error()})
-		default:
-			ctx.JSON(500, gin.H{"err": err.Error()})
-		}
+		r.handleError(ctx, err)
 		return
 	}
 
@@ -165,12 +162,7 @@ func (r *kmsHttpRoutes) ImportKey(ctx *gin.Context) {
 	})
 
 	if err != nil {
-		switch err {
-		case errs.ErrValidateBadRequest:
-			ctx.JSON(400, gin.H{"err": err.Error()})
-		default:
-			ctx.JSON(500, gin.H{"err": err.Error()})
-		}
+		r.handleError(ctx, err)
 		return
 	}
 
@@ -200,16 +192,7 @@ func (r *kmsHttpRoutes) UpdateKeyAliases(ctx *gin.Context) {
 	})
 
 	if err != nil {
-		switch err {
-		case errs.ErrKeyNotFound:
-			ctx.JSON(404, gin.H{"err": err.Error()})
-		case errs.ErrKeyEngineRequired:
-			ctx.JSON(400, gin.H{"err": err.Error()})
-		case errs.ErrValidateBadRequest:
-			ctx.JSON(400, gin.H{"err": err.Error()})
-		default:
-			ctx.JSON(500, gin.H{"err": err.Error()})
-		}
+		r.handleError(ctx, err)
 		return
 	}
 
@@ -239,16 +222,7 @@ func (r *kmsHttpRoutes) UpdateKeyMetadata(ctx *gin.Context) {
 	})
 
 	if err != nil {
-		switch err {
-		case errs.ErrKeyNotFound:
-			ctx.JSON(404, gin.H{"err": err.Error()})
-		case errs.ErrKeyEngineRequired:
-			ctx.JSON(400, gin.H{"err": err.Error()})
-		case errs.ErrValidateBadRequest:
-			ctx.JSON(400, gin.H{"err": err.Error()})
-		default:
-			ctx.JSON(500, gin.H{"err": err.Error()})
-		}
+		r.handleError(ctx, err)
 		return
 	}
 
@@ -277,16 +251,7 @@ func (r *kmsHttpRoutes) UpdateKeyName(ctx *gin.Context) {
 		Name: requestBody.Name,
 	})
 	if err != nil {
-		switch err {
-		case errs.ErrKeyNotFound:
-			ctx.JSON(404, gin.H{"err": err.Error()})
-		case errs.ErrKeyEngineRequired:
-			ctx.JSON(400, gin.H{"err": err.Error()})
-		case errs.ErrValidateBadRequest:
-			ctx.JSON(400, gin.H{"err": err.Error()})
-		default:
-			ctx.JSON(500, gin.H{"err": err.Error()})
-		}
+		r.handleError(ctx, err)
 		return
 	}
 
@@ -316,16 +281,7 @@ func (r *kmsHttpRoutes) UpdateKeyTags(ctx *gin.Context) {
 	})
 
 	if err != nil {
-		switch err {
-		case errs.ErrKeyNotFound:
-			ctx.JSON(404, gin.H{"err": err.Error()})
-		case errs.ErrKeyEngineRequired:
-			ctx.JSON(400, gin.H{"err": err.Error()})
-		case errs.ErrValidateBadRequest:
-			ctx.JSON(400, gin.H{"err": err.Error()})
-		default:
-			ctx.JSON(500, gin.H{"err": err.Error()})
-		}
+		r.handleError(ctx, err)
 		return
 	}
 
@@ -348,16 +304,7 @@ func (r *kmsHttpRoutes) DeleteKeyByID(ctx *gin.Context) {
 	})
 
 	if err != nil {
-		switch err {
-		case errs.ErrKeyNotFound:
-			ctx.JSON(404, gin.H{"err": err.Error()})
-		case errs.ErrKeyEngineRequired:
-			ctx.JSON(400, gin.H{"err": err.Error()})
-		case errs.ErrValidateBadRequest:
-			ctx.JSON(400, gin.H{"err": err.Error()})
-		default:
-			ctx.JSON(500, gin.H{"err": err.Error()})
-		}
+		r.handleError(ctx, err)
 
 		return
 	}
@@ -389,16 +336,7 @@ func (r *kmsHttpRoutes) SignMessage(ctx *gin.Context) {
 		MessageType: requestBody.MessageType,
 	})
 	if err != nil {
-		switch err {
-		case errs.ErrKeyNotFound:
-			ctx.JSON(404, gin.H{"err": err.Error()})
-		case errs.ErrKeyEngineRequired:
-			ctx.JSON(400, gin.H{"err": err.Error()})
-		case errs.ErrValidateBadRequest:
-			ctx.JSON(400, gin.H{"err": err.Error()})
-		default:
-			ctx.JSON(500, gin.H{"err": err.Error()})
-		}
+		r.handleError(ctx, err)
 		return
 	}
 	ctx.JSON(200, signature)
@@ -429,16 +367,7 @@ func (r *kmsHttpRoutes) VerifySignature(ctx *gin.Context) {
 		MessageType: requestBody.MessageType,
 	})
 	if err != nil {
-		switch err {
-		case errs.ErrKeyNotFound:
-			ctx.JSON(404, gin.H{"err": err.Error()})
-		case errs.ErrKeyEngineRequired:
-			ctx.JSON(400, gin.H{"err": err.Error()})
-		case errs.ErrValidateBadRequest:
-			ctx.JSON(400, gin.H{"err": err.Error()})
-		default:
-			ctx.JSON(500, gin.H{"err": err.Error()})
-		}
+		r.handleError(ctx, err)
 		return
 	}
 	ctx.JSON(200, valid)
@@ -455,12 +384,7 @@ func (r *kmsHttpRoutes) GetStats(ctx *gin.Context) {
 		QueryParameters: queryParams,
 	})
 	if err != nil {
-		switch err {
-		case errs.ErrValidateBadRequest:
-			ctx.JSON(400, gin.H{"err": err.Error()})
-		default:
-			ctx.JSON(500, gin.H{"err": err.Error()})
-		}
+		r.handleError(ctx, err)
 		return
 	}
 

--- a/backend/pkg/migration/catokms/migration.go
+++ b/backend/pkg/migration/catokms/migration.go
@@ -165,7 +165,7 @@ func runMigration(ctx context.Context, logger *log.Entry, kmsStorage storage.KMS
 			continue
 		}
 
-		exists, _, err := kmsStorage.SelectExistsByKeyID(ctx, entry.keyID)
+		exists, _, err := kmsStorage.SelectExistsByKeyID(ctx, entry.keyID, entry.engineID)
 		if err != nil {
 			logger.Errorf("could not check key %s in KMS storage: %s", entry.keyID, err)
 			failed++

--- a/backend/pkg/migration/catokms/migration_test.go
+++ b/backend/pkg/migration/catokms/migration_test.go
@@ -121,19 +121,32 @@ func newMockKMSStorage() *mockKMSStorage {
 	return &mockKMSStorage{existing: map[string]*models.Key{}}
 }
 
-func (m *mockKMSStorage) SelectExistsByKeyID(_ context.Context, id string) (bool, *models.Key, error) {
+// kmsKeyIndex mirrors the (key_id, engine_id) identity of a stored key.
+func kmsKeyIndex(keyID, engineID string) string { return keyID + "@" + engineID }
+
+func (m *mockKMSStorage) SelectExistsByKeyID(_ context.Context, keyID, engineID string) (bool, *models.Key, error) {
 	if m.existsErr != nil {
 		return false, nil, m.existsErr
 	}
-	k, ok := m.existing[id]
+	k, ok := m.existing[kmsKeyIndex(keyID, engineID)]
 	return ok, k, nil
+}
+
+func (m *mockKMSStorage) SelectByKeyID(_ context.Context, keyID string) ([]*models.Key, error) {
+	var copies []*models.Key
+	for _, k := range m.existing {
+		if k.KeyID == keyID {
+			copies = append(copies, k)
+		}
+	}
+	return copies, nil
 }
 
 func (m *mockKMSStorage) Insert(_ context.Context, key *models.Key) (*models.Key, error) {
 	if m.insertErr != nil {
 		return nil, m.insertErr
 	}
-	m.existing[key.KeyID] = key
+	m.existing[kmsKeyIndex(key.KeyID, key.EngineID)] = key
 	m.inserted = append(m.inserted, key)
 	return key, nil
 }
@@ -154,7 +167,7 @@ func (m *mockKMSStorage) SelectExistsByAlias(_ context.Context, _ string) (bool,
 func (m *mockKMSStorage) Update(_ context.Context, key *models.Key) (*models.Key, error) {
 	return key, nil
 }
-func (m *mockKMSStorage) Delete(_ context.Context, _ string) error { return nil }
+func (m *mockKMSStorage) Delete(_ context.Context, _, _ string) error { return nil }
 
 // controlledKMSStorage wraps mockKMSStorage but fails Insert after failAfter successful calls.
 type controlledKMSStorage struct {
@@ -163,8 +176,12 @@ type controlledKMSStorage struct {
 	insertions int
 }
 
-func (c *controlledKMSStorage) SelectExistsByKeyID(ctx context.Context, id string) (bool, *models.Key, error) {
-	return c.inner.SelectExistsByKeyID(ctx, id)
+func (c *controlledKMSStorage) SelectExistsByKeyID(ctx context.Context, keyID, engineID string) (bool, *models.Key, error) {
+	return c.inner.SelectExistsByKeyID(ctx, keyID, engineID)
+}
+
+func (c *controlledKMSStorage) SelectByKeyID(ctx context.Context, keyID string) ([]*models.Key, error) {
+	return c.inner.SelectByKeyID(ctx, keyID)
 }
 func (c *controlledKMSStorage) Insert(ctx context.Context, key *models.Key) (*models.Key, error) {
 	c.insertions++
@@ -189,7 +206,7 @@ func (c *controlledKMSStorage) SelectExistsByAlias(_ context.Context, _ string) 
 func (c *controlledKMSStorage) Update(_ context.Context, key *models.Key) (*models.Key, error) {
 	return key, nil
 }
-func (c *controlledKMSStorage) Delete(_ context.Context, _ string) error { return nil }
+func (c *controlledKMSStorage) Delete(_ context.Context, _, _ string) error { return nil }
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -595,7 +612,7 @@ func TestRunMigration_InsertsNewKey(t *testing.T) {
 func TestRunMigration_SkipsExistingKey(t *testing.T) {
 	entry := newKeyEntryFromRSA(t, "engine-a", "serial-1", "MyCA")
 	kms := newMockKMSStorage()
-	kms.existing[entry.keyID] = &models.Key{KeyID: entry.keyID}
+	kms.existing[kmsKeyIndex(entry.keyID, entry.engineID)] = &models.Key{KeyID: entry.keyID, EngineID: entry.engineID}
 
 	ins, skip, fail := runMigration(context.Background(), silentLogger(), kms, map[string]*keyEntry{entry.keyID: entry}, false)
 
@@ -648,7 +665,7 @@ func TestRunMigration_DryRun_DoesNotInsert(t *testing.T) {
 func TestRunMigration_DryRun_SkipsExistingKey(t *testing.T) {
 	entry := newKeyEntryFromRSA(t, "engine-a", "serial-1", "MyCA")
 	kms := newMockKMSStorage()
-	kms.existing[entry.keyID] = &models.Key{KeyID: entry.keyID}
+	kms.existing[kmsKeyIndex(entry.keyID, entry.engineID)] = &models.Key{KeyID: entry.keyID, EngineID: entry.engineID}
 
 	ins, skip, fail := runMigration(context.Background(), silentLogger(), kms, map[string]*keyEntry{entry.keyID: entry}, true)
 
@@ -663,7 +680,7 @@ func TestRunMigration_Mixed_NewExistingFailed(t *testing.T) {
 	failEntry := newKeyEntryFromRSA(t, "engine-a", "fail-sn", "FailCA")
 
 	inner := newMockKMSStorage()
-	inner.existing[existingEntry.keyID] = &models.Key{KeyID: existingEntry.keyID}
+	inner.existing[kmsKeyIndex(existingEntry.keyID, existingEntry.engineID)] = &models.Key{KeyID: existingEntry.keyID, EngineID: existingEntry.engineID}
 
 	kms := &controlledKMSStorage{inner: inner, failAfter: 1}
 

--- a/backend/pkg/routes/kms.go
+++ b/backend/pkg/routes/kms.go
@@ -38,16 +38,13 @@ func NewKMSHTTPLayer(parentRouterGroup *gin.RouterGroup, svc services.KMSService
 			}
 		}
 
+		// Resolving an alias reads storage before the caller is known to be authorized, so
+		// every failure denies with the same status: distinguishing "no such key" from
+		// "held by several engines" here would tell an unauthorized caller which
+		// identifiers exist and which are mirrored.
 		key, err := svc.GetKey(c.Request.Context(), services.GetKeyInput{Identifier: identifier})
 		if err != nil {
-			switch err {
-			case errs.ErrKeyEngineRequired:
-				c.AbortWithStatusJSON(400, gin.H{"err": err.Error()})
-			case errs.ErrKeyNotFound:
-				c.AbortWithStatusJSON(404, gin.H{"err": err.Error()})
-			default:
-				c.AbortWithStatusJSON(500, gin.H{"err": err.Error()})
-			}
+			c.AbortWithStatusJSON(403, gin.H{"err": "Access denied"})
 			return nil
 		}
 

--- a/backend/pkg/routes/kms.go
+++ b/backend/pkg/routes/kms.go
@@ -1,10 +1,13 @@
 package routes
 
 import (
+	"strings"
+
 	"github.com/gin-gonic/gin"
 	middleware "github.com/lamassuiot/authz/sdk/gin-middleware"
 	"github.com/lamassuiot/lamassuiot/backend/v3/pkg/config"
 	"github.com/lamassuiot/lamassuiot/backend/v3/pkg/controllers"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/errs"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
 	"github.com/lamassuiot/lamassuiot/core/v3/pkg/services"
 	"github.com/sirupsen/logrus"
@@ -15,24 +18,46 @@ func NewKMSHTTPLayer(parentRouterGroup *gin.RouterGroup, svc services.KMSService
 
 	remoteEngine := newRemoteAuthzEngine(authzConf, models.KMSSource, logger)
 
+	// A key is identified by (key_id, engine_id), so the authz entity key can only be built
+	// from a PKCS#11 URI, which carries the engine in token-id, or from an alias, which is
+	// unique across engines but needs a storage lookup to resolve. Same rule as svc.GetKey;
+	// it lives in both places because the authz middleware is bypassed in admin mode.
 	keyIDExtractor := func(c *gin.Context) map[string]string {
-		pkcs11Uri := c.Param("id")
-		keyUriParts, err := models.ParsePKCS11URI(pkcs11Uri)
-		if err != nil {
+		identifier := c.Param("id")
+
+		if strings.HasPrefix(identifier, "pkcs11:") {
+			keyUriParts, err := models.ParsePKCS11URI(identifier)
+			if err != nil || keyUriParts["id"] == "" || keyUriParts["token-id"] == "" {
+				c.AbortWithStatusJSON(400, gin.H{"err": errs.ErrValidateBadRequest.Error()})
+				return nil
+			}
+
 			return map[string]string{
-				"key_id": pkcs11Uri, // Fallback to using the raw ID if parsing fails
+				"key_id":    keyUriParts["id"],
+				"engine_id": keyUriParts["token-id"],
 			}
 		}
 
-		keyID := keyUriParts["id"]
-		engineID := keyUriParts["token-id"]
+		key, err := svc.GetKey(c.Request.Context(), services.GetKeyInput{Identifier: identifier})
+		if err != nil {
+			switch err {
+			case errs.ErrKeyEngineRequired:
+				c.AbortWithStatusJSON(400, gin.H{"err": err.Error()})
+			case errs.ErrKeyNotFound:
+				c.AbortWithStatusJSON(404, gin.H{"err": err.Error()})
+			default:
+				c.AbortWithStatusJSON(500, gin.H{"err": err.Error()})
+			}
+			return nil
+		}
+
 		return map[string]string{
-			"key_id":    keyID,
-			"engine_id": engineID,
+			"key_id":    key.KeyID,
+			"engine_id": key.EngineID,
 		}
 	}
 
-	kmsAuthzMw := middleware.NewCompositeAuthzMiddleware(remoteEngine, "pki", "kms", "kms_key", []string{"key_id", "type", "engine_id"}, logger)
+	kmsAuthzMw := middleware.NewCompositeAuthzMiddleware(remoteEngine, "pki", "kms", "kms_key", []string{"key_id", "engine_id"}, logger)
 
 	router := parentRouterGroup
 	rv1 := router.Group("/v1")

--- a/backend/pkg/services/ca.go
+++ b/backend/pkg/services/ca.go
@@ -1252,8 +1252,9 @@ func (svc *CAServiceBackend) deleteCAPrivateKey(ctx context.Context, ca *models.
 		return
 	}
 
+	// Delete the copy held by this CA's engine, not every engine's copy of the same keyID.
 	err = svc.kmsService.DeleteKeyByID(ctx, services.GetKeyInput{
-		Identifier: keyID,
+		Identifier: buildPKCS11ID(ca.Certificate.EngineID, keyID, "private"),
 	})
 	if err != nil {
 		lFunc.Warnf("could not delete private key for CA %s from crypto engine %s: %s", ca.ID, ca.Certificate.EngineID, err)

--- a/backend/pkg/services/casigner.go
+++ b/backend/pkg/services/casigner.go
@@ -13,18 +13,20 @@ import (
 )
 
 type certSignerImpl struct {
-	sdk  services.KMSService
-	cert *x509.Certificate
-	ctx  context.Context
+	sdk      services.KMSService
+	cert     *x509.Certificate
+	engineID string
+	ctx      context.Context
 }
 
 func NewCertificateSigner(ctx context.Context, cert *models.Certificate, kmsSDK services.KMSService) crypto.Signer {
 	x509Cert := (*x509.Certificate)(cert.Certificate)
 
 	return &certSignerImpl{
-		ctx:  ctx,
-		sdk:  kmsSDK,
-		cert: x509Cert,
+		ctx:      ctx,
+		sdk:      kmsSDK,
+		cert:     x509Cert,
+		engineID: cert.EngineID,
 	}
 }
 
@@ -41,8 +43,15 @@ func (s *certSignerImpl) Sign(rand io.Reader, digest []byte, opts crypto.SignerO
 		return nil, err
 	}
 
+	// The certificate's key is addressed by (keyID, engineID): the SKI alone would stop
+	// resolving as soon as another engine holds a copy of the same key.
+	identifier := ski
+	if s.engineID != "" {
+		identifier = buildPKCS11ID(s.engineID, ski, "private")
+	}
+
 	key, err := s.sdk.GetKey(s.ctx, services.GetKeyInput{
-		Identifier: ski,
+		Identifier: identifier,
 	})
 
 	if err != nil {

--- a/backend/pkg/services/kms.go
+++ b/backend/pkg/services/kms.go
@@ -304,17 +304,8 @@ func (svc *KMSServiceBackend) GetKey(ctx context.Context, input services.GetKeyI
 		return key, nil
 	}
 
-	lFunc.Debugf("checking if Key '%s' exists via Alias", input.Identifier)
-	exists, key, err := svc.kmsStorage.SelectExistsByAlias(ctx, input.Identifier)
-	if err != nil {
-		lFunc.Errorf("something went wrong while checking if alias '%s' exists in storage engine: %s", input.Identifier, err)
-		return nil, err
-	}
-
-	if exists {
-		return key, nil
-	}
-
+	// A keyID takes precedence over an alias, so an alias can never shadow the key whose
+	// keyID it happens to match.
 	lFunc.Debugf("checking if Key '%s' exists via KeyID", input.Identifier)
 	copies, err := svc.kmsStorage.SelectByKeyID(ctx, input.Identifier)
 	if err != nil {
@@ -322,13 +313,11 @@ func (svc *KMSServiceBackend) GetKey(ctx context.Context, input services.GetKeyI
 		return nil, err
 	}
 
-	switch len(copies) {
-	case 0:
-		lFunc.Infof("key %s can not be found in storage engine via alias or keyID", input.Identifier)
-		return nil, errs.ErrKeyNotFound
-	case 1:
+	if len(copies) == 1 {
 		return copies[0], nil
-	default:
+	}
+
+	if len(copies) > 1 {
 		engineIDs := make([]string, len(copies))
 		for i, k := range copies {
 			engineIDs[i] = k.EngineID
@@ -336,6 +325,20 @@ func (svc *KMSServiceBackend) GetKey(ctx context.Context, input services.GetKeyI
 		lFunc.Infof("keyID %s is held by engines %v; an engine must be specified", input.Identifier, engineIDs)
 		return nil, errs.ErrKeyEngineRequired
 	}
+
+	lFunc.Debugf("checking if Key '%s' exists via Alias", input.Identifier)
+	exists, key, err := svc.kmsStorage.SelectExistsByAlias(ctx, input.Identifier)
+	if err != nil {
+		lFunc.Errorf("something went wrong while checking if alias '%s' exists in storage engine: %s", input.Identifier, err)
+		return nil, err
+	}
+
+	if !exists {
+		lFunc.Infof("key %s can not be found in storage engine via keyID or alias", input.Identifier)
+		return nil, errs.ErrKeyNotFound
+	}
+
+	return key, nil
 }
 
 func (svc *KMSServiceBackend) GetKeyStats(ctx context.Context, input services.GetKeyStatsInput) (*models.KeyStats, error) {
@@ -705,6 +708,19 @@ func (svc *KMSServiceBackend) UpdateKeyAliases(ctx context.Context, input servic
 			if exist {
 				lFunc.Errorf("duplicate alias '%s' found for key '%s'", alias, input.ID)
 				return nil, fmt.Errorf("duplicate alias found")
+			}
+
+			// A keyID wins over an alias when resolving an identifier, so an alias that
+			// matches one would never resolve to this key.
+			shadowed, err := svc.kmsStorage.SelectByKeyID(ctx, alias)
+			if err != nil {
+				lFunc.Errorf("failed to check if alias '%s' collides with a keyID: %v", alias, err)
+				return nil, err
+			}
+
+			if len(shadowed) > 0 {
+				lFunc.Errorf("alias '%s' collides with an existing keyID", alias)
+				return nil, errs.ErrKeyAliasCollidesWithKeyID
 			}
 		}
 	}

--- a/backend/pkg/services/kms.go
+++ b/backend/pkg/services/kms.go
@@ -278,52 +278,63 @@ func (svc *KMSServiceBackend) GetKey(ctx context.Context, input services.GetKeyI
 		return nil, errs.ErrValidateBadRequest
 	}
 
+	// A key is identified by (key_id, engine_id). A PKCS#11 URI carries the engine in
+	// token-id and an alias is unique across engines, so both address a single key. A bare
+	// keyID is only a search: it resolves while one engine holds it and is rejected once
+	// several do, rather than silently picking a copy.
 	if strings.HasPrefix(input.Identifier, "pkcs11:") {
 		lFunc.Debugf("checking if Key '%s' exists via PKCS11URI", input.Identifier)
-		_, keyID, _, err := parsePKCS11ID(input.Identifier)
+		engineID, keyID, _, err := parsePKCS11ID(input.Identifier)
 		if err != nil {
 			lFunc.Errorf("failed to parse PKCS11 ID: %s", err)
-			return nil, err
+			return nil, errs.ErrValidateBadRequest
 		}
 
-		lFunc.Debugf("checking if Key '%s' exists via KeyID", keyID)
-		exists, key, err := svc.kmsStorage.SelectExistsByKeyID(ctx, keyID)
+		exists, key, err := svc.kmsStorage.SelectExistsByKeyID(ctx, keyID, engineID)
 		if err != nil {
-			lFunc.Errorf("something went wrong while checking if key '%s' exists in storage engine: %s", keyID, err)
+			lFunc.Errorf("something went wrong while checking if key '%s' exists in engine '%s': %s", keyID, engineID, err)
 			return nil, err
 		}
 
 		if !exists {
-			lFunc.Infof("key %s can not be found in storage engine via keyID", keyID)
+			lFunc.Infof("key %s can not be found in engine %s", keyID, engineID)
 			return nil, errs.ErrKeyNotFound
 		}
 
 		return key, nil
-	} else {
+	}
 
-		lFunc.Debugf("checking if Key '%s' exists via KeyID", input.Identifier)
-		exists, key, err := svc.kmsStorage.SelectExistsByKeyID(ctx, input.Identifier)
-		if err != nil {
-			lFunc.Errorf("something went wrong while checking if key '%s' exists in storage engine: %s", input.Identifier, err)
-			return nil, err
-		}
+	lFunc.Debugf("checking if Key '%s' exists via Alias", input.Identifier)
+	exists, key, err := svc.kmsStorage.SelectExistsByAlias(ctx, input.Identifier)
+	if err != nil {
+		lFunc.Errorf("something went wrong while checking if alias '%s' exists in storage engine: %s", input.Identifier, err)
+		return nil, err
+	}
 
-		if !exists {
-			lFunc.Infof("key %s can not be found in storage engine via keyID", input.Identifier)
-			lFunc.Debugf("checking if Key '%s' exists via Alias", input.Identifier)
-			exists, key, err = svc.kmsStorage.SelectExistsByAlias(ctx, input.Identifier)
-			if err != nil {
-				lFunc.Errorf("something went wrong while checking if key '%s' exists in storage engine: %s", input.Identifier, err)
-				return nil, err
-			}
-
-			if !exists {
-				lFunc.Infof("key %s can not be found in storage engine via alias", input.Identifier)
-				return nil, errs.ErrKeyNotFound
-			}
-		}
-
+	if exists {
 		return key, nil
+	}
+
+	lFunc.Debugf("checking if Key '%s' exists via KeyID", input.Identifier)
+	copies, err := svc.kmsStorage.SelectByKeyID(ctx, input.Identifier)
+	if err != nil {
+		lFunc.Errorf("something went wrong while checking if key '%s' exists in storage engine: %s", input.Identifier, err)
+		return nil, err
+	}
+
+	switch len(copies) {
+	case 0:
+		lFunc.Infof("key %s can not be found in storage engine via alias or keyID", input.Identifier)
+		return nil, errs.ErrKeyNotFound
+	case 1:
+		return copies[0], nil
+	default:
+		engineIDs := make([]string, len(copies))
+		for i, k := range copies {
+			engineIDs[i] = k.EngineID
+		}
+		lFunc.Infof("keyID %s is held by engines %v; an engine must be specified", input.Identifier, engineIDs)
+		return nil, errs.ErrKeyEngineRequired
 	}
 }
 
@@ -804,8 +815,8 @@ func (svc *KMSServiceBackend) DeleteKeyByID(ctx context.Context, input services.
 		return err
 	}
 
-	lFunc.Debugf("deleting key %s from storage engine", key.KeyID)
-	err = svc.kmsStorage.Delete(ctx, key.KeyID)
+	lFunc.Debugf("deleting key %s (engine %s) from storage engine", key.KeyID, key.EngineID)
+	err = svc.kmsStorage.Delete(ctx, key.KeyID, key.EngineID)
 	if err != nil {
 		lFunc.Errorf("delete by ID error: %s", err)
 		return fmt.Errorf("failed to delete key from storage: %w", err)

--- a/backend/pkg/specs/ca-openapi.yaml
+++ b/backend/pkg/specs/ca-openapi.yaml
@@ -1174,7 +1174,11 @@ components:
           description: Crypto engine to generate the key in
         key_identifier:
           type: string
-          description: Optional pre-existing key identifier to reuse
+          description: >-
+            Optional pre-existing key to reuse, given as its PKCS#11 URI, one of its
+            aliases, or its key_id. A key_id resolves only while a single engine holds it:
+            once several engines hold the same key_id it no longer identifies one key and
+            the PKCS#11 URI or an alias must be used instead.
 
     CreateCertificateBody:
       type: object

--- a/connectors/authz/config.yaml
+++ b/connectors/authz/config.yaml
@@ -6,7 +6,7 @@ debug: true
 # Schema name -> path to the JSON schema file
 schemas:
   authz: /home/ubuntu/dev/lamassu/lamassuiot/connectors/authz/authz.json
-  pki: /home/ubuntu/dev/authz/examples/iot/pki.json
+  pki: /home/ubuntu/dev/lamassu/lamassuiot/connectors/authz/pki.json
 
 # http_schemas: list of HTTP schema JSON files (for Envoy ext_authz route mapping)
 http_schemas:

--- a/connectors/authz/sdk/gin-middleware/middleware.go
+++ b/connectors/authz/sdk/gin-middleware/middleware.go
@@ -61,6 +61,11 @@ func (m *AuthzMiddleware) AuthzCheckCustom(action string, entityKeyFunc func(*gi
 		}
 
 		entityKey := entityKeyFunc(c)
+		// An extractor that cannot resolve the entity key aborts the request itself:
+		// authorizing on a partial key would check a different entity than the caller asked for.
+		if c.IsAborted() {
+			return
+		}
 
 		authorized, matchedPrincipals, err := m.engine.MatchAndAuthorize(c.Request.Context(), authType, authMaterial, m.namespace, m.schemaName, action, m.entityType, entityKey)
 		if err != nil {

--- a/core/pkg/engines/storage/kms.go
+++ b/core/pkg/engines/storage/kms.go
@@ -12,10 +12,16 @@ type KMSKeysRepo interface {
 	CountWithFilters(ctx context.Context, queryParams *resources.QueryParameters) (int, error)
 	CountByEngineWithFilters(ctx context.Context, engineID string, queryParams *resources.QueryParameters) (int, error)
 	SelectAll(ctx context.Context, req StorageListRequest[models.Key]) (string, error)
-	SelectExistsByKeyID(ctx context.Context, id string) (bool, *models.Key, error)
+	// SelectExistsByKeyID looks a key up by its full identity. The same keyID can live in
+	// several engines at once (e.g. the private key in an offline HSM and the public key in
+	// an online engine), so engineID is required to address a single row.
+	SelectExistsByKeyID(ctx context.Context, keyID, engineID string) (bool, *models.Key, error)
 	SelectExistsByAlias(ctx context.Context, alias string) (bool, *models.Key, error)
+	// SelectByKeyID returns every engine's copy of the given keyID. A keyID alone is a
+	// search, not an identity: it resolves a key only while a single engine holds it.
+	SelectByKeyID(ctx context.Context, keyID string) ([]*models.Key, error)
 
 	Insert(ctx context.Context, key *models.Key) (*models.Key, error)
 	Update(ctx context.Context, key *models.Key) (*models.Key, error)
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, keyID, engineID string) error
 }

--- a/core/pkg/errs/ca.go
+++ b/core/pkg/errs/ca.go
@@ -30,6 +30,9 @@ var (
 
 	//KMS
 	ErrKeyNotFound error = errors.New("key not found")
+	// A key is identified by (key_id, engine_id), so a keyID held by more than one engine
+	// does not address a single key.
+	ErrKeyEngineRequired error = errors.New("keyID is held by several engines: identify the key by its pkcs11 URI or one of its aliases")
 
 	// CreateCertificate
 	ErrInvalidKeySpec error = errors.New("invalid key spec: exactly one of (Type+Bits) or KeyIdentifier must be provided")

--- a/core/pkg/errs/ca.go
+++ b/core/pkg/errs/ca.go
@@ -33,6 +33,9 @@ var (
 	// A key is identified by (key_id, engine_id), so a keyID held by more than one engine
 	// does not address a single key.
 	ErrKeyEngineRequired error = errors.New("keyID is held by several engines: identify the key by its pkcs11 URI or one of its aliases")
+	// A keyID wins over an alias when resolving an identifier, so such an alias would never
+	// resolve to the key it was set on.
+	ErrKeyAliasCollidesWithKeyID error = errors.New("alias collides with an existing keyID")
 
 	// CreateCertificate
 	ErrInvalidKeySpec error = errors.New("invalid key spec: exactly one of (Type+Bits) or KeyIdentifier must be provided")

--- a/core/pkg/services/ca.go
+++ b/core/pkg/services/ca.go
@@ -213,7 +213,8 @@ type CertificateKeySpec struct {
 	EngineID string         `json:"engine_id"` // optional: target a specific crypto engine
 
 	// --- reuse mode ---
-	// KeyIdentifier references an existing KMS key by its KeyID, Alias, or PKCS11URI.
+	// KeyIdentifier references an existing KMS key by its PKCS11URI, Alias, or KeyID. A bare
+	// KeyID resolves only while a single engine holds the key.
 	KeyIdentifier string `json:"key_identifier"`
 }
 

--- a/core/pkg/services/kms.go
+++ b/core/pkg/services/kms.go
@@ -28,7 +28,11 @@ type KMSService interface {
 	VerifySignature(ctx context.Context, input VerifySignInput) (*models.MessageValidation, error)
 }
 
-// Identifier can be either KeyID, Alias, or PKCS11URI
+// Identifier can be a PKCS11URI, an Alias, or a KeyID. A key is identified by
+// (KeyID, EngineID) because the same KeyID can be held by several engines at once (e.g. the
+// private key in an offline HSM and the public key in an online engine): the URI carries the
+// engine in token-id and an alias is unique across engines, while a bare KeyID resolves only
+// while a single engine holds it and is rejected once several do.
 type GetKeyInput struct {
 	Identifier string `validate:"required"`
 }

--- a/engines/storage/postgres/kmsstorage.go
+++ b/engines/storage/postgres/kmsstorage.go
@@ -59,8 +59,31 @@ func (db *PostgresKMSStore) SelectAll(ctx context.Context, req storage.StorageLi
 	return db.querier.SelectAll(ctx, req.QueryParams, opts, req.ExhaustiveRun, req.ApplyFunc)
 }
 
-func (db *PostgresKMSStore) SelectExistsByKeyID(ctx context.Context, id string) (bool, *models.Key, error) {
-	return db.querier.SelectExists(ctx, id, nil)
+// The identity of a key is (key_id, engine_id): the same key_id can be held by several
+// engines at once. DBQuerier addresses rows by a single column, so the composite-key
+// operations below build their own WHERE clauses instead of going through it.
+func (db *PostgresKMSStore) SelectExistsByKeyID(ctx context.Context, keyID, engineID string) (bool, *models.Key, error) {
+	var elem models.Key
+	tx := db.querier.Table(kmsTableName).WithContext(ctx).Where("key_id = ? AND engine_id = ?", keyID, engineID).Limit(1).Find(&elem)
+	if tx.Error != nil {
+		return false, nil, tx.Error
+	}
+
+	if tx.RowsAffected == 0 {
+		return false, nil, nil
+	}
+
+	return true, &elem, nil
+}
+
+func (db *PostgresKMSStore) SelectByKeyID(ctx context.Context, keyID string) ([]*models.Key, error) {
+	var keys []*models.Key
+	tx := db.querier.Table(kmsTableName).WithContext(ctx).Where("key_id = ?", keyID).Order("engine_id").Find(&keys)
+	if tx.Error != nil {
+		return nil, tx.Error
+	}
+
+	return keys, nil
 }
 
 func (db *PostgresKMSStore) SelectExistsByName(ctx context.Context, name string) (bool, *models.Key, error) {
@@ -70,7 +93,16 @@ func (db *PostgresKMSStore) SelectExistsByName(ctx context.Context, name string)
 
 func (db *PostgresKMSStore) SelectExistsByAlias(ctx context.Context, alias string) (bool, *models.Key, error) {
 	var elem models.Key
-	tx := db.querier.Table(kmsTableName).WithContext(ctx).Where("aliases @> ?::jsonb", fmt.Sprintf(`["%s"]`, alias)).Limit(1).Find(&elem)
+	query := db.querier.Table(kmsTableName).WithContext(ctx)
+	// The monolithic deployment runs this repository on SQLite, which has neither jsonb nor
+	// the containment operator.
+	if isSQLite(db.querier.DB) {
+		query = query.Where("EXISTS (SELECT 1 FROM json_each(aliases) WHERE value = ?)", alias)
+	} else {
+		query = query.Where("aliases @> ?::jsonb", fmt.Sprintf(`["%s"]`, alias))
+	}
+
+	tx := query.Limit(1).Find(&elem)
 	if tx.Error != nil {
 		return false, nil, tx.Error
 	}
@@ -87,9 +119,29 @@ func (db *PostgresKMSStore) Insert(ctx context.Context, kmsKey *models.Key) (*mo
 }
 
 func (db *PostgresKMSStore) Update(ctx context.Context, kmsKey *models.Key) (*models.Key, error) {
-	return db.querier.Update(ctx, kmsKey, kmsKey.KeyID)
+	tx := db.querier.Session(&gorm.Session{FullSaveAssociations: true}).Table(kmsTableName).WithContext(ctx).
+		Where("key_id = ? AND engine_id = ?", kmsKey.KeyID, kmsKey.EngineID).Save(kmsKey)
+	if tx.Error != nil {
+		return nil, tx.Error
+	}
+
+	if tx.RowsAffected != 1 {
+		return nil, gorm.ErrRecordNotFound
+	}
+
+	return kmsKey, nil
 }
 
-func (db *PostgresKMSStore) Delete(ctx context.Context, id string) error {
-	return db.querier.Delete(ctx, id)
+func (db *PostgresKMSStore) Delete(ctx context.Context, keyID, engineID string) error {
+	tx := db.querier.Table(kmsTableName).WithContext(ctx).
+		Where("key_id = ? AND engine_id = ?", keyID, engineID).Delete(nil)
+	if tx.Error != nil {
+		return tx.Error
+	}
+
+	if tx.RowsAffected != 1 {
+		return gorm.ErrRecordNotFound
+	}
+
+	return nil
 }

--- a/engines/storage/postgres/migrations/kms/20260909084500_kms_key_composite_pk.sql
+++ b/engines/storage/postgres/migrations/kms/20260909084500_kms_key_composite_pk.sql
@@ -1,0 +1,52 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- The identity of a key is (key_id, engine_id): the same key_id can be held by several
+-- engines at once (e.g. the private key in an offline HSM and the public key in an online
+-- engine). 20251031174938_key.sql split the old PKCS#11-URI "id" column into key_id +
+-- engine_id but kept the primary key on key_id alone, which makes that case unstorable.
+
+-- Refuse to promote the key rather than inventing an identity for rows we cannot address.
+DO $$
+DECLARE orphans int;
+BEGIN
+    SELECT count(*) INTO orphans FROM kms_keys WHERE engine_id IS NULL OR engine_id = '';
+    IF orphans > 0 THEN
+        RAISE EXCEPTION 'cannot promote (key_id, engine_id) to primary key: % row(s) have no engine_id; backfill them before migrating', orphans;
+    END IF;
+END $$;
+
+ALTER TABLE kms_keys ALTER COLUMN engine_id SET NOT NULL;
+ALTER TABLE kms_keys DROP CONSTRAINT keys_pkey;
+ALTER TABLE kms_keys ADD CONSTRAINT keys_pkey PRIMARY KEY (key_id, engine_id);
+
+-- An alias is the other identifier that addresses a single key, so it is looked up on every
+-- request that does not carry a PKCS#11 URI. jsonb_path_ops covers the containment operator
+-- those lookups use and nothing else, which keeps the index smaller than the default class.
+-- Note this does NOT enforce alias uniqueness: GIN has no unique indexes, and a unique index
+-- cannot span the elements of an array.
+CREATE INDEX kms_keys_aliases_idx ON kms_keys USING gin (aliases jsonb_path_ops);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+-- Only reversible while no key_id is held by more than one engine.
+DO $$
+DECLARE duplicates int;
+BEGIN
+    SELECT count(*) INTO duplicates FROM (
+        SELECT key_id FROM kms_keys GROUP BY key_id HAVING count(*) > 1
+    ) d;
+    IF duplicates > 0 THEN
+        RAISE EXCEPTION 'cannot revert primary key to key_id: % key_id(s) are held by more than one engine', duplicates;
+    END IF;
+END $$;
+
+DROP INDEX kms_keys_aliases_idx;
+ALTER TABLE kms_keys DROP CONSTRAINT keys_pkey;
+ALTER TABLE kms_keys ADD CONSTRAINT keys_pkey PRIMARY KEY (key_id);
+ALTER TABLE kms_keys ALTER COLUMN engine_id DROP NOT NULL;
+
+-- +goose StatementEnd

--- a/engines/storage/postgres/migrations_test/kms_test.go
+++ b/engines/storage/postgres/migrations_test/kms_test.go
@@ -1,0 +1,107 @@
+package migrationstest
+
+import (
+	"testing"
+
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/config"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/helpers"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+)
+
+var kmsDBName = "kms"
+
+func migrationTest_KMS_00000000000001_create_table(t *testing.T, logger *logrus.Entry, con *gorm.DB) {
+	ApplyMigration(t, logger, con, kmsDBName)
+
+	tx := con.Exec(`INSERT INTO kms_keys
+		(id, metadata, "name", algorithm, size, public_key, status, creation_ts)
+		VALUES('pkcs11:token-id=hsm-offline;id=abc123;type=private', '{}', 'MyKey', 'RSA', 2048, 'pub', 'ACTIVE', '2024-11-25 10:46:28.914');
+	`)
+	if tx.Error != nil {
+		t.Fatalf("failed to insert row: %v", tx.Error)
+	}
+}
+
+func migrationTest_KMS_20251031174938_key(t *testing.T, logger *logrus.Entry, con *gorm.DB) {
+	ApplyMigration(t, logger, con, kmsDBName)
+
+	var engineID, keyID string
+	tx := con.Raw("SELECT engine_id, key_id FROM kms_keys").Row().Scan(&engineID, &keyID)
+	if tx != nil {
+		t.Fatalf("failed to read split columns: %v", tx)
+	}
+
+	assert.Equal(t, "hsm-offline", engineID)
+	assert.Equal(t, "abc123", keyID)
+}
+
+func migrationTest_KMS_20260909084500_kms_key_composite_pk(t *testing.T, logger *logrus.Entry, con *gorm.DB) {
+	ApplyMigration(t, logger, con, kmsDBName)
+
+	var pkCols string
+	tx := con.Raw(`
+		SELECT string_agg(a.attname, ',' ORDER BY k.ord)
+		FROM pg_constraint con
+		JOIN pg_class c ON c.oid = con.conrelid
+		JOIN unnest(con.conkey) WITH ORDINALITY AS k(attnum, ord) ON true
+		JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = k.attnum
+		WHERE c.relname = 'kms_keys' AND con.contype = 'p'`).Scan(&pkCols)
+	if tx.Error != nil {
+		t.Fatalf("failed to read primary key columns: %v", tx.Error)
+	}
+	assert.Equal(t, "key_id,engine_id", pkCols)
+
+	var aliasesIndexDef string
+	tx = con.Raw("SELECT indexdef FROM pg_indexes WHERE tablename = 'kms_keys' AND indexname = 'kms_keys_aliases_idx'").Scan(&aliasesIndexDef)
+	if tx.Error != nil {
+		t.Fatalf("failed to read the aliases index: %v", tx.Error)
+	}
+	assert.Contains(t, aliasesIndexDef, "gin")
+	assert.Contains(t, aliasesIndexDef, "jsonb_path_ops")
+
+	// The point of the composite key: the same key_id in two engines, e.g. the private key
+	// in an offline HSM and the public key in an online engine.
+	insert := con.Exec(`INSERT INTO kms_keys
+		(key_id, metadata, "name", algorithm, size, public_key, creation_ts, engine_id, has_private_key)
+		VALUES('abc123', '{}', 'MyKey', 'RSA', 2048, 'pub', '2024-11-25 10:46:28.914', 'online-1', false);
+	`)
+	if insert.Error != nil {
+		t.Fatalf("could not store the same key_id in a second engine: %v", insert.Error)
+	}
+
+	var engines int64
+	con.Raw("SELECT count(*) FROM kms_keys WHERE key_id = 'abc123'").Scan(&engines)
+	assert.EqualValues(t, 2, engines)
+
+	// A duplicate within the same engine is still rejected.
+	dup := con.Exec(`INSERT INTO kms_keys
+		(key_id, metadata, "name", algorithm, size, public_key, creation_ts, engine_id, has_private_key)
+		VALUES('abc123', '{}', 'MyKey', 'RSA', 2048, 'pub', '2024-11-25 10:46:28.914', 'online-1', false);
+	`)
+	assert.Error(t, dup.Error, "the same key_id must not be storable twice in one engine")
+}
+
+func TestKMSMigrations(t *testing.T) {
+	logger := helpers.SetupLogger(config.Info, "test", "test")
+	cleanup, con := RunDB(t, logger, kmsDBName)
+
+	defer cleanup()
+
+	migrationTest_KMS_00000000000001_create_table(t, logger, con)
+	if t.Failed() {
+		t.Fatalf("failed while running migration v00000000000001_create_table")
+	}
+
+	migrationTest_KMS_20251031174938_key(t, logger, con)
+	if t.Failed() {
+		t.Fatalf("failed while running migration v20251031174938_key")
+	}
+
+	migrationTest_KMS_20260909084500_kms_key_composite_pk(t, logger, con)
+	if t.Failed() {
+		t.Fatalf("failed while running migration v20260909084500_kms_key_composite_pk")
+	}
+}

--- a/engines/storage/postgres/test/kms_composite_key_test.go
+++ b/engines/storage/postgres/test/kms_composite_key_test.go
@@ -1,0 +1,107 @@
+package postgrestest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/config"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/helpers"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
+	postgres "github.com/lamassuiot/lamassuiot/engines/storage/postgres/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A key is identified by (key_id, engine_id): the same key_id can be held by several engines
+// at once, e.g. the private key in an offline HSM and the public key in an online engine.
+func TestKMSStoreCompositeKeyIdentity(t *testing.T) {
+	cfg, suite := BeforeSuite([]string{postgres.KMS_SCHEMA}, false)
+	defer suite.AfterSuite()
+
+	logger := helpers.SetupLogger(config.Info, "PostgreSQL", "Test")
+	require.NoError(t, postgres.MigrateDatabase(logger, cfg, postgres.KMS_SCHEMA))
+
+	store, err := postgres.NewKMSPostgresRepository(logger, suite.DB[postgres.KMS_SCHEMA])
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	const keyID = "shared-key-id"
+
+	newKey := func(engineID string, hasPrivateKey bool, name string) *models.Key {
+		return &models.Key{
+			KeyID:         keyID,
+			EngineID:      engineID,
+			Name:          name,
+			Algorithm:     "RSA",
+			Size:          2048,
+			PublicKey:     "pub",
+			HasPrivateKey: hasPrivateKey,
+			CreationTS:    time.Now().UTC().Truncate(time.Second),
+			Aliases:       []string{},
+			Tags:          []string{},
+			Metadata:      map[string]any{},
+		}
+	}
+
+	_, err = store.Insert(ctx, newKey("hsm-offline", true, "offline copy"))
+	require.NoError(t, err)
+	_, err = store.Insert(ctx, newKey("online-1", false, "online copy"))
+	require.NoError(t, err, "the same key_id must be storable in a second engine")
+
+	copies, err := store.SelectByKeyID(ctx, keyID)
+	require.NoError(t, err)
+	assert.Len(t, copies, 2)
+
+	t.Run("reads address a single engine", func(t *testing.T) {
+		exists, key, err := store.SelectExistsByKeyID(ctx, keyID, "hsm-offline")
+		require.NoError(t, err)
+		require.True(t, exists)
+		assert.Equal(t, "hsm-offline", key.EngineID)
+		assert.True(t, key.HasPrivateKey)
+
+		exists, key, err = store.SelectExistsByKeyID(ctx, keyID, "online-1")
+		require.NoError(t, err)
+		require.True(t, exists)
+		assert.Equal(t, "online-1", key.EngineID)
+		assert.False(t, key.HasPrivateKey)
+
+		exists, _, err = store.SelectExistsByKeyID(ctx, keyID, "unknown-engine")
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("updates do not reach the other engine", func(t *testing.T) {
+		_, key, err := store.SelectExistsByKeyID(ctx, keyID, "online-1")
+		require.NoError(t, err)
+
+		key.Name = "renamed online copy"
+		_, err = store.Update(ctx, key)
+		require.NoError(t, err)
+
+		_, updated, err := store.SelectExistsByKeyID(ctx, keyID, "online-1")
+		require.NoError(t, err)
+		assert.Equal(t, "renamed online copy", updated.Name)
+
+		_, untouched, err := store.SelectExistsByKeyID(ctx, keyID, "hsm-offline")
+		require.NoError(t, err)
+		assert.Equal(t, "offline copy", untouched.Name)
+	})
+
+	t.Run("deletes remove one copy only", func(t *testing.T) {
+		require.NoError(t, store.Delete(ctx, keyID, "online-1"))
+
+		exists, _, err := store.SelectExistsByKeyID(ctx, keyID, "online-1")
+		require.NoError(t, err)
+		assert.False(t, exists)
+
+		exists, _, err = store.SelectExistsByKeyID(ctx, keyID, "hsm-offline")
+		require.NoError(t, err)
+		assert.True(t, exists, "deleting the online copy must not delete the offline one")
+
+		copies, err := store.SelectByKeyID(ctx, keyID)
+		require.NoError(t, err)
+		assert.Len(t, copies, 1)
+		assert.Equal(t, "hsm-offline", copies[0].EngineID)
+	})
+}

--- a/monolithic/pkg/storage/sqlite/kms_test.go
+++ b/monolithic/pkg/storage/sqlite/kms_test.go
@@ -49,6 +49,44 @@ func TestKMSStoreOnSQLite(t *testing.T) {
 		assert.False(t, exists)
 	})
 
+	t.Run("upgrades a database still on the old primary key", func(t *testing.T) {
+		old, err := CreateSQLiteDBConnection(logger, "file:upgrade?mode=memory&cache=shared")
+		require.NoError(t, err)
+		require.NoError(t, old.Exec(`CREATE TABLE kms_keys (
+			key_id TEXT NOT NULL,
+			metadata TEXT NULL,
+			name TEXT NOT NULL,
+			algorithm TEXT NOT NULL,
+			size INTEGER NOT NULL,
+			public_key TEXT NOT NULL,
+			creation_ts DATETIME NULL,
+			engine_id TEXT NULL,
+			aliases TEXT DEFAULT '[]',
+			has_private_key INTEGER DEFAULT 1,
+			tags TEXT DEFAULT '[]',
+			PRIMARY KEY (key_id)
+		)`).Error)
+		require.NoError(t, old.Exec(`INSERT INTO kms_keys (key_id, name, algorithm, size, public_key, engine_id)
+			VALUES ('legacy-key', 'legacy', 'RSA', 2048, 'pub', 'hsm-offline')`).Error)
+
+		require.NoError(t, initializeSchema(old))
+
+		var schema string
+		require.NoError(t, old.Raw("SELECT sql FROM sqlite_master WHERE type='table' AND name='kms_keys'").Scan(&schema).Error)
+		assert.Contains(t, schema, "PRIMARY KEY (key_id, engine_id)")
+
+		upgraded, err := postgres.NewKMSPostgresRepository(logger, old)
+		require.NoError(t, err)
+
+		exists, key, err := upgraded.SelectExistsByKeyID(ctx, "legacy-key", "hsm-offline")
+		require.NoError(t, err)
+		require.True(t, exists, "the existing row must survive the rebuild")
+		assert.Equal(t, "legacy", key.Name)
+
+		_, err = upgraded.Insert(ctx, newKey("legacy-key", "online-1", "legacy-online-alias"))
+		require.NoError(t, err, "the upgraded table must accept the same key_id in a second engine")
+	})
+
 	t.Run("composite identity", func(t *testing.T) {
 		copies, err := store.SelectByKeyID(ctx, "shared-key")
 		require.NoError(t, err)

--- a/monolithic/pkg/storage/sqlite/kms_test.go
+++ b/monolithic/pkg/storage/sqlite/kms_test.go
@@ -1,0 +1,64 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/config"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/helpers"
+	"github.com/lamassuiot/lamassuiot/core/v3/pkg/models"
+	"github.com/lamassuiot/lamassuiot/engines/storage/postgres/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The monolithic deployment runs the Postgres KMS repository on SQLite, so every query it
+// issues has to work on both dialects.
+func TestKMSStoreOnSQLite(t *testing.T) {
+	logger := helpers.SetupLogger(config.Info, "SQLite", "Test")
+	db, err := CreateSQLiteDBConnection(logger, "file::memory:?cache=shared")
+	require.NoError(t, err)
+	require.NoError(t, initializeSchema(db))
+
+	store, err := postgres.NewKMSPostgresRepository(logger, db)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	newKey := func(keyID, engineID, alias string) *models.Key {
+		return &models.Key{
+			KeyID: keyID, EngineID: engineID, Name: keyID, Algorithm: "RSA", Size: 2048,
+			PublicKey: "pub", HasPrivateKey: true, CreationTS: time.Now().UTC().Truncate(time.Second),
+			Aliases: []string{alias}, Tags: []string{}, Metadata: map[string]any{},
+		}
+	}
+
+	_, err = store.Insert(ctx, newKey("shared-key", "hsm-offline", "offline-alias"))
+	require.NoError(t, err)
+	_, err = store.Insert(ctx, newKey("shared-key", "online-1", "online-alias"))
+	require.NoError(t, err, "the same key_id must be storable in a second engine")
+
+	t.Run("alias lookup", func(t *testing.T) {
+		exists, key, err := store.SelectExistsByAlias(ctx, "online-alias")
+		require.NoError(t, err)
+		require.True(t, exists)
+		assert.Equal(t, "online-1", key.EngineID)
+
+		exists, _, err = store.SelectExistsByAlias(ctx, "missing-alias")
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("composite identity", func(t *testing.T) {
+		copies, err := store.SelectByKeyID(ctx, "shared-key")
+		require.NoError(t, err)
+		assert.Len(t, copies, 2)
+
+		require.NoError(t, store.Delete(ctx, "shared-key", "online-1"))
+
+		copies, err = store.SelectByKeyID(ctx, "shared-key")
+		require.NoError(t, err)
+		require.Len(t, copies, 1, "deleting one copy must not delete the other")
+		assert.Equal(t, "hsm-offline", copies[0].EngineID)
+	})
+}

--- a/monolithic/pkg/storage/sqlite/schema.go
+++ b/monolithic/pkg/storage/sqlite/schema.go
@@ -180,6 +180,7 @@ func initializeSchema(db *gorm.DB) error {
 		// - 20251031174938_key.sql: Added engine_id, key_id, aliases, has_private_key, tags;
 		//                           changed primary key from id to key_id; dropped status column;
 		//                           changed metadata to jsonb
+		// - 20260909084500_kms_key_composite_pk.sql: primary key is (key_id, engine_id)
 		`CREATE TABLE IF NOT EXISTS kms_keys (
 			key_id TEXT NOT NULL,
 			metadata TEXT NULL,
@@ -188,11 +189,11 @@ func initializeSchema(db *gorm.DB) error {
 			size INTEGER NOT NULL,
 			public_key TEXT NOT NULL,
 			creation_ts DATETIME NULL,
-			engine_id TEXT NULL,
+			engine_id TEXT NOT NULL,
 			aliases TEXT DEFAULT '[]',
 			has_private_key INTEGER DEFAULT 1,
 			tags TEXT DEFAULT '[]',
-			PRIMARY KEY (key_id)
+			PRIMARY KEY (key_id, engine_id)
 		)`,
 	}
 

--- a/monolithic/pkg/storage/sqlite/schema.go
+++ b/monolithic/pkg/storage/sqlite/schema.go
@@ -1,8 +1,28 @@
 package sqlite
 
 import (
+	"fmt"
+	"strings"
+
 	"gorm.io/gorm"
 )
+
+// kmsKeysTableDDL is shared with upgradeKMSKeysPrimaryKey so the created table and the
+// rebuilt one cannot drift apart.
+const kmsKeysTableDDL = `CREATE TABLE IF NOT EXISTS kms_keys (
+	key_id TEXT NOT NULL,
+	metadata TEXT NULL,
+	name TEXT NOT NULL,
+	algorithm TEXT NOT NULL,
+	size INTEGER NOT NULL,
+	public_key TEXT NOT NULL,
+	creation_ts DATETIME NULL,
+	engine_id TEXT NOT NULL,
+	aliases TEXT DEFAULT '[]',
+	has_private_key INTEGER DEFAULT 1,
+	tags TEXT DEFAULT '[]',
+	PRIMARY KEY (key_id, engine_id)
+)`
 
 // initializeSchema creates all tables in their final state based on the Postgres schema
 // This bypasses migrations and creates tables directly in SQLite-compatible SQL
@@ -181,20 +201,7 @@ func initializeSchema(db *gorm.DB) error {
 		//                           changed primary key from id to key_id; dropped status column;
 		//                           changed metadata to jsonb
 		// - 20260909084500_kms_key_composite_pk.sql: primary key is (key_id, engine_id)
-		`CREATE TABLE IF NOT EXISTS kms_keys (
-			key_id TEXT NOT NULL,
-			metadata TEXT NULL,
-			name TEXT NOT NULL,
-			algorithm TEXT NOT NULL,
-			size INTEGER NOT NULL,
-			public_key TEXT NOT NULL,
-			creation_ts DATETIME NULL,
-			engine_id TEXT NOT NULL,
-			aliases TEXT DEFAULT '[]',
-			has_private_key INTEGER DEFAULT 1,
-			tags TEXT DEFAULT '[]',
-			PRIMARY KEY (key_id, engine_id)
-		)`,
+		kmsKeysTableDDL,
 	}
 
 	for _, stmt := range statements {
@@ -203,5 +210,45 @@ func initializeSchema(db *gorm.DB) error {
 		}
 	}
 
-	return nil
+	return upgradeKMSKeysPrimaryKey(db)
+}
+
+// upgradeKMSKeysPrimaryKey rebuilds kms_keys when an existing database still carries the
+// old single-column primary key. The statements above only create missing tables, and
+// SQLite cannot alter a primary key in place, so without this an existing monolithic
+// database would keep rejecting the same key held by two engines.
+func upgradeKMSKeysPrimaryKey(db *gorm.DB) error {
+	var currentSchema string
+	if err := db.Raw("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'kms_keys'").Scan(&currentSchema).Error; err != nil {
+		return err
+	}
+
+	if currentSchema == "" || strings.Contains(currentSchema, "PRIMARY KEY (key_id, engine_id)") {
+		return nil
+	}
+
+	var orphans int64
+	if err := db.Raw("SELECT count(*) FROM kms_keys WHERE engine_id IS NULL OR engine_id = ''").Scan(&orphans).Error; err != nil {
+		return err
+	}
+
+	if orphans > 0 {
+		return fmt.Errorf("cannot promote (key_id, engine_id) to primary key: %d kms_keys row(s) have no engine_id; backfill them before starting", orphans)
+	}
+
+	return db.Transaction(func(tx *gorm.DB) error {
+		for _, stmt := range []string{
+			`ALTER TABLE kms_keys RENAME TO kms_keys_old`,
+			kmsKeysTableDDL,
+			`INSERT INTO kms_keys (key_id, metadata, name, algorithm, size, public_key, creation_ts, engine_id, aliases, has_private_key, tags)
+				SELECT key_id, metadata, name, algorithm, size, public_key, creation_ts, engine_id, aliases, has_private_key, tags FROM kms_keys_old`,
+			`DROP TABLE kms_keys_old`,
+		} {
+			if err := tx.Exec(stmt).Error; err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
 }


### PR DESCRIPTION
## Summary

The same key can live in two crypto engines at once — the private key in an offline HSM, the public key in an online engine. [`20251031174938_key.sql`](engines/storage/postgres/migrations/kms/20251031174938_key.sql) split the old PKCS#11-URI `id` column into `engine_id` + `key_id` but kept `PRIMARY KEY (key_id)`, so that case could not be stored at all, and the Go layer kept addressing rows by a column that no longer identifies them.

Three consequences, all reachable the moment a key is mirrored:

- **Deletes destroyed both copies.** `DBQuerier` is single-column, so `Delete` ran `DELETE WHERE key_id` and removed every engine's copy, then returned `ErrRecordNotFound` because `RowsAffected == 2` — with no transaction to roll it back. `Update` fanned out the same way.
- **Reads were nondeterministic.** `SelectExists` is `WHERE key_id = ? LIMIT 1` with no `ORDER BY`, so a lookup returned an arbitrary engine's row and could hand the wrong engine to the signer.
- **HTTP 500 on any bare keyID.** The authz schema for `kms_key` already declared the composite key, so an entity key without `engine_id` blew up in filter generation as `failed to generate filter: entityKey missing required primary key column "engine_id"`.

## What changed

- **Migration** to `PRIMARY KEY (key_id, engine_id)` with `engine_id NOT NULL`, guarded so it refuses to run rather than invent an identity for rows without an engine, and a `Down` that refuses while any keyID is mirrored. Mirrored in the monolithic SQLite schema.
- **Repository** reads, updates and deletes are scoped by both columns, building their own `WHERE` clauses instead of going through the single-column `DBQuerier`. New `SelectByKeyID` returns every engine's copy.
- **Identifier semantics.** A PKCS#11 URI and an alias address a single key. A bare keyID is a *search*: it resolves while one engine holds the key and returns `ErrKeyEngineRequired` (400) once several do, instead of picking a copy. Where the engine is known — the certificate signer and CA key deletion — the exact identity is passed rather than relying on the search.
- **Authz path.** The route extractor resolves the full identity or aborts, and `AuthzCheckCustom` now honours `c.IsAborted()` instead of authorizing on a partial key. Dropped `type` from the entity key columns; it is not part of the primary key.
- **Alias lookups.** GIN index (`jsonb_path_ops`) since an alias is queried on every request without a URI, and the query is now dialect-aware — it used Postgres-only `@>`/`::jsonb` and failed with `unrecognized token: "@"` on the SQLite the monolithic deployment runs this repository on.

## Test plan

- [x] New migration test: primary key is `(key_id, engine_id)`, the GIN index exists, the same keyID stores in two engines, a duplicate within one engine is still rejected
- [x] New storage test: reads address a single engine, updates and deletes touch one copy only
- [x] New SQLite test: alias lookup and composite identity work on the monolithic dialect
- [x] `assemblers/tests/{kms,ca,device-manager,dms-manager,alerts,va}`, `migration/catokms`, `core`, authz `engine`+`sdk`
- [x] `go build` and `go vet` across the five modules

## Notes for review

Two follow-ups this PR deliberately leaves open:

1. **Alias uniqueness is not enforced.** It is a check-then-act in `UpdateKeyAliases` with no constraint and no transaction; a unique index cannot span the elements of a `jsonb` array, so enforcing it means normalizing aliases into a child table. The GIN index added here is performance only.
2. **Per-key grants cross engines.** `applyDirectGrants` filters on `PrimaryKeys[0]`, so a grant naming a key compiles to `key_id IN (...)` and matches both copies — a grant on the online public-key copy would authorize `sign` against the offline HSM copy. Not exposed today because the live policies are `direct_grants: ["*"]`, but it must be fixed before any per-key policy is written.

Separately: `authorizeAtomic` returns "not authorized" both when no policy grants the action and when the policy grants it but no row matches the entity key, so a misaddressed entity surfaces as 403 rather than 404. With the engine now part of the entity key this will be hit more often.

🤖 Generated with [Claude Code](https://claude.com/claude-code)