### PR TITLE
[Task]: Fix gosec SARIF upload permissions

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -20,15 +20,15 @@ jobs:
       GO111MODULE: on
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@v2.20.0
+        uses: securego/gosec@6fbd381238e97e1d1f3358f0d6d65de78dcf9245 # v2.20.0
         with:
           # we let the report trigger content trigger a failure using the GitHub Security features.
           args: '-no-fail -fmt sarif -out results.sarif -exclude G104,G601 ./...'
       - name: Upload SARIF file
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@b96794f015dfd88f77b49b1c93e0fa7110f94c63
         with:
           # Path to SARIF file relative to the root of the repository
           sarif_file: results.sarif

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     env:
       GO111MODULE: on
     steps:
@@ -24,7 +27,8 @@ jobs:
           # we let the report trigger content trigger a failure using the GitHub Security features.
           args: '-no-fail -fmt sarif -out results.sarif -exclude G104,G601 ./...'
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: github/codeql-action/upload-sarif@v4
         with:
           # Path to SARIF file relative to the root of the repository
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- Upgrade CodeQL upload-sarif from v3 to v4.
- Grant the workflow contents read and security-events write permissions.
- Skip SARIF uploads for pull requests originating from forks.

## Validation
- YAML parsed successfully.
- git diff --check passed.

Closes #700